### PR TITLE
[codex] Scaffold Go backend health route

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,48 @@
+# Nuchi Go Backend
+
+This directory contains the separate Go API that will replace the current
+Hono/Drizzle/Neon backend.
+
+The scaffold currently exposes only a health endpoint. Database access, auth,
+OpenAPI generation, migrations, and frontend integration are intentionally left
+to their own issues.
+
+## Local Run
+
+```bash
+cd backend
+go run ./cmd/api
+```
+
+The API listens on `0.0.0.0:8080` by default.
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `BACKEND_HOST` | `0.0.0.0` | HTTP listen host |
+| `BACKEND_PORT` | `8080` | HTTP listen port |
+
+## Health Check
+
+```bash
+curl http://localhost:8080/api/health
+```
+
+Expected response:
+
+```json
+{
+  "service": "nuchi-api",
+  "status": "ok",
+  "time": "2026-06-29T00:00:00Z"
+}
+```
+
+## Verification
+
+```bash
+cd backend
+go test ./...
+go run ./cmd/api
+```

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/GonzaloSecades/nuchi/backend/internal/config"
+	httpapi "github.com/GonzaloSecades/nuchi/backend/internal/http"
+)
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	cfg := config.Load()
+	server := &http.Server{
+		Addr:              cfg.Addr(),
+		Handler:           httpapi.NewRouter(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	errs := make(chan error, 1)
+	go func() {
+		logger.Info("starting api", "addr", cfg.Addr())
+		errs <- server.ListenAndServe()
+	}()
+
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
+
+	select {
+	case err := <-errs:
+		if !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("api stopped", "error", err)
+			os.Exit(1)
+		}
+	case sig := <-shutdown:
+		logger.Info("shutting down api", "signal", sig.String())
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			logger.Error("graceful shutdown failed", "error", err)
+			os.Exit(1)
+		}
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,5 @@
+module github.com/GonzaloSecades/nuchi/backend
+
+go 1.23
+
+require github.com/go-chi/chi/v5 v5.2.3

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
+github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,0 +1,38 @@
+package config
+
+import "os"
+
+const (
+	defaultHost = "0.0.0.0"
+	defaultPort = "8080"
+)
+
+// Config contains process-level settings that are safe to read from the
+// environment at startup. Database and auth settings are intentionally absent
+// until those scoped issues add them.
+type Config struct {
+	Host string
+	Port string
+}
+
+// Load reads API host and port from the environment, falling back to local
+// development defaults.
+func Load() Config {
+	return Config{
+		Host: getEnv("BACKEND_HOST", defaultHost),
+		Port: getEnv("BACKEND_PORT", defaultPort),
+	}
+}
+
+// Addr returns the listen address accepted by net/http.
+func (c Config) Addr() string {
+	return c.Host + ":" + c.Port
+}
+
+func getEnv(key string, fallback string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/backend/internal/http/health.go
+++ b/backend/internal/http/health.go
@@ -1,0 +1,28 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+type healthResponse struct {
+	Service string `json:"service"`
+	Status  string `json:"status"`
+	Time    string `json:"time"`
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	response := healthResponse{
+		Service: "nuchi-api",
+		Status:  "ok",
+		Time:    time.Now().UTC().Format(time.RFC3339),
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, "failed to encode health response", http.StatusInternalServerError)
+	}
+}

--- a/backend/internal/http/health_test.go
+++ b/backend/internal/http/health_test.go
@@ -1,0 +1,39 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHealthEndpoint(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	response := httptest.NewRecorder()
+
+	NewRouter().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, response.Code)
+	}
+
+	if contentType := response.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Fatalf("expected JSON content type, got %q", contentType)
+	}
+
+	var body healthResponse
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+
+	if body.Service != "nuchi-api" {
+		t.Fatalf("expected service nuchi-api, got %q", body.Service)
+	}
+	if body.Status != "ok" {
+		t.Fatalf("expected status ok, got %q", body.Status)
+	}
+	if _, err := time.Parse(time.RFC3339, body.Time); err != nil {
+		t.Fatalf("expected RFC3339 time, got %q", body.Time)
+	}
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -1,0 +1,22 @@
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// NewRouter wires the API routes owned by this service. It is intentionally
+// small for the scaffold issue; future issues add auth, OpenAPI handlers, and
+// database-backed resources.
+func NewRouter() http.Handler {
+	router := chi.NewRouter()
+	router.Use(middleware.RequestID)
+	router.Use(middleware.RealIP)
+	router.Use(middleware.Recoverer)
+
+	router.Get("/api/health", healthHandler)
+
+	return router
+}


### PR DESCRIPTION
## Summary

- Adds a separate Go backend module under `backend/`.
- Wires a minimal `chi` router with `GET /api/health`.
- Adds host/port config defaults and a backend README with local run and health-check instructions.

## Scope

This intentionally does not add database access, auth, OpenAPI generation, migrations, Hono removal, or frontend integration. Those are separate issues from the #18 parent spec.

Closes #19

## Verification

- `cd backend && go test ./...`
- `cd backend && go run ./cmd/api`
- `curl http://localhost:8080/api/health`

Health check returned `200 OK` with:

```json
{"service":"nuchi-api","status":"ok","time":"2026-06-29T18:52:46Z"}
```
