### PR TITLE
10.search filters

### DIFF
--- a/PR-15/PR_SUMMARY.md
+++ b/PR-15/PR_SUMMARY.md
@@ -1,94 +1,110 @@
-# PR Overview: Dashboard Account/Date Filters with Query-Scoped Caching
+# PR Overview: Header Filters Expansion with Preset Date Ranges and Query-Scoped Refresh
 
 ## Summary
 
-This PR adds dashboard-level account and date filters in the header, persists those filters in URL query params, and wires the same params into data fetching so transaction and summary views stay aligned with user-selected scope; it also broadens summary cache invalidation after mutation flows and updates chart empty-state behavior for all-zero periods.
+This PR evolves dashboard filtering by introducing account/date URL-driven filters in the header, extending the date filter UX with preset ranges and controlled popover state, scoping transactions/summary fetching to query params, and broadening summary invalidation after write mutations; it also includes branch-level review artifact files committed into `PR-15/`.
 
 **Key Statistics** bullets:
 
-- Files changed: 20 files (+260/ -38)
-- Commits: 3 (`Add account filter`, `Add date filter`, `some todos remaining`)
-- Backend: None (no API route or server business-logic file changes in this PR)
-- Frontend: Next.js client header filters, React Query key/invalidation updates, Radix UI popover/select integration
-- Database: None (no schema, migration, or ORM model changes)
+- Files changed: 22 files (+854/ -38)
+- Commits: 5 (`Enhance DateFilter component with preset date ranges and improved state management`, `codex review files`, `some todos remaining`, `Add date filter`, `Add account filter`)
+- Backend: None (no backend route/controller/database-query logic changed in this PR)
+- Frontend: Next.js client filters, React Query cache key/invalidation updates, Radix popover/select usage, preset date-range UX
+- Database: None (no migration/schema/model changes)
 
 ---
 
 ## Key Changes by Area
 
-### 1. Frontend - Data/State (React Query, Next Navigation, URL Query State)
+### 1. Frontend - Data/State (React Query, URL query state, Next navigation)
 
 **Files:**
 
-- `components/account-filter.tsx` - adds account select state sourced from URL and pushes updated `accountId` query params
-- `components/date-filter.tsx` - adds date-range parsing/apply/reset flow tied to `from`/`to` query params
-- `features/transactions/api/use-get-transactions.ts` - scopes transactions query cache key by `from`, `to`, and `accountId`
-- `features/summary/use-get-summary.ts` - keeps summary query key param-scoped and removes stale TODO
-- `features/accounts/api/use-delete-account.ts` - invalidates `summary` cache after account delete
-- `features/accounts/api/use-edit-account.ts` - invalidates `summary` cache after account edit
-- `features/categories/api/use-bulk-delete-categories.ts` - invalidates `summary` cache after category bulk delete
-- `features/categories/api/use-delete-category.ts` - invalidates `summary` cache after category delete
-- `features/categories/api/use-edit-category.ts` - invalidates `summary` cache after category edit
-- `features/transactions/api/use-bulk-create-transactions.ts` - invalidates `summary` cache after bulk create
-- `features/transactions/api/use-bulk-delete-transactions.ts` - invalidates `summary` cache after bulk delete
-- `features/transactions/api/use-create-transaction.ts` - invalidates `summary` cache after create
-- `features/transactions/api/use-delete-transaction.ts` - invalidates `summary` cache after delete
-- `features/transactions/api/use-edit-transaction.ts` - invalidates `summary` cache after edit
+- `components/account-filter.tsx` - reads/writes `accountId`, preserves `from`/`to`, and updates URL query state
+- `components/date-filter.tsx` - parses URL dates, manages range/month/open state, applies filter query params, and adds preset range logic
+- `features/transactions/api/use-get-transactions.ts` - updates query key to include `from`, `to`, and `accountId`
+- `features/summary/use-get-summary.ts` - keeps param-scoped summary key and uses query params as request input
+- `features/accounts/api/use-delete-account.ts` - invalidates `summary` after delete
+- `features/accounts/api/use-edit-account.ts` - invalidates `summary` after edit
+- `features/categories/api/use-bulk-delete-categories.ts` - invalidates `summary` after bulk delete
+- `features/categories/api/use-delete-category.ts` - invalidates `summary` after delete
+- `features/categories/api/use-edit-category.ts` - invalidates `summary` after edit
+- `features/transactions/api/use-bulk-create-transactions.ts` - invalidates `summary` after bulk create
+- `features/transactions/api/use-bulk-delete-transactions.ts` - invalidates `summary` after bulk delete
+- `features/transactions/api/use-create-transaction.ts` - invalidates `summary` after create
+- `features/transactions/api/use-delete-transaction.ts` - invalidates `summary` after delete
+- `features/transactions/api/use-edit-transaction.ts` - invalidates `summary` after edit
 
 **Changes:**
 
-- Adds account filter selection that keeps existing date params while changing `accountId`.
-- Adds calendar-based date-range filter that serializes dates as `yyyy-MM-dd` and applies them to URL state.
-- Uses query-param-aware React Query keys for transactions to avoid cross-filter cache collisions.
-- Expands summary invalidation across most create/edit/delete mutation success paths.
-- Uses current query params as single source of truth for fetch scoping in transactions/summary hooks.
+- Adds account-level filtering that persists in URL query params.
+- Adds date-range URL serialization (`yyyy-MM-dd`) with explicit Apply/Reset actions.
+- Adds preset selectors: Today, Yesterday, This week, Last week, This month, Last month, This year, Last year, All time.
+- Re-seeds date/month local state from URL each time the filter popover opens.
+- Scopes transactions query caching by active filter params to avoid stale cross-filter cache reuse.
+- Expands summary invalidation across most create/edit/delete mutation success handlers.
 
 **Rationale:**
 
-- Makes filtering shareable/bookmarkable through URL state.
-- Improves cache correctness when switching between date/account scopes.
-- Reduces stale summary widgets after transactional mutations.
+- Keeps filters shareable and refresh-safe through URL state.
+- Improves cache correctness under rapid filter switching.
+- Reduces stale summary UI after transactional writes.
 
-### 2. Frontend - UI Components (React, Radix UI, Dashboard Layout)
+### 2. Frontend - UI Components (Dashboard layout, filters, chart empty-state)
 
 **Files:**
 
-- `components/filters.tsx` - composes account and date filters into a single reusable header block
-- `components/header.tsx` - injects `Filters` beneath welcome message
-- `components/account-filter.tsx` - new select-based account filter control
-- `components/date-filter.tsx` - new popover calendar with Apply/Reset controls
-- `components/ui/popover.tsx` - exports `PopoverClose` and normalizes style/exports
-- `components/chart.tsx` - treats all-zero income/expense datasets as empty state
+- `components/filters.tsx` - new wrapper combining account and date controls
+- `components/header.tsx` - injects filters into dashboard header under welcome message
+- `components/account-filter.tsx` - adds account selector control with loading-based disabling
+- `components/date-filter.tsx` - implements two-pane popover (preset rail + two-month calendar) and action buttons
+- `components/ui/popover.tsx` - exports `PopoverClose` primitive used in date actions
+- `components/chart.tsx` - expands empty-state logic to treat all-zero periods as no-data
 
 **Changes:**
 
-- Adds a visible filters row to dashboard header layout.
-- Introduces account selector loading-disable behavior while accounts/summary are loading.
-- Introduces date popover with two-month range calendar and explicit apply/reset actions.
-- Exposes `PopoverClose` primitive to close popover via action buttons.
-- Updates chart empty-state logic to hide chart rendering for zeroed datasets.
+- Adds visible global filters area in header.
+- Introduces popover UX with preset quick-selects and controlled month navigation.
+- Keeps apply/reset explicit instead of auto-submitting selection changes.
+- Uses icon-only reset button and apply action inside popover footer.
+- Prevents chart rendering for datasets where every day has `income=0` and `expenses=0`.
 
 **Rationale:**
 
-- Surfaces filtering controls at the top navigation context where users expect global data scope controls.
-- Keeps filter interactions explicit (Apply/Reset) to avoid accidental range changes.
-- Improves chart readability when filtered periods return no meaningful values.
+- Improves discoverability and speed of common time-range filtering.
+- Preserves predictable user intent with explicit apply step.
+- Avoids misleading "flat-zero" visualizations in charts.
 
-### 3. Developer Experience & Configuration (Dependency Management)
+### 3. Developer Experience & Configuration (Dependencies, lockfile)
 
 **Files:**
 
 - `package.json` - adds `query-string@9.0.0`
-- `bun.lock` - records transitive lock updates (`decode-uri-component`, `filter-obj`, `split-on-first`)
+- `bun.lock` - lockfile updates for `query-string` and transitive packages
 
 **Changes:**
 
-- Introduces URL query serialization dependency used by filter components.
-- Updates lockfile for deterministic installs.
+- Introduces library-based query serialization for stable URL construction.
+- Updates dependency graph entries (`decode-uri-component`, `filter-obj`, `split-on-first`).
 
 **Rationale:**
 
-- Avoids manual query-string building/parsing edge cases in filter URL updates.
+- Reduces manual query-string handling complexity and encoding edge cases.
+
+### 4. Documentation & PR Artifacts (Review docs)
+
+**Files:**
+
+- `PR-15/PR_SUMMARY.md` - PR technical summary artifact
+- `PR-15/TECH_DEBT_TICKETS.md` - derived debt-ticket artifact
+
+**Changes:**
+
+- Adds branch-local review documentation files committed in this PR.
+
+**Rationale:**
+
+- Captures review output and debt tracking directly in repository context for this branch.
 
 ---
 
@@ -96,20 +112,20 @@ This PR adds dashboard-level account and date filters in the header, persists th
 
 ### Why This Architecture?
 
-1. URL-driven filter state
-   - Query params (`from`, `to`, `accountId`) create a stable contract between UI controls and data hooks.
-2. Query-key scoping in data hooks
-   - Param-scoped keys separate cache entries by filter state and reduce stale reuse.
-3. Shared filter composition in header
-   - Centralizing controls in `Header` provides consistent navigation-level scoping for dashboard pages.
-4. Broad mutation invalidation
-   - Invalidating `summary` on write operations improves coherence between CRUD actions and analytics cards/charts.
+1. URL-as-source-of-truth filtering
+   - `from`/`to`/`accountId` query params align navigation state and fetch state.
+2. Preset-first date UX layered over range picker
+   - Quick ranges reduce clicks for common analytics windows while retaining custom range support.
+3. Query-key partitioning
+   - Param-scoped keys isolate cache entries per filter context.
+4. Broad summary invalidation strategy
+   - Summary data is refreshed after most mutation paths to preserve dashboard consistency.
 
 ### Business Value
 
-- Users can quickly segment financial views by account and period from a single header location.
-- Filter state can be shared via URL and restored on refresh/navigation.
-- Dashboard totals/charts refresh more reliably after create/edit/delete flows.
+- Faster insight slicing by account and period from a single header control area.
+- Better daily usability via one-click date presets.
+- Fewer stale analytics scenarios after transaction/account/category updates.
 
 ---
 
@@ -117,60 +133,66 @@ This PR adds dashboard-level account and date filters in the header, persists th
 
 ### High-Impact Risks
 
-1. No high-impact production-stability risk identified from this diff
-   - Issue: Current changes are UI/query-state oriented and do not modify persistence schema or auth boundaries.
-   - Mitigation: Validate end-to-end filter + mutation flows in staging before release.
-   - Rollback: Revert header filter components and query-key/invalidation deltas in this PR range.
+1. No high-impact production outage/security risk directly introduced by this diff
+   - Issue: Changes are primarily UI/query-state/caching behavior.
+   - Mitigation: Validate end-to-end filter + mutation flows in staging with realistic data.
+   - Rollback: Revert header filter/date preset components and query-key/invalidation deltas.
 
 ### Medium-Impact Risks
 
-1. Date picker local state can diverge from URL-driven state after navigation
-   - Issue: `DateFilter` initializes local `date` from params but does not resync when params change externally.
-   - Mitigation: Sync component state from search params with an effect keyed by `from`/`to`.
-   - Rollback: Keep URL as display source and remove local-state dependence for selected range.
+1. Assumption: Summary invalidation is still incomplete for account bulk delete path
+   - Issue: `useBulkDeleteAccounts` remains unmodified in this PR while other mutations now invalidate `summary`.
+   - Mitigation: Add `summary` invalidation parity check across all mutation hooks.
+   - Rollback: Trigger manual refresh or route reload post bulk-delete until parity patch lands.
 
-2. Account filter currently couples control state to summary loading on all dashboard routes
-   - Issue: `AccountFilter` calls `useGetSummary()` to derive `isLoadingSummary`, even where summary data is not rendered.
-   - Mitigation: Decouple disabled state from summary query or gate summary hook usage to overview route.
-   - Rollback: Remove summary-loading dependency from filter disable logic.
+2. "All time" preset uses a hardcoded start date
+   - Issue: Preset currently sets `from` to `new Date(2000, 0, 1)`.
+   - Mitigation: Replace with product/system minimum transaction date from backend or config.
+   - Rollback: Temporarily hide/rename preset if it causes user confusion.
 
-3. Assumption: Summary invalidation coverage may still be incomplete for `useBulkDeleteAccounts`
-   - Issue: This PR adds multiple summary invalidations, but `useBulkDeleteAccounts` still invalidates only `accounts`.
-   - Mitigation: Add summary invalidation parity check across all write mutations.
-   - Rollback: Force refresh dashboard summary after bulk account delete until hook parity is added.
+3. Header filter disables account selector based on summary loading globally
+   - Issue: `AccountFilter` uses `useGetSummary()` loading state even on routes where summary is not the primary content.
+   - Mitigation: Decouple disable criteria from summary loading or scope summary loading by route.
+   - Rollback: Remove summary dependency from disabled prop.
 
 ### Low-Impact Risks
 
-1. Debug logs remain in account filter handler
-   - Issue: `console.log(query)` and `console.log(url)` are still present in `components/account-filter.tsx`.
-   - Mitigation: Remove logs or guard with development-only utility.
-   - Rollback: N/A (cleanup-only).
+1. Debug logs still present in account filter
+   - Issue: `console.log(query)` and `console.log(url)` remain in client component.
+   - Mitigation: Remove logs or gate through dev-only logger utility.
+   - Rollback: N/A.
 
-2. Reset behavior applies default date range rather than clearing date params
-   - Issue: `onReset` pushes formatted default dates, which may not match expected "clear filters" semantics.
-   - Mitigation: Decide product behavior and either clear params or keep explicit defaults consistently.
-   - Rollback: Keep existing behavior and document it in UI/help text.
+2. Large commented legacy JSX block left in date filter
+   - Issue: Previous popover implementation remains commented in `components/date-filter.tsx`.
+   - Mitigation: Remove dead commented block to reduce maintenance noise.
+   - Rollback: N/A.
+
+3. Reset behavior enforces default range instead of clearing date params
+   - Issue: Reset pushes default `from`/`to` values.
+   - Mitigation: Confirm product intent and align reset semantics/documentation.
+   - Rollback: Keep current behavior and document as "Reset to last 30 days".
 
 ### Deployment Considerations
 
 **Pre-Deployment:**
 
-- [ ] Validate account/date filter interactions on overview and transactions pages.
-- [ ] Validate URL deep-linking (`from`, `to`, `accountId`) across refresh/back-forward navigation.
-- [ ] Validate summary and transactions refresh after create/edit/delete and bulk mutation operations.
-- [ ] Remove debug logs before production deploy.
+- [ ] Validate all presets produce expected `from`/`to` URL values.
+- [ ] Validate account filter + date filter interactions on overview and transactions pages.
+- [ ] Validate back/forward navigation and deep-linking with query params.
+- [ ] Validate summary/charts refresh after create/edit/delete and bulk operations.
+- [ ] Remove debug logs and dead commented code before production release.
 
 **Post-Deployment Monitoring:**
 
-- [ ] Monitor dashboard/transactions API request volume for unexpected increases from header-level hooks.
-- [ ] Monitor client error logs around date parsing/query serialization paths.
-- [ ] Monitor UX feedback about date Reset semantics.
+- [ ] Monitor dashboard/transactions request rates for filter-related overfetch.
+- [ ] Monitor client error logs around date parsing and preset application.
+- [ ] Monitor support feedback about All time and Reset semantics.
 
 **Rollback Plan:**
 
-- Revert `components/account-filter.tsx`, `components/date-filter.tsx`, `components/filters.tsx`, and `components/header.tsx`.
-- Revert query-key and invalidation changes under `features/**/api/*`.
-- Reinstall lockfile state from previous commit and redeploy.
+- Revert `components/date-filter.tsx`, `components/account-filter.tsx`, `components/filters.tsx`, and `components/header.tsx`.
+- Revert query-key/invalidation updates in `features/**/api` hooks.
+- Revert dependency additions in `package.json` and `bun.lock` if filter feature is disabled.
 
 ---
 
@@ -178,69 +200,68 @@ This PR adds dashboard-level account and date filters in the header, persists th
 
 ### Introduced Technical Debt
 
-1. Debug logging left in account filter handler
+1. Hardcoded baseline for "All time" preset
 
-- Issue: `console.log` calls remain in production component path.
-- Impact: Noisy logs and accidental leakage of URL/query context in client consoles.
-- Recommendation: Remove logs or wrap with development-only logging utility.
-- Effort: S
-
-2. Date filter state synchronization gap
-
-- Issue: Local date state is initialized from params once and may drift from URL updates.
-- Impact: Calendar selected state can become inconsistent with displayed active range.
-- Recommendation: Add state synchronization from `useSearchParams` changes.
-- Effort: S
-
-3. Reset semantics are ambiguous
-
-- Issue: Reset pushes default date values instead of clearing date params.
-- Impact: Potential mismatch between user expectation ("clear") and actual behavior ("set defaults").
-- Recommendation: Define/reset contract and implement consistently (clear or explicit default).
-- Effort: S
-
-4. Assumption: Summary invalidation coverage may still be incomplete for `useBulkDeleteAccounts`
-
-- Issue: Mutation invalidation was expanded broadly, but one account bulk-delete path appears unaligned.
-- Impact: Potential stale summary widgets after bulk account deletion.
-- Recommendation: Standardize invalidation policy and audit all mutation hooks.
-- Effort: S
-
-5. Account filter currently couples control state to summary loading on all dashboard routes
-
-- Issue: Filter disabled-state logic depends on summary loading even when summary is not displayed.
-- Impact: Extra background requests and unnecessary control blocking in non-summary routes.
-- Recommendation: Route-scope summary fetching or decouple filter disabled criteria.
+- Issue: All-time range starts at a fixed year-2000 date in UI logic.
+- Impact: Data before 2000 (or product-specific true start) is silently excluded.
+- Recommendation: Resolve minimum selectable date from backend metadata or first-transaction query.
 - Effort: M
+
+2. Mutation invalidation policy is still inconsistent
+
+- Issue: Most mutation hooks now invalidate `summary`, but account bulk-delete path appears to lag.
+- Impact: Possible stale dashboard aggregates after certain operations.
+- Recommendation: Introduce and enforce a centralized invalidation checklist/helper.
+- Effort: S
+
+3. Filter control coupling to summary loading on all dashboard pages
+
+- Issue: Account filter disabled state depends on summary hook loading globally.
+- Impact: Extra fetches and avoidable input blocking.
+- Recommendation: Route-scope summary dependencies or refactor disabled criteria.
+- Effort: M
+
+4. Dead commented UI block in DateFilter
+
+- Issue: Obsolete commented JSX remains in production file.
+- Impact: Increased noise and slower maintenance/readability.
+- Recommendation: Remove commented legacy block.
+- Effort: S
+
+5. Debug logging in client path
+
+- Issue: `console.log` statements remain in filter change handler.
+- Impact: Noisy production consoles and weak logging hygiene.
+- Recommendation: Remove or gate with dev-only logger.
+- Effort: S
 
 ### Mitigated Technical Debt
 
-- Replaces unscoped transactions cache key with filter-aware cache key to reduce stale data reuse.
-- Adds `summary` invalidation to multiple mutation hooks that previously left TODOs.
-- Consolidates filter controls into reusable components instead of page-specific ad-hoc implementations.
+- Replaces unscoped transaction cache key with filter-aware key.
+- Clears multiple existing TODOs by adding summary invalidation across mutation hooks.
+- Improves date filter state handling by re-seeding local state from URL on popover open.
 
 ### Recommended Next Steps
 
 **Immediate (This Sprint):**
 
-- Remove debug logs from `components/account-filter.tsx`.
-- Add summary invalidation in `useBulkDeleteAccounts` for parity.
-- Confirm and document date reset behavior (clear vs default range).
+- Remove debug logs and commented legacy block from date/account filter components.
+- Add missing summary invalidation parity for account bulk-delete.
+- Confirm and document reset/all-time product semantics.
 
 **Short-term (Next Sprint):**
 
-- Add URL-param-to-local-state synchronization tests for `DateFilter`.
-- Add integration tests for filter-driven fetch scoping on overview and transactions pages.
-- Decouple account filter disabled state from summary loading where not required.
+- Add integration tests for preset behavior, URL serialization, and filter interactions across pages.
+- Refactor filter disable logic to avoid non-essential summary-loading coupling.
 
 **Medium-term (Within Quarter):**
 
-- Define a shared React Query invalidation policy helper for mutation hooks.
-- Add route-level performance baselines for header-mounted data dependencies.
+- Create shared React Query invalidation helper/policy across mutation hooks.
+- Add telemetry around filter usage/preset selection to guide UX tuning.
 
 **Long-term (Future Quarters):**
 
-- Consider central filter-state management abstraction (URL + UI sync) to reduce duplicated query-state logic.
+- Consider centralized dashboard filter-state module shared across header and feature pages.
 
 ---
 
@@ -248,19 +269,20 @@ This PR adds dashboard-level account and date filters in the header, persists th
 
 ### Manual Testing Checklist
 
-- [ ] Open dashboard overview, change account filter, and confirm URL/query + cards/charts update.
-- [ ] Open transactions page with filters and verify table rows respect `from`/`to`/`accountId`.
-- [ ] Use browser back/forward after changing dates and verify displayed range and selected calendar range are consistent.
-- [ ] Edit/delete/create transactions and categories, then verify summary cards/charts refresh.
-- [ ] Bulk-delete accounts and verify whether summary refreshes correctly (current assumption risk).
-- [ ] Confirm all-zero filtered periods show expected chart empty state messaging.
+- [ ] Verify each preset (today/yesterday/week/month/year/all-time) updates URL and displayed range correctly.
+- [ ] Verify custom date-range selection persists after Apply and survives refresh.
+- [ ] Verify Reset behavior and confirm expected default range semantics.
+- [ ] Verify account filter keeps date params intact when changing account.
+- [ ] Verify overview charts/cards and transactions table respond to combined account/date filters.
+- [ ] Verify summary updates after create/edit/delete and bulk mutation flows.
+- [ ] Verify all-zero datasets show "No data for this period" in chart card.
 
 ### Automated Testing Needs
 
-- [ ] Component tests for `AccountFilter` URL serialization and "All Accounts" behavior.
-- [ ] Component tests for `DateFilter` Apply/Reset behavior and state synchronization with URL changes.
-- [ ] Hook/integration tests verifying transactions query key partitioning by filter params.
-- [ ] Mutation-hook tests validating `summary` invalidation parity across all CRUD/bulk operations.
+- [ ] Component tests for `DateFilter` presets, apply/reset, and URL serialization.
+- [ ] Component tests for `AccountFilter` "All Accounts" behavior and param preservation.
+- [ ] Hook/integration tests for transactions query-key partitioning by filters.
+- [ ] Mutation-hook tests for summary invalidation parity across all write paths.
 
 ---
 
@@ -272,11 +294,11 @@ This PR adds dashboard-level account and date filters in the header, persists th
 
 ### External Service Dependencies
 
-- Existing dashboard stack only (Next.js app router, Hono API client, React Query, Radix UI primitives).
+- Existing Next.js + Hono client + React Query + Radix stack only.
 
 ### Breaking Changes
 
-- None.
+- None identified.
 
 ---
 
@@ -284,34 +306,35 @@ This PR adds dashboard-level account and date filters in the header, persists th
 
 ### Frontend
 
-- Query-key scoping improves cache correctness but can increase cache entry count for many filter combinations.
-- Header-mounted account filter now includes summary loading coupling, which may add background summary requests on non-overview pages.
+- Preset/date popover adds UI complexity but remains client-local.
+- Filtered query-key partitioning may increase cache entries for many date/account combinations.
+- Summary-loading coupling in header may trigger unnecessary requests on non-summary routes.
 
 ### API
 
-- No direct API contract or endpoint implementation changes in this PR.
+- No endpoint logic changes in this PR.
 
 ### Database
 
-- No schema/query-layer changes introduced.
+- No schema/query changes in this PR.
 
 ---
 
 ## Security Considerations
 
-- No authn/authz boundary changes in this PR.
-- No new sensitive data fields introduced in URL params; filters use account IDs and date strings already used by existing API contracts.
-- Server-side validation remains important for `from`/`to`/`accountId` query inputs regardless of client formatting behavior.
+- No authentication or authorization flow changes.
+- No new secret material introduced in URL/query params.
+- Query params remain user-controllable; backend validation should continue to enforce date/account constraints.
 
 ---
 
 ## Conclusion
 
-This PR delivers useful dashboard filtering and better cache coherence for analytics-driven UI, with moderate follow-up needed around filter-state sync semantics and invalidation parity.
+This PR materially improves filter usability and cache correctness with preset date ranges and broader summary refresh handling, with follow-up needed to clean logging/dead code and finalize invalidation/preset semantics.
 
-- Deployment Status: ⚠️ Needs Follow-up (recommended to address debug logs and invalidation/sync gaps before production hardening)
+- Deployment Status: ⚠️ Needs Follow-up (recommended to close medium/low debt items before production hardening)
 
-- Generated: February 16, 2026
+- Generated: February 18, 2026
 - Branch: 10.SearchFilters
 - Base: origin/master
-- Files Changed: 20 files (+260/ -38)
+- Files Changed: 22 files (+854/ -38)

--- a/PR-15/PR_SUMMARY.md
+++ b/PR-15/PR_SUMMARY.md
@@ -1,0 +1,317 @@
+# PR Overview: Dashboard Account/Date Filters with Query-Scoped Caching
+
+## Summary
+
+This PR adds dashboard-level account and date filters in the header, persists those filters in URL query params, and wires the same params into data fetching so transaction and summary views stay aligned with user-selected scope; it also broadens summary cache invalidation after mutation flows and updates chart empty-state behavior for all-zero periods.
+
+**Key Statistics** bullets:
+
+- Files changed: 20 files (+260/ -38)
+- Commits: 3 (`Add account filter`, `Add date filter`, `some todos remaining`)
+- Backend: None (no API route or server business-logic file changes in this PR)
+- Frontend: Next.js client header filters, React Query key/invalidation updates, Radix UI popover/select integration
+- Database: None (no schema, migration, or ORM model changes)
+
+---
+
+## Key Changes by Area
+
+### 1. Frontend - Data/State (React Query, Next Navigation, URL Query State)
+
+**Files:**
+
+- `components/account-filter.tsx` - adds account select state sourced from URL and pushes updated `accountId` query params
+- `components/date-filter.tsx` - adds date-range parsing/apply/reset flow tied to `from`/`to` query params
+- `features/transactions/api/use-get-transactions.ts` - scopes transactions query cache key by `from`, `to`, and `accountId`
+- `features/summary/use-get-summary.ts` - keeps summary query key param-scoped and removes stale TODO
+- `features/accounts/api/use-delete-account.ts` - invalidates `summary` cache after account delete
+- `features/accounts/api/use-edit-account.ts` - invalidates `summary` cache after account edit
+- `features/categories/api/use-bulk-delete-categories.ts` - invalidates `summary` cache after category bulk delete
+- `features/categories/api/use-delete-category.ts` - invalidates `summary` cache after category delete
+- `features/categories/api/use-edit-category.ts` - invalidates `summary` cache after category edit
+- `features/transactions/api/use-bulk-create-transactions.ts` - invalidates `summary` cache after bulk create
+- `features/transactions/api/use-bulk-delete-transactions.ts` - invalidates `summary` cache after bulk delete
+- `features/transactions/api/use-create-transaction.ts` - invalidates `summary` cache after create
+- `features/transactions/api/use-delete-transaction.ts` - invalidates `summary` cache after delete
+- `features/transactions/api/use-edit-transaction.ts` - invalidates `summary` cache after edit
+
+**Changes:**
+
+- Adds account filter selection that keeps existing date params while changing `accountId`.
+- Adds calendar-based date-range filter that serializes dates as `yyyy-MM-dd` and applies them to URL state.
+- Uses query-param-aware React Query keys for transactions to avoid cross-filter cache collisions.
+- Expands summary invalidation across most create/edit/delete mutation success paths.
+- Uses current query params as single source of truth for fetch scoping in transactions/summary hooks.
+
+**Rationale:**
+
+- Makes filtering shareable/bookmarkable through URL state.
+- Improves cache correctness when switching between date/account scopes.
+- Reduces stale summary widgets after transactional mutations.
+
+### 2. Frontend - UI Components (React, Radix UI, Dashboard Layout)
+
+**Files:**
+
+- `components/filters.tsx` - composes account and date filters into a single reusable header block
+- `components/header.tsx` - injects `Filters` beneath welcome message
+- `components/account-filter.tsx` - new select-based account filter control
+- `components/date-filter.tsx` - new popover calendar with Apply/Reset controls
+- `components/ui/popover.tsx` - exports `PopoverClose` and normalizes style/exports
+- `components/chart.tsx` - treats all-zero income/expense datasets as empty state
+
+**Changes:**
+
+- Adds a visible filters row to dashboard header layout.
+- Introduces account selector loading-disable behavior while accounts/summary are loading.
+- Introduces date popover with two-month range calendar and explicit apply/reset actions.
+- Exposes `PopoverClose` primitive to close popover via action buttons.
+- Updates chart empty-state logic to hide chart rendering for zeroed datasets.
+
+**Rationale:**
+
+- Surfaces filtering controls at the top navigation context where users expect global data scope controls.
+- Keeps filter interactions explicit (Apply/Reset) to avoid accidental range changes.
+- Improves chart readability when filtered periods return no meaningful values.
+
+### 3. Developer Experience & Configuration (Dependency Management)
+
+**Files:**
+
+- `package.json` - adds `query-string@9.0.0`
+- `bun.lock` - records transitive lock updates (`decode-uri-component`, `filter-obj`, `split-on-first`)
+
+**Changes:**
+
+- Introduces URL query serialization dependency used by filter components.
+- Updates lockfile for deterministic installs.
+
+**Rationale:**
+
+- Avoids manual query-string building/parsing edge cases in filter URL updates.
+
+---
+
+## Rationale
+
+### Why This Architecture?
+
+1. URL-driven filter state
+   - Query params (`from`, `to`, `accountId`) create a stable contract between UI controls and data hooks.
+2. Query-key scoping in data hooks
+   - Param-scoped keys separate cache entries by filter state and reduce stale reuse.
+3. Shared filter composition in header
+   - Centralizing controls in `Header` provides consistent navigation-level scoping for dashboard pages.
+4. Broad mutation invalidation
+   - Invalidating `summary` on write operations improves coherence between CRUD actions and analytics cards/charts.
+
+### Business Value
+
+- Users can quickly segment financial views by account and period from a single header location.
+- Filter state can be shared via URL and restored on refresh/navigation.
+- Dashboard totals/charts refresh more reliably after create/edit/delete flows.
+
+---
+
+## Risks & Rollout Considerations
+
+### High-Impact Risks
+
+1. No high-impact production-stability risk identified from this diff
+   - Issue: Current changes are UI/query-state oriented and do not modify persistence schema or auth boundaries.
+   - Mitigation: Validate end-to-end filter + mutation flows in staging before release.
+   - Rollback: Revert header filter components and query-key/invalidation deltas in this PR range.
+
+### Medium-Impact Risks
+
+1. Date picker local state can diverge from URL-driven state after navigation
+   - Issue: `DateFilter` initializes local `date` from params but does not resync when params change externally.
+   - Mitigation: Sync component state from search params with an effect keyed by `from`/`to`.
+   - Rollback: Keep URL as display source and remove local-state dependence for selected range.
+
+2. Account filter currently couples control state to summary loading on all dashboard routes
+   - Issue: `AccountFilter` calls `useGetSummary()` to derive `isLoadingSummary`, even where summary data is not rendered.
+   - Mitigation: Decouple disabled state from summary query or gate summary hook usage to overview route.
+   - Rollback: Remove summary-loading dependency from filter disable logic.
+
+3. Assumption: Summary invalidation coverage may still be incomplete for `useBulkDeleteAccounts`
+   - Issue: This PR adds multiple summary invalidations, but `useBulkDeleteAccounts` still invalidates only `accounts`.
+   - Mitigation: Add summary invalidation parity check across all write mutations.
+   - Rollback: Force refresh dashboard summary after bulk account delete until hook parity is added.
+
+### Low-Impact Risks
+
+1. Debug logs remain in account filter handler
+   - Issue: `console.log(query)` and `console.log(url)` are still present in `components/account-filter.tsx`.
+   - Mitigation: Remove logs or guard with development-only utility.
+   - Rollback: N/A (cleanup-only).
+
+2. Reset behavior applies default date range rather than clearing date params
+   - Issue: `onReset` pushes formatted default dates, which may not match expected "clear filters" semantics.
+   - Mitigation: Decide product behavior and either clear params or keep explicit defaults consistently.
+   - Rollback: Keep existing behavior and document it in UI/help text.
+
+### Deployment Considerations
+
+**Pre-Deployment:**
+
+- [ ] Validate account/date filter interactions on overview and transactions pages.
+- [ ] Validate URL deep-linking (`from`, `to`, `accountId`) across refresh/back-forward navigation.
+- [ ] Validate summary and transactions refresh after create/edit/delete and bulk mutation operations.
+- [ ] Remove debug logs before production deploy.
+
+**Post-Deployment Monitoring:**
+
+- [ ] Monitor dashboard/transactions API request volume for unexpected increases from header-level hooks.
+- [ ] Monitor client error logs around date parsing/query serialization paths.
+- [ ] Monitor UX feedback about date Reset semantics.
+
+**Rollback Plan:**
+
+- Revert `components/account-filter.tsx`, `components/date-filter.tsx`, `components/filters.tsx`, and `components/header.tsx`.
+- Revert query-key and invalidation changes under `features/**/api/*`.
+- Reinstall lockfile state from previous commit and redeploy.
+
+---
+
+## Technical Debt Assessment
+
+### Introduced Technical Debt
+
+1. Debug logging left in account filter handler
+
+- Issue: `console.log` calls remain in production component path.
+- Impact: Noisy logs and accidental leakage of URL/query context in client consoles.
+- Recommendation: Remove logs or wrap with development-only logging utility.
+- Effort: S
+
+2. Date filter state synchronization gap
+
+- Issue: Local date state is initialized from params once and may drift from URL updates.
+- Impact: Calendar selected state can become inconsistent with displayed active range.
+- Recommendation: Add state synchronization from `useSearchParams` changes.
+- Effort: S
+
+3. Reset semantics are ambiguous
+
+- Issue: Reset pushes default date values instead of clearing date params.
+- Impact: Potential mismatch between user expectation ("clear") and actual behavior ("set defaults").
+- Recommendation: Define/reset contract and implement consistently (clear or explicit default).
+- Effort: S
+
+4. Assumption: Summary invalidation coverage may still be incomplete for `useBulkDeleteAccounts`
+
+- Issue: Mutation invalidation was expanded broadly, but one account bulk-delete path appears unaligned.
+- Impact: Potential stale summary widgets after bulk account deletion.
+- Recommendation: Standardize invalidation policy and audit all mutation hooks.
+- Effort: S
+
+5. Account filter currently couples control state to summary loading on all dashboard routes
+
+- Issue: Filter disabled-state logic depends on summary loading even when summary is not displayed.
+- Impact: Extra background requests and unnecessary control blocking in non-summary routes.
+- Recommendation: Route-scope summary fetching or decouple filter disabled criteria.
+- Effort: M
+
+### Mitigated Technical Debt
+
+- Replaces unscoped transactions cache key with filter-aware cache key to reduce stale data reuse.
+- Adds `summary` invalidation to multiple mutation hooks that previously left TODOs.
+- Consolidates filter controls into reusable components instead of page-specific ad-hoc implementations.
+
+### Recommended Next Steps
+
+**Immediate (This Sprint):**
+
+- Remove debug logs from `components/account-filter.tsx`.
+- Add summary invalidation in `useBulkDeleteAccounts` for parity.
+- Confirm and document date reset behavior (clear vs default range).
+
+**Short-term (Next Sprint):**
+
+- Add URL-param-to-local-state synchronization tests for `DateFilter`.
+- Add integration tests for filter-driven fetch scoping on overview and transactions pages.
+- Decouple account filter disabled state from summary loading where not required.
+
+**Medium-term (Within Quarter):**
+
+- Define a shared React Query invalidation policy helper for mutation hooks.
+- Add route-level performance baselines for header-mounted data dependencies.
+
+**Long-term (Future Quarters):**
+
+- Consider central filter-state management abstraction (URL + UI sync) to reduce duplicated query-state logic.
+
+---
+
+## Testing Recommendations
+
+### Manual Testing Checklist
+
+- [ ] Open dashboard overview, change account filter, and confirm URL/query + cards/charts update.
+- [ ] Open transactions page with filters and verify table rows respect `from`/`to`/`accountId`.
+- [ ] Use browser back/forward after changing dates and verify displayed range and selected calendar range are consistent.
+- [ ] Edit/delete/create transactions and categories, then verify summary cards/charts refresh.
+- [ ] Bulk-delete accounts and verify whether summary refreshes correctly (current assumption risk).
+- [ ] Confirm all-zero filtered periods show expected chart empty state messaging.
+
+### Automated Testing Needs
+
+- [ ] Component tests for `AccountFilter` URL serialization and "All Accounts" behavior.
+- [ ] Component tests for `DateFilter` Apply/Reset behavior and state synchronization with URL changes.
+- [ ] Hook/integration tests verifying transactions query key partitioning by filter params.
+- [ ] Mutation-hook tests validating `summary` invalidation parity across all CRUD/bulk operations.
+
+---
+
+## Dependencies & Prerequisites
+
+### Required Environment Variables
+
+- None introduced by this PR.
+
+### External Service Dependencies
+
+- Existing dashboard stack only (Next.js app router, Hono API client, React Query, Radix UI primitives).
+
+### Breaking Changes
+
+- None.
+
+---
+
+## Performance Considerations
+
+### Frontend
+
+- Query-key scoping improves cache correctness but can increase cache entry count for many filter combinations.
+- Header-mounted account filter now includes summary loading coupling, which may add background summary requests on non-overview pages.
+
+### API
+
+- No direct API contract or endpoint implementation changes in this PR.
+
+### Database
+
+- No schema/query-layer changes introduced.
+
+---
+
+## Security Considerations
+
+- No authn/authz boundary changes in this PR.
+- No new sensitive data fields introduced in URL params; filters use account IDs and date strings already used by existing API contracts.
+- Server-side validation remains important for `from`/`to`/`accountId` query inputs regardless of client formatting behavior.
+
+---
+
+## Conclusion
+
+This PR delivers useful dashboard filtering and better cache coherence for analytics-driven UI, with moderate follow-up needed around filter-state sync semantics and invalidation parity.
+
+- Deployment Status: ⚠️ Needs Follow-up (recommended to address debug logs and invalidation/sync gaps before production hardening)
+
+- Generated: February 16, 2026
+- Branch: 10.SearchFilters
+- Base: origin/master
+- Files Changed: 20 files (+260/ -38)

--- a/PR-15/TECH_DEBT_TICKETS.md
+++ b/PR-15/TECH_DEBT_TICKETS.md
@@ -1,0 +1,81 @@
+# Technical Debt Tickets
+
+- Source: `PR-15/PR_SUMMARY.md`
+- Ticket count: 5 (<=10)
+
+## Priority Order
+
+## P1 — Complete summary invalidation parity for bulk account delete
+
+- Problem: Summary cache invalidation appears incomplete for at least one mutation path, which can leave analytics views stale after destructive account operations.
+- Evidence (quote): "Assumption: Summary invalidation coverage may still be incomplete for `useBulkDeleteAccounts`" (`Risks & Rollout Considerations` → `Medium-Impact Risks`)
+- Why it matters: Users can see outdated KPI/chart data after bulk account deletion, reducing trust in dashboard accuracy.
+- Scope / Proposed fix:
+  - Add `queryClient.invalidateQueries({ queryKey: ['summary'] })` to `useBulkDeleteAccounts` success path.
+  - Audit all mutation hooks for consistent invalidation policy across `summary`, `transactions`, and related entities.
+  - Add a lightweight shared helper/pattern to reduce future invalidation drift.
+- Acceptance criteria:
+  - [ ] Bulk account delete triggers summary refetch for current filter scope.
+  - [ ] Mutation-hook invalidation behavior is documented and consistent across CRUD/bulk paths.
+- Effort: S
+- Owner suggestion: Full-stack
+
+## P2 — Synchronize DateFilter local state with URL query changes
+
+- Problem: The date filter component initializes from URL params but may become out of sync when params change through navigation history or external URL updates.
+- Evidence (quote): "Date picker local state can diverge from URL-driven state after navigation" (`Risks & Rollout Considerations` → `Medium-Impact Risks`)
+- Why it matters: Users may see one active date range in label/URL and a different selected range in the calendar popover.
+- Scope / Proposed fix:
+  - Add an effect to update local `date` state when `from`/`to` search params change.
+  - Normalize parse + fallback behavior in a dedicated utility for deterministic behavior.
+  - Add component tests covering back/forward navigation and external param updates.
+- Acceptance criteria:
+  - [ ] Calendar selected range always matches active URL date params.
+  - [ ] Navigation back/forward does not produce stale calendar selections.
+- Effort: S
+- Owner suggestion: Frontend
+
+## P2 — Decouple account filter disabled state from summary loading on non-summary pages
+
+- Problem: Account filter control currently depends on summary hook loading state globally in dashboard layout, potentially triggering unnecessary summary fetches and blocking interaction where summary is not rendered.
+- Evidence (quote): "Account filter currently couples control state to summary loading on all dashboard routes" (`Technical Debt Assessment` → `Introduced Technical Debt`)
+- Why it matters: Adds avoidable request/load overhead and can degrade responsiveness on accounts/categories/transactions routes.
+- Scope / Proposed fix:
+  - Remove direct `useGetSummary` dependency from account filter disabled logic.
+  - Gate summary loading usage by route, or pass loading state only from pages that render summary.
+  - Add integration coverage for filter behavior on non-overview pages.
+- Acceptance criteria:
+  - [ ] Account filter remains usable on non-summary routes without waiting on summary fetch.
+  - [ ] No extra summary API call is triggered solely by rendering header filters outside overview.
+- Effort: M
+- Owner suggestion: Frontend
+
+## P2 — Define and implement explicit DateFilter reset contract
+
+- Problem: Reset currently applies default dates instead of clearing date params, which can be interpreted differently by users and maintainers.
+- Evidence (quote): "Reset behavior applies default date range rather than clearing date params" (`Risks & Rollout Considerations` → `Low-Impact Risks`)
+- Why it matters: Ambiguous behavior creates UX inconsistency and complicates testing/support.
+- Scope / Proposed fix:
+  - Decide product contract: clear params vs enforce explicit default range.
+  - Implement reset path to match contract and update button/help text as needed.
+  - Add tests for reset behavior and resulting URL state.
+- Acceptance criteria:
+  - [ ] Reset behavior is documented and deterministic in UI + URL.
+  - [ ] Automated tests validate chosen reset semantics.
+- Effort: S
+- Owner suggestion: Frontend
+
+## P3 — Remove debug logging from account filter handler
+
+- Problem: Debug `console.log` statements remain in a production-path client component.
+- Evidence (quote): "Debug logs remain in account filter handler" (`Risks & Rollout Considerations` → `Low-Impact Risks`)
+- Why it matters: Console noise reduces signal during troubleshooting and can expose internal query state in shared debugging sessions.
+- Scope / Proposed fix:
+  - Remove `console.log` statements from `components/account-filter.tsx`.
+  - If logging is needed, introduce a development-only logger guard.
+  - Add lint/static rule enforcement for stray console statements in production components.
+- Acceptance criteria:
+  - [ ] No raw console logs remain in account filter component.
+  - [ ] CI/lint prevents future unintended console logging in app components.
+- Effort: S
+- Owner suggestion: Frontend

--- a/PR-15/TECH_DEBT_TICKETS.md
+++ b/PR-15/TECH_DEBT_TICKETS.md
@@ -1,81 +1,96 @@
 # Technical Debt Tickets
 
 - Source: `PR-15/PR_SUMMARY.md`
-- Ticket count: 5 (<=10)
+- Ticket count: 6 (<=10)
 
 ## Priority Order
 
-## P1 — Complete summary invalidation parity for bulk account delete
+## P1 — Ensure summary invalidation parity for account bulk delete
 
-- Problem: Summary cache invalidation appears incomplete for at least one mutation path, which can leave analytics views stale after destructive account operations.
-- Evidence (quote): "Assumption: Summary invalidation coverage may still be incomplete for `useBulkDeleteAccounts`" (`Risks & Rollout Considerations` → `Medium-Impact Risks`)
-- Why it matters: Users can see outdated KPI/chart data after bulk account deletion, reducing trust in dashboard accuracy.
+- Problem: Summary cache invalidation appears inconsistent across mutation paths, with account bulk-delete called out as an uncovered case.
+- Evidence (quote): "Assumption: Summary invalidation is still incomplete for account bulk delete path" (`Risks & Rollout Considerations` -> `Medium-Impact Risks`)
+- Why it matters: Dashboard totals/charts can remain stale after bulk account deletion, creating correctness drift.
 - Scope / Proposed fix:
-  - Add `queryClient.invalidateQueries({ queryKey: ['summary'] })` to `useBulkDeleteAccounts` success path.
-  - Audit all mutation hooks for consistent invalidation policy across `summary`, `transactions`, and related entities.
-  - Add a lightweight shared helper/pattern to reduce future invalidation drift.
+  - Add `summary` invalidation in `useBulkDeleteAccounts` success handler.
+  - Audit all mutation hooks and document required invalidation keys.
+  - Add one shared helper/checklist to enforce invalidation consistency.
 - Acceptance criteria:
-  - [ ] Bulk account delete triggers summary refetch for current filter scope.
-  - [ ] Mutation-hook invalidation behavior is documented and consistent across CRUD/bulk paths.
+  - [ ] Bulk account delete triggers summary refetch for current filter context.
+  - [ ] All write mutation hooks follow the documented invalidation policy.
 - Effort: S
 - Owner suggestion: Full-stack
 
-## P2 — Synchronize DateFilter local state with URL query changes
+## P2 — Replace hardcoded All time lower bound with real data boundary
 
-- Problem: The date filter component initializes from URL params but may become out of sync when params change through navigation history or external URL updates.
-- Evidence (quote): "Date picker local state can diverge from URL-driven state after navigation" (`Risks & Rollout Considerations` → `Medium-Impact Risks`)
-- Why it matters: Users may see one active date range in label/URL and a different selected range in the calendar popover.
+- Problem: The All time preset uses a fixed year-2000 start date in client logic.
+- Evidence (quote): "Hardcoded baseline for \"All time\" preset" (`Technical Debt Assessment` -> `Introduced Technical Debt`)
+- Why it matters: Transactions earlier than the fixed date are excluded, producing incomplete analytics.
 - Scope / Proposed fix:
-  - Add an effect to update local `date` state when `from`/`to` search params change.
-  - Normalize parse + fallback behavior in a dedicated utility for deterministic behavior.
-  - Add component tests covering back/forward navigation and external param updates.
+  - Source earliest transaction date from backend metadata/query.
+  - Use that value (or configured product min date) for All time preset.
+  - Add fallback behavior when no transactions exist.
 - Acceptance criteria:
-  - [ ] Calendar selected range always matches active URL date params.
-  - [ ] Navigation back/forward does not produce stale calendar selections.
-- Effort: S
-- Owner suggestion: Frontend
+  - [ ] All time preset includes full historical range for the user.
+  - [ ] Behavior is deterministic when no historical data exists.
+- Effort: M
+- Owner suggestion: Full-stack
 
-## P2 — Decouple account filter disabled state from summary loading on non-summary pages
+## P2 — Decouple account filter disabled logic from summary loading on non-summary routes
 
-- Problem: Account filter control currently depends on summary hook loading state globally in dashboard layout, potentially triggering unnecessary summary fetches and blocking interaction where summary is not rendered.
-- Evidence (quote): "Account filter currently couples control state to summary loading on all dashboard routes" (`Technical Debt Assessment` → `Introduced Technical Debt`)
-- Why it matters: Adds avoidable request/load overhead and can degrade responsiveness on accounts/categories/transactions routes.
+- Problem: Account filter interactivity is tied to summary hook loading globally in dashboard header.
+- Evidence (quote): "Header filter disables account selector based on summary loading globally" (`Risks & Rollout Considerations` -> `Medium-Impact Risks`)
+- Why it matters: Adds avoidable background requests and can block filter interaction unnecessarily.
 - Scope / Proposed fix:
-  - Remove direct `useGetSummary` dependency from account filter disabled logic.
-  - Gate summary loading usage by route, or pass loading state only from pages that render summary.
-  - Add integration coverage for filter behavior on non-overview pages.
+  - Remove direct summary-loading dependency from `AccountFilter` disabled criteria.
+  - Gate summary dependency by route where summary is actually rendered.
+  - Add route-level integration tests for filter responsiveness.
 - Acceptance criteria:
-  - [ ] Account filter remains usable on non-summary routes without waiting on summary fetch.
-  - [ ] No extra summary API call is triggered solely by rendering header filters outside overview.
+  - [ ] Account filter remains responsive on non-summary pages.
+  - [ ] Non-summary routes do not trigger unnecessary summary fetches from header filters.
 - Effort: M
 - Owner suggestion: Frontend
 
-## P2 — Define and implement explicit DateFilter reset contract
+## P2 — Clarify and enforce reset semantics for date filtering
 
-- Problem: Reset currently applies default dates instead of clearing date params, which can be interpreted differently by users and maintainers.
-- Evidence (quote): "Reset behavior applies default date range rather than clearing date params" (`Risks & Rollout Considerations` → `Low-Impact Risks`)
-- Why it matters: Ambiguous behavior creates UX inconsistency and complicates testing/support.
+- Problem: Reset currently applies a default range instead of clearing date params, but behavior intent is not explicitly settled.
+- Evidence (quote): "Reset behavior enforces default range instead of clearing date params" (`Risks & Rollout Considerations` -> `Low-Impact Risks`)
+- Why it matters: Ambiguous behavior causes UX confusion and inconsistent expectations in QA/support.
 - Scope / Proposed fix:
-  - Decide product contract: clear params vs enforce explicit default range.
-  - Implement reset path to match contract and update button/help text as needed.
-  - Add tests for reset behavior and resulting URL state.
+  - Decide canonical reset behavior (clear vs default range).
+  - Implement chosen behavior consistently in UI and URL state.
+  - Add tests for reset outcomes and documentation text.
 - Acceptance criteria:
-  - [ ] Reset behavior is documented and deterministic in UI + URL.
-  - [ ] Automated tests validate chosen reset semantics.
+  - [ ] Reset behavior is explicitly documented and consistent in UI + URL.
+  - [ ] Automated tests validate the chosen reset contract.
 - Effort: S
 - Owner suggestion: Frontend
 
-## P3 — Remove debug logging from account filter handler
+## P3 — Remove dead commented DateFilter implementation block
 
-- Problem: Debug `console.log` statements remain in a production-path client component.
-- Evidence (quote): "Debug logs remain in account filter handler" (`Risks & Rollout Considerations` → `Low-Impact Risks`)
-- Why it matters: Console noise reduces signal during troubleshooting and can expose internal query state in shared debugging sessions.
+- Problem: Obsolete commented JSX from prior implementation remains in production component.
+- Evidence (quote): "Large commented legacy JSX block left in date filter" (`Risks & Rollout Considerations` -> `Low-Impact Risks`)
+- Why it matters: Dead commented code increases cognitive load and maintenance friction.
 - Scope / Proposed fix:
-  - Remove `console.log` statements from `components/account-filter.tsx`.
-  - If logging is needed, introduce a development-only logger guard.
-  - Add lint/static rule enforcement for stray console statements in production components.
+  - Delete the commented legacy popover block in `components/date-filter.tsx`.
+  - Keep current implementation only.
+  - Add lint rule/policy for avoiding large commented dead code blocks.
 - Acceptance criteria:
-  - [ ] No raw console logs remain in account filter component.
-  - [ ] CI/lint prevents future unintended console logging in app components.
+  - [ ] `components/date-filter.tsx` contains no large dead commented implementation block.
+  - [ ] Team coding standards/lint checks discourage reintroducing similar dead blocks.
+- Effort: S
+- Owner suggestion: Frontend
+
+## P3 — Remove debug logs from account filter handler
+
+- Problem: Debug `console.log` calls remain in user-facing filter change path.
+- Evidence (quote): "Debug logs still present in account filter" (`Risks & Rollout Considerations` -> `Low-Impact Risks`)
+- Why it matters: Console noise reduces debugging signal quality and weakens production logging hygiene.
+- Scope / Proposed fix:
+  - Remove `console.log(query)` and `console.log(url)` from `components/account-filter.tsx`.
+  - If required, replace with dev-only logger wrapper.
+  - Add lint guard for console usage in production components.
+- Acceptance criteria:
+  - [ ] No raw debug `console.log` calls remain in account filter component.
+  - [ ] Lint/static checks prevent accidental reintroduction.
 - Effort: S
 - Owner suggestion: Frontend

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
         "next-themes": "^0.4.6",
+        "query-string": "9.0.0",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-countup": "6.5.3",
@@ -757,6 +758,8 @@
 
     "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
+    "decode-uri-component": ["decode-uri-component@0.4.1", "", {}, "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
@@ -898,6 +901,8 @@
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "filter-obj": ["filter-obj@5.1.0", "", {}, "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng=="],
 
     "find-root": ["find-root@1.1.0", "", {}, "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="],
 
@@ -1245,6 +1250,8 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "query-string": ["query-string@9.0.0", "", { "dependencies": { "decode-uri-component": "^0.4.1", "filter-obj": "^5.1.0", "split-on-first": "^3.0.0" } }, "sha512-4EWwcRGsO2H+yzq6ddHcVqkCQ2EFUSfDMEjF8ryp8ReymyZhIuaFRGLomeOQLkrzacMHoyky2HW0Qe30UbzkKw=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
@@ -1354,6 +1361,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "split-on-first": ["split-on-first@3.0.0", "", {}, "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 

--- a/components/account-filter.tsx
+++ b/components/account-filter.tsx
@@ -28,14 +28,10 @@ export const AccountFilter = () => {
 
   const onChange = (newValue: string) => {
     const query = {
-      accountId: newValue,
+      accountId: newValue === 'all' ? '' : newValue,
       from,
       to,
     };
-    console.log(query);
-    if (newValue === 'all') {
-      query.accountId = '';
-    }
 
     const url = qs.stringifyUrl(
       {
@@ -44,7 +40,6 @@ export const AccountFilter = () => {
       },
       { skipNull: true, skipEmptyString: true }
     );
-    console.log(url);
 
     router.push(url);
   };

--- a/components/account-filter.tsx
+++ b/components/account-filter.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import qs from 'query-string';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import { useGetAccounts } from '@/features/accounts/api/use-get-accounts';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useGetSummary } from '@/features/summary/use-get-summary';
+
+export const AccountFilter = () => {
+  const { data: accounts, isLoading: isLoadingAccounts } = useGetAccounts();
+  const { isLoading: isLoadingSummary } = useGetSummary();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const params = useSearchParams();
+  const accountId = params.get('accountId') || 'all';
+  const from = params.get('from') || '';
+  const to = params.get('to') || '';
+
+  const onChange = (newValue: string) => {
+    const query = {
+      accountId: newValue,
+      from,
+      to,
+    };
+    console.log(query);
+    if (newValue === 'all') {
+      query.accountId = '';
+    }
+
+    const url = qs.stringifyUrl(
+      {
+        url: pathname,
+        query,
+      },
+      { skipNull: true, skipEmptyString: true }
+    );
+    console.log(url);
+
+    router.push(url);
+  };
+
+  return (
+    <Select
+      value={accountId}
+      onValueChange={onChange}
+      disabled={isLoadingAccounts || isLoadingSummary}
+    >
+      <SelectTrigger className="h-9 w-full rounded-md border-none bg-white/10 px-3 font-normal text-white transition outline-none hover:bg-white/20 hover:text-white focus:bg-white/30 focus:ring-transparent focus:ring-offset-0 lg:w-auto">
+        <SelectValue placeholder="Select account" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All Accounts</SelectItem>
+        {accounts?.map((account) => (
+          <SelectItem key={account.id} value={account.id}>
+            {account.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};

--- a/components/chart.tsx
+++ b/components/chart.tsx
@@ -41,6 +41,11 @@ export const Chart = ({ data = [] }: Props) => {
     setChartType(type);
   };
 
+  const isEmpty = data.length === 0;
+  const emptyTransactions = data.every(
+    (item) => item.income === 0 && item.expenses === 0
+  );
+
   return (
     <Card className="border-none drop-shadow-sm">
       <CardHeader className="flex justify-between space-y-2 lg:flex-row lg:items-center lg:space-y-0">
@@ -76,7 +81,7 @@ export const Chart = ({ data = [] }: Props) => {
         </Select>
       </CardHeader>
       <CardContent>
-        {data.length === 0 ? (
+        {isEmpty || emptyTransactions ? (
           <div className="flex h-87.5 flex-col items-center justify-center gap-y-4">
             <FileSearch className="text-muted-foreground size-6" />
             <p className="text-muted-foreground text-sm">

--- a/components/date-filter.tsx
+++ b/components/date-filter.tsx
@@ -1,7 +1,21 @@
 'use client';
 
-import { format, isValid, parse, subDays } from 'date-fns';
-import { ChevronDown } from 'lucide-react';
+import {
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  format,
+  isValid,
+  parse,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+  subDays,
+  subMonths,
+  subWeeks,
+  subYears,
+} from 'date-fns';
+import { ChevronDown, RotateCcw } from 'lucide-react';
 import { useState } from 'react';
 import { DateRange } from 'react-day-picker';
 
@@ -18,6 +32,34 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { formatDateRange } from '@/lib/utils';
+
+type PresetKey =
+  | 'today'
+  | 'yesterday'
+  | 'thisWeek'
+  | 'lastWeek'
+  | 'thisMonth'
+  | 'lastMonth'
+  | 'thisYear'
+  | 'lastYear'
+  | 'allTime';
+
+type Preset = {
+  key: PresetKey;
+  label: string;
+};
+
+const PRESETS: Preset[] = [
+  { key: 'today', label: 'Today' },
+  { key: 'yesterday', label: 'Yesterday' },
+  { key: 'thisWeek', label: 'This week' },
+  { key: 'lastWeek', label: 'Last week' },
+  { key: 'thisMonth', label: 'This month' },
+  { key: 'lastMonth', label: 'Last month' },
+  { key: 'thisYear', label: 'This year' },
+  { key: 'lastYear', label: 'Last year' },
+  { key: 'allTime', label: 'All time' },
+];
 
 export const DateFilter = () => {
   const router = useRouter();
@@ -42,7 +84,19 @@ export const DateFilter = () => {
     to: parseDateParam(to, defaultTo),
   };
 
+  const [open, setOpen] = useState(false);
   const [date, setDate] = useState<DateRange | undefined>(paramState);
+  const [month, setMonth] = useState<Date>(paramState.from);
+
+  const onOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+
+    if (nextOpen) {
+      // re-seed from URL-derived state every time the popover opens
+      setDate(paramState);
+      setMonth(paramState.from);
+    }
+  };
 
   const pushToUrl = (dateRange: DateRange | undefined) => {
     const query = {
@@ -67,8 +121,78 @@ export const DateFilter = () => {
     pushToUrl(undefined);
   };
 
+  const onPresetSelect = (preset: PresetKey) => {
+    const now = new Date();
+    let next: DateRange;
+
+    switch (preset) {
+      case 'today': {
+        next = { from: now, to: now };
+        break;
+      }
+      case 'yesterday': {
+        const y = subDays(now, 1);
+        next = { from: y, to: y };
+        break;
+      }
+      case 'thisWeek': {
+        next = {
+          from: startOfWeek(now, { weekStartsOn: 1 }),
+          to: endOfWeek(now, { weekStartsOn: 1 }),
+        };
+        break;
+      }
+      case 'lastWeek': {
+        const lastWeekDate = subWeeks(now, 1);
+        next = {
+          from: startOfWeek(lastWeekDate, { weekStartsOn: 1 }),
+          to: endOfWeek(lastWeekDate, { weekStartsOn: 1 }),
+        };
+        break;
+      }
+      case 'thisMonth': {
+        next = { from: startOfMonth(now), to: endOfMonth(now) };
+        break;
+      }
+      case 'lastMonth': {
+        const lastMonthDate = subMonths(now, 1);
+        next = {
+          from: startOfMonth(lastMonthDate),
+          to: endOfMonth(lastMonthDate),
+        };
+        break;
+      }
+      case 'thisYear': {
+        next = { from: startOfYear(now), to: endOfYear(now) };
+        break;
+      }
+      case 'lastYear': {
+        const lastYearDate = subYears(now, 1);
+        next = {
+          from: startOfYear(lastYearDate),
+          to: endOfYear(lastYearDate),
+        };
+        break;
+      }
+      case 'allTime': {
+        // Adjust to your product's "true min date" if you have one in DB
+        next = { from: new Date(2000, 0, 1), to: now };
+        break;
+      }
+      default: {
+        next = { from: defaultFrom, to: defaultTo };
+      }
+    }
+
+    setDate(next);
+
+    if (preset !== 'allTime' && next.from) {
+      setMonth(next.from);
+    }
+  };
+
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>
         <Button
           disabled={false}
@@ -80,25 +204,28 @@ export const DateFilter = () => {
           <ChevronDown className="ml-2 size-4 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-full p-0 lg:w-auto" align="start">
-        <Calendar
-          disabled={false}
-          autoFocus={true}
-          mode="range"
-          defaultMonth={date?.from}
-          selected={date}
-          onSelect={setDate}
-          numberOfMonths={2}
-        />
-        <div className="flex w-full flex-col gap-y-2 p-4">
+      {/* <PopoverContent className="w-full p-0 lg:w-auto" align="start">
+        <div className="flex items-center gap-2 border-b p-4">
+          <Calendar
+            disabled={false}
+            autoFocus={true}
+            mode="range"
+            defaultMonth={date?.from}
+            selected={date}
+            onSelect={setDate}
+            numberOfMonths={2}
+          />
+          <div>Hola</div>
+        </div>
+        <div className="flex w-full items-center gap-2 p-4">
           <PopoverClose asChild>
             <Button
               onClick={onReset}
               disabled={!date?.from || !date?.to}
-              className="w-full"
+              className="h-9 w-9 p-0"
               variant="outline"
             >
-              Reset
+              <RotateCcw />
             </Button>
           </PopoverClose>
           <PopoverClose asChild>
@@ -107,11 +234,80 @@ export const DateFilter = () => {
                 pushToUrl(date);
               }}
               disabled={!date?.from || !date?.to}
-              className="w-full"
+              className="h-9 flex-1 basis-1/2"
             >
               Apply
             </Button>
           </PopoverClose>
+        </div>
+      </PopoverContent> */}
+      <PopoverContent
+        align="start"
+        className="w-auto max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl p-0"
+      >
+        <div className="flex w-fit">
+          {/* Presets column */}
+          <aside className="bg-muted/20 w-42.5 shrink-0 border-r p-3">
+            <div className="flex flex-col items-start gap-1">
+              {PRESETS.map((preset) => (
+                <Button
+                  key={preset.key}
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onPresetSelect(preset.key)}
+                  className="hover:bg-muted h-8 w-fit justify-start px-2 text-sm font-normal"
+                >
+                  {preset.label}
+                </Button>
+              ))}
+            </div>
+          </aside>
+
+          {/* Calendar + actions */}
+          <div className="flex-1">
+            <div className="w-fit border-b p-3">
+              <Calendar
+                disabled={false}
+                autoFocus
+                mode="range"
+                month={month}
+                onMonthChange={setMonth}
+                defaultMonth={date?.from}
+                selected={date}
+                onSelect={(range) => {
+                  setDate(range);
+                  if (range?.from) setMonth(range.from);
+                }}
+                numberOfMonths={2}
+              />
+            </div>
+
+            <div className="flex items-center justify-between gap-2 p-3">
+              <PopoverClose asChild>
+                <Button
+                  onClick={onReset}
+                  disabled={!date?.from || !date?.to}
+                  className="h-9 w-9 p-0"
+                  variant="outline"
+                >
+                  <RotateCcw className="size-4" />
+                </Button>
+              </PopoverClose>
+
+              <div className="ml-auto flex items-center gap-2">
+                <PopoverClose asChild>
+                  <Button
+                    onClick={() => pushToUrl(date)}
+                    disabled={!date?.from || !date?.to}
+                    className="h-9 min-w-24"
+                  >
+                    Apply
+                  </Button>
+                </PopoverClose>
+              </div>
+            </div>
+          </div>
         </div>
       </PopoverContent>
     </Popover>

--- a/components/date-filter.tsx
+++ b/components/date-filter.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { format, isValid, parse, subDays } from 'date-fns';
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+import { DateRange } from 'react-day-picker';
+
+import qs from 'query-string';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { formatDateRange } from '@/lib/utils';
+
+export const DateFilter = () => {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const params = useSearchParams();
+  const accountId = params.get('accountId');
+  const from = params.get('from') || '';
+  const to = params.get('to') || '';
+
+  const defaultTo = new Date();
+  const defaultFrom = subDays(defaultTo, 30);
+
+  const parseDateParam = (value: string, fallback: Date) => {
+    if (!value) return fallback;
+    const parsed = parse(value, 'yyyy-MM-dd', new Date());
+    return isValid(parsed) ? parsed : fallback;
+  };
+
+  const paramState = {
+    from: parseDateParam(from, defaultFrom),
+    to: parseDateParam(to, defaultTo),
+  };
+
+  const [date, setDate] = useState<DateRange | undefined>(paramState);
+
+  const pushToUrl = (dateRange: DateRange | undefined) => {
+    const query = {
+      from: format(dateRange?.from || defaultFrom, 'yyyy-MM-dd'),
+      to: format(dateRange?.to || defaultTo, 'yyyy-MM-dd'),
+      accountId,
+    };
+
+    const url = qs.stringifyUrl(
+      {
+        url: pathname,
+        query,
+      },
+      { skipEmptyString: true, skipNull: true }
+    );
+
+    router.push(url);
+  };
+
+  const onReset = () => {
+    setDate(undefined);
+    pushToUrl(undefined);
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          disabled={false}
+          size="sm"
+          variant="outline"
+          className="h-9 w-full rounded-md border-none bg-white/10 px-3 font-normal text-white transition outline-none hover:bg-white/20 hover:text-white focus:bg-white/30 focus:ring-transparent focus:ring-offset-0 lg:w-auto"
+        >
+          <span>{formatDateRange(paramState)}</span>
+          <ChevronDown className="ml-2 size-4 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-full p-0 lg:w-auto" align="start">
+        <Calendar
+          disabled={false}
+          autoFocus={true}
+          mode="range"
+          defaultMonth={date?.from}
+          selected={date}
+          onSelect={setDate}
+          numberOfMonths={2}
+        />
+        <div className="flex w-full flex-col gap-y-2 p-4">
+          <PopoverClose asChild>
+            <Button
+              onClick={onReset}
+              disabled={!date?.from || !date?.to}
+              className="w-full"
+              variant="outline"
+            >
+              Reset
+            </Button>
+          </PopoverClose>
+          <PopoverClose asChild>
+            <Button
+              onClick={() => {
+                pushToUrl(date);
+              }}
+              disabled={!date?.from || !date?.to}
+              className="w-full"
+            >
+              Apply
+            </Button>
+          </PopoverClose>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/components/date-filter.tsx
+++ b/components/date-filter.tsx
@@ -98,12 +98,22 @@ export const DateFilter = () => {
     }
   };
 
-  const pushToUrl = (dateRange: DateRange | undefined) => {
-    const query = {
-      from: format(dateRange?.from || defaultFrom, 'yyyy-MM-dd'),
-      to: format(dateRange?.to || defaultTo, 'yyyy-MM-dd'),
-      accountId,
-    };
+  const pushToUrl = (
+    dateRange: DateRange | undefined,
+    mode: 'set' | 'clear' = 'set'
+  ) => {
+    const query =
+      mode === 'clear'
+        ? {
+            accountId,
+            from: null,
+            to: null,
+          }
+        : {
+            accountId,
+            from: dateRange?.from ? format(dateRange.from, 'yyyy-MM-dd') : null,
+            to: dateRange?.to ? format(dateRange.to, 'yyyy-MM-dd') : null,
+          };
 
     const url = qs.stringifyUrl(
       {
@@ -118,7 +128,7 @@ export const DateFilter = () => {
 
   const onReset = () => {
     setDate(undefined);
-    pushToUrl(undefined);
+    pushToUrl(undefined, 'clear');
   };
 
   const onPresetSelect = (preset: PresetKey) => {
@@ -191,6 +201,8 @@ export const DateFilter = () => {
     }
   };
 
+  const selectedDate = open ? date : paramState;
+
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>
@@ -204,43 +216,6 @@ export const DateFilter = () => {
           <ChevronDown className="ml-2 size-4 opacity-50" />
         </Button>
       </PopoverTrigger>
-      {/* <PopoverContent className="w-full p-0 lg:w-auto" align="start">
-        <div className="flex items-center gap-2 border-b p-4">
-          <Calendar
-            disabled={false}
-            autoFocus={true}
-            mode="range"
-            defaultMonth={date?.from}
-            selected={date}
-            onSelect={setDate}
-            numberOfMonths={2}
-          />
-          <div>Hola</div>
-        </div>
-        <div className="flex w-full items-center gap-2 p-4">
-          <PopoverClose asChild>
-            <Button
-              onClick={onReset}
-              disabled={!date?.from || !date?.to}
-              className="h-9 w-9 p-0"
-              variant="outline"
-            >
-              <RotateCcw />
-            </Button>
-          </PopoverClose>
-          <PopoverClose asChild>
-            <Button
-              onClick={() => {
-                pushToUrl(date);
-              }}
-              disabled={!date?.from || !date?.to}
-              className="h-9 flex-1 basis-1/2"
-            >
-              Apply
-            </Button>
-          </PopoverClose>
-        </div>
-      </PopoverContent> */}
       <PopoverContent
         align="start"
         className="w-auto max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl p-0"
@@ -274,7 +249,7 @@ export const DateFilter = () => {
                 month={month}
                 onMonthChange={setMonth}
                 defaultMonth={date?.from}
-                selected={date}
+                selected={selectedDate}
                 onSelect={(range) => {
                   setDate(range);
                   if (range?.from) setMonth(range.from);

--- a/components/filters.tsx
+++ b/components/filters.tsx
@@ -1,0 +1,9 @@
+import { AccountFilter } from './account-filter';
+
+export const Filters = () => {
+  return (
+    <div className="flex flex-col items-center gap-y-2 lg:flex-row lg:gap-x-2 lg:gap-y-0">
+      <AccountFilter />
+    </div>
+  );
+};

--- a/components/filters.tsx
+++ b/components/filters.tsx
@@ -1,9 +1,11 @@
 import { AccountFilter } from './account-filter';
+import { DateFilter } from './date-filter';
 
 export const Filters = () => {
   return (
     <div className="flex flex-col items-center gap-y-2 lg:flex-row lg:gap-x-2 lg:gap-y-0">
       <AccountFilter />
+      <DateFilter />
     </div>
   );
 };

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,8 +1,10 @@
 import { ClerkLoaded, ClerkLoading, UserButton } from '@clerk/nextjs';
-import { HeaderLogo } from './header-logo';
-import { Navigation } from './navigation';
 import { Loader2 } from 'lucide-react';
-import { WelcomeMsg } from './welcome-msg';
+
+import { Filters } from '@/components/filters';
+import { HeaderLogo } from '@/components/header-logo';
+import { Navigation } from '@/components/navigation';
+import { WelcomeMsg } from '@/components/welcome-msg';
 
 export const Header = () => {
   return (
@@ -21,6 +23,7 @@ export const Header = () => {
           </ClerkLoading>
         </div>
         <WelcomeMsg />
+        <Filters />
       </div>
     </header>
   );

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,25 +1,25 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { Popover as PopoverPrimitive } from "radix-ui"
+import { Popover as PopoverPrimitive } from 'radix-ui';
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Popover({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
-  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
 function PopoverTrigger({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
 function PopoverContent({
   className,
-  align = "center",
+  align = 'center',
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
@@ -30,60 +30,63 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
           className
         )}
         {...props}
       />
     </PopoverPrimitive.Portal>
-  )
+  );
 }
 
 function PopoverAnchor({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
-function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="popover-header"
-      className={cn("flex flex-col gap-1 text-sm", className)}
+      className={cn('flex flex-col gap-1 text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
-function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+function PopoverTitle({ className, ...props }: React.ComponentProps<'h2'>) {
   return (
     <div
       data-slot="popover-title"
-      className={cn("font-medium", className)}
+      className={cn('font-medium', className)}
       {...props}
     />
-  )
+  );
 }
 
 function PopoverDescription({
   className,
   ...props
-}: React.ComponentProps<"p">) {
+}: React.ComponentProps<'p'>) {
   return (
     <p
       data-slot="popover-description"
-      className={cn("text-muted-foreground", className)}
+      className={cn('text-muted-foreground', className)}
       {...props}
     />
-  )
+  );
 }
+
+const PopoverClose = PopoverPrimitive.Close;
 
 export {
   Popover,
-  PopoverTrigger,
-  PopoverContent,
   PopoverAnchor,
+  PopoverClose,
+  PopoverContent,
+  PopoverDescription,
   PopoverHeader,
   PopoverTitle,
-  PopoverDescription,
-}
+  PopoverTrigger,
+};

--- a/features/accounts/api/use-bulk-delete-accounts.ts
+++ b/features/accounts/api/use-bulk-delete-accounts.ts
@@ -30,6 +30,7 @@ export const useBulkDeleteAccounts = () => {
     onSuccess: () => {
       toast.success('Accounts deleted successfully');
       queryClient.invalidateQueries({ queryKey: ['accounts'] });
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: () => {
       toast.error(`Error deleting accounts`);

--- a/features/accounts/api/use-delete-account.ts
+++ b/features/accounts/api/use-delete-account.ts
@@ -29,7 +29,7 @@ export const useDeleteAccount = (id?: string) => {
       queryClient.invalidateQueries({ queryKey: ['account', { id }] });
       queryClient.invalidateQueries({ queryKey: ['accounts'] });
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
-      //TODO: Invalidate Summary
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: () => {
       toast.error(`Error to delete account`);

--- a/features/accounts/api/use-edit-account.ts
+++ b/features/accounts/api/use-edit-account.ts
@@ -33,7 +33,7 @@ export const useEditAccount = (id?: string) => {
       queryClient.invalidateQueries({ queryKey: ['account', { id }] });
       queryClient.invalidateQueries({ queryKey: ['accounts'] });
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
-      //TODO: Invalidate Summary
+      queryClient.invalidateQueries({ queryKey: ['summary'] }); //jic
     },
     onError: (error) => {
       const apiMessage =

--- a/features/categories/api/use-bulk-delete-categories.ts
+++ b/features/categories/api/use-bulk-delete-categories.ts
@@ -30,6 +30,7 @@ export const useBulkDeleteCategories = () => {
     onSuccess: () => {
       toast.success('Categories deleted successfully');
       queryClient.invalidateQueries({ queryKey: ['categories'] });
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: () => {
       toast.error(`Error deleting categories`);

--- a/features/categories/api/use-delete-category.ts
+++ b/features/categories/api/use-delete-category.ts
@@ -29,7 +29,7 @@ export const useDeleteCategory = (id?: string) => {
       queryClient.invalidateQueries({ queryKey: ['category', { id }] });
       queryClient.invalidateQueries({ queryKey: ['categories'] });
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
-      //TODO: Invalidate Summary and transactions later
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: () => {
       toast.error(`Error deleting category`);

--- a/features/categories/api/use-edit-category.ts
+++ b/features/categories/api/use-edit-category.ts
@@ -33,7 +33,7 @@ export const useEditCategory = (id?: string) => {
       queryClient.invalidateQueries({ queryKey: ['category', { id }] });
       queryClient.invalidateQueries({ queryKey: ['categories'] });
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
-      //TODO: Invalidate Summary and transactions later
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: () => {
       toast.error(`Error editing category`);

--- a/features/summary/use-get-summary.ts
+++ b/features/summary/use-get-summary.ts
@@ -13,8 +13,6 @@ export const useGetSummary = () => {
   const accountId = params.get('accountId') || '';
 
   const query = useQuery({
-    //TODO: Check if params ar needed in the key;
-
     queryKey: ['summary', { from, to, accountId }],
     queryFn: async () => {
       const response = await client.api.summary.$get({

--- a/features/transactions/api/use-bulk-create-transactions.ts
+++ b/features/transactions/api/use-bulk-create-transactions.ts
@@ -30,6 +30,7 @@ export const useBulkCreateTransactions = () => {
     onSuccess: () => {
       toast.success('Transactions created successfully');
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: () => {
       toast.error(`Error creating transactions`);

--- a/features/transactions/api/use-bulk-delete-transactions.ts
+++ b/features/transactions/api/use-bulk-delete-transactions.ts
@@ -30,6 +30,7 @@ export const useBulkDeleteTransactions = () => {
     onSuccess: () => {
       toast.success('Transactions deleted successfully');
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: () => {
       toast.error(`Error deleting transactions`);

--- a/features/transactions/api/use-create-transaction.ts
+++ b/features/transactions/api/use-create-transaction.ts
@@ -26,6 +26,7 @@ export const useCreateTransaction = () => {
     onSuccess: () => {
       toast.success('Transaction created successfully');
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: (error) => {
       const apiMessage =

--- a/features/transactions/api/use-delete-transaction.ts
+++ b/features/transactions/api/use-delete-transaction.ts
@@ -28,7 +28,7 @@ export const useDeleteTransaction = (id?: string) => {
       toast.success('Transaction deleted successfully');
       queryClient.invalidateQueries({ queryKey: ['transaction', { id }] });
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
-      //TODO: Invalidate Summary
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: () => {
       toast.error(`Error to delete transaction`);

--- a/features/transactions/api/use-edit-transaction.ts
+++ b/features/transactions/api/use-edit-transaction.ts
@@ -32,7 +32,7 @@ export const useEditTransaction = (id?: string) => {
       toast.success('Transaction edited successfully');
       queryClient.invalidateQueries({ queryKey: ['transaction', { id }] });
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
-      //TODO: Invalidate Summary
+      queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: (error) => {
       const apiMessage =

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -13,8 +13,6 @@ export const useGetTransactions = () => {
   const accountId = params.get('accountId') || '';
 
   const query = useQuery({
-    //TODO: Check if params ar needed in the key;
-
     queryKey: ['transactions', { from, to, accountId }],
     queryFn: async () => {
       const response = await client.api.transactions.$get({

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -15,7 +15,7 @@ export const useGetTransactions = () => {
   const query = useQuery({
     //TODO: Check if params ar needed in the key;
 
-    queryKey: ['transactions'],
+    queryKey: ['transactions', { from, to, accountId }],
     queryFn: async () => {
       const response = await client.api.transactions.$get({
         query: {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "next-themes": "^0.4.6",
+    "query-string": "9.0.0",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-countup": "6.5.3",


### PR DESCRIPTION
# PR Overview: Header Filters Expansion with Preset Date Ranges and Query-Scoped Refresh

## Summary

This PR evolves dashboard filtering by introducing account/date URL-driven filters in the header, extending the date filter UX with preset ranges and controlled popover state, scoping transactions/summary fetching to query params, and broadening summary invalidation after write mutations; it also includes branch-level review artifact files committed into `PR-15/`.

**Key Statistics** bullets:

- Files changed: 22 files (+854/ -38)
- Commits: 5 (`Enhance DateFilter component with preset date ranges and improved state management`, `codex review files`, `some todos remaining`, `Add date filter`, `Add account filter`)
- Backend: None (no backend route/controller/database-query logic changed in this PR)
- Frontend: Next.js client filters, React Query cache key/invalidation updates, Radix popover/select usage, preset date-range UX
- Database: None (no migration/schema/model changes)

---
