### PR TITLE
[codex] Add local dev services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL=postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable
+NEXT_PUBLIC_API_URL=http://localhost:3000
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your_key_here
+CLERK_SECRET_KEY=sk_test_your_key_here
+SMTP_HOST=localhost
+SMTP_PORT=1025
+MAILPIT_WEB_URL=http://localhost:8025

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -37,13 +37,22 @@ bun install
 
 2. Copy environment variables from `.env.example` into `.env.local`.
 
-3. Run database migrations.
+3. Start local Postgres and Mailpit.
+
+```bash
+docker compose up -d postgres mailpit
+```
+
+Postgres listens on `localhost:5432` with `nuchi`/`nuchi` and database `nuchi`.
+Mailpit's SMTP server listens on `localhost:1025`; its UI is at `http://localhost:8025`.
+
+4. Run database migrations.
 
 ```bash
 bun run db:migrate
 ```
 
-4. Start the app.
+5. Start the app.
 
 ```bash
 bun dev
@@ -51,11 +60,26 @@ bun dev
 
 The app runs at `http://localhost:3000`.
 
+To check Postgres:
+
+```bash
+docker compose exec postgres pg_isready -U nuchi -d nuchi
+```
+
+To destroy local service data:
+
+```bash
+docker compose down --volumes
+```
+
 ## Environment Variables
 - `DATABASE_URL`
 - `NEXT_PUBLIC_API_URL`
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
 - `CLERK_SECRET_KEY`
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `MAILPIT_WEB_URL`
 
 See `.env.example` for the expected local shape.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: nuchi
+      POSTGRES_USER: nuchi
+      POSTGRES_PASSWORD: nuchi
+    ports:
+      - "5432:5432"
+    volumes:
+      - nuchi-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nuchi -d nuchi"]
+      interval: 2s
+      timeout: 5s
+      retries: 20
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+
+volumes:
+  nuchi-postgres-data:


### PR DESCRIPTION
## Summary

- Adds root Docker Compose services for local Postgres and Mailpit.
- Documents local DB/mail defaults in .env.example and the root README.
- Documents the destructive docker compose down --volumes reset command without automating it.

Closes #20

## Verification

- bun run lint
- docker compose config
- docker compose up -d postgres mailpit pulled images and started Mailpit, but Postgres could not bind localhost:5432 because that port is already in use on this machine.
- docker compose ps showed Mailpit healthy on 1025 and 8025.
- docker compose exec postgres pg_isready -U nuchi -d nuchi could not run because the Postgres service was not running after the host port conflict.

Mailpit UI should be available locally at http://localhost:8025 while the compose service is running.