### PR TITLE
[Issue - #53] Add CI workflow and PR merge automation config

### DIFF
--- a/.claude/agents/go-migrator.md
+++ b/.claude/agents/go-migrator.md
@@ -1,0 +1,40 @@
+---
+name: go-migrator
+description: Implements exactly one [Backend Migration NN] ticket in Go from a briefing (ticket, spec section, fixtures section, Hono reference source, OpenAPI operations). Use to dispatch the implementation work of a migration ticket after the orchestrator has made the design decisions.
+model: sonnet
+---
+
+You are a senior Go backend engineer implementing one nuchi migration ticket.
+You receive a briefing containing: the ticket text, the relevant section of
+`docs/specs/18-go-backend-replacement/spec.md`, the relevant section of
+`docs/specs/18-go-backend-replacement/api-parity-fixtures.md`, the legacy Hono
+source path(s) to port, and the OpenAPI operations in scope. If any of these
+is missing from your briefing, read them from the repo before writing code.
+
+Rules:
+
+- Implement ONLY what the ticket names. Honor its negative scope ("must not")
+  lines strictly. If you discover missing prerequisites, stop and report
+  instead of building them.
+- The fixtures document is the behavioral oracle. When the fixtures and your
+  intuition disagree, the fixtures win. When fixtures and the OpenAPI contract
+  intentionally differ, the contract's operation description decides.
+- Money is signed integer milliunits (int64). Never floats for money.
+- Handler request/response shapes come from generated types in
+  `backend/internal/openapi/` only. Never hand-edit generated files.
+- All user-data SQL includes ownership predicates even though RLS exists.
+- Write table-driven tests covering every acceptance criterion, including
+  unauthorized and cross-user isolation cases where applicable.
+- Design decisions (crypto choices, policy shapes, library picks) belong to
+  the orchestrator. If the briefing does not pin a decision you need, stop
+  and ask rather than choosing.
+
+Definition of done:
+
+1. `cd backend && go vet ./...` and `go test ./...` pass.
+2. Acceptance criteria each map to at least one test.
+3. `graphify update .` has been run and artifacts are included.
+4. Your final report lists: files changed, criteria->test mapping,
+   verification output, and any fixture ambiguities you hit.
+
+Never merge, never push to master, never touch tickets or the board.

--- a/.claude/agents/parity-reviewer.md
+++ b/.claude/agents/parity-reviewer.md
@@ -1,0 +1,32 @@
+---
+name: parity-reviewer
+description: Read-only review of a migration diff against api-parity-fixtures.md and the OpenAPI contract before human review. Use after go-migrator finishes and before opening or updating a PR. Reports severity-ranked findings; makes no edits.
+model: sonnet
+tools: Read, Glob, Grep, Bash
+---
+
+You review one migration ticket's diff for behavioral parity. You make no
+edits; you report findings.
+
+Method:
+
+1. Read the ticket's acceptance criteria and the matching sections of
+   `docs/specs/18-go-backend-replacement/api-parity-fixtures.md` and
+   `openapi/nuchi.openapi.json`.
+2. Read the diff (`git diff master...HEAD`) and the new tests.
+3. Check, in order of severity:
+   - Money: any float math, rounding drift, or non-milliunit amounts.
+   - Ownership/auth: any query path missing ownership predicates; identity
+     read from request body; endpoints missing auth.
+   - Contract conformance: status codes, error shapes, `{ "data": ... }`
+     envelope, required fields, currency default `ARS`.
+   - Fixture divergence: behavior that differs from the fixtures without a
+     documented intentional change in the OpenAPI operation description.
+   - Test adequacy: acceptance criteria without a covering test; missing
+     cross-user isolation or unauthorized cases.
+4. Run `cd backend && go vet ./...` and `go test ./...` and include results.
+
+Report format: findings ranked most-severe first, each with file:line, the
+fixture/contract line it violates, and a concrete failing scenario. If
+nothing survives verification, say so plainly. Do not pad with style nits;
+this review is about correctness and parity only.

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,0 +1,22 @@
+---
+name: researcher
+description: Fast web research for library docs, Go idioms, GitHub features, and API references. Use for any external docs lookup during migration work (goose/sqlc/pgxpool/oapi-codegen usage, GitHub API shapes, Next.js rewrites). Returns concise findings with source links.
+model: haiku
+tools: WebSearch, WebFetch, Read
+---
+
+You are a research assistant for the nuchi Go backend migration. Answer the
+question you are given using current web sources and return a concise brief.
+
+Rules:
+
+- Prefer official docs (pkg.go.dev, GitHub repos' README/docs, github.com
+  docs) over blog posts.
+- Always include the version the docs describe; the repo pins Go 1.23.
+- Quote exact API signatures, config keys, or CLI flags rather than
+  paraphrasing them.
+- If sources conflict or the feature looks recently changed, say so
+  explicitly instead of picking one silently.
+- Return: a 3-10 line answer, then a short list of source links. No code
+  dumps unless the question asks for a snippet.
+- Never modify files; you are read-only apart from your report.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "C:\\Users\\zecan\\.local\\bin\\graphify.EXE hook-check"
+            "command": "graphify hook-check"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,40 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go test:*)",
+      "Bash(go vet:*)",
+      "Bash(go build:*)",
+      "Bash(bun run lint:*)",
+      "Bash(bun run build:*)",
+      "Bash(bun run openapi:validate:*)",
+      "Bash(bun test:*)",
+      "Bash(bun install:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(graphify query:*)",
+      "Bash(graphify path:*)",
+      "Bash(graphify explain:*)",
+      "Bash(graphify update:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "C:\\Users\\zecan\\.local\\bin\\graphify.EXE hook-check"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/pr-review-cycle/SKILL.md
+++ b/.claude/skills/pr-review-cycle/SKILL.md
@@ -53,9 +53,14 @@ that Gonzalo re-triggers Copilot manually or reviews directly. Stop.
 
 Merge ONLY when all of these hold:
 
-1. Gonzalo has approved the PR (`reviewDecision: APPROVED`).
+1. Gonzalo has explicitly said to merge — in the session, or in a PR comment
+   ("approved", "merge it", "LGTM"). GitHub review approval is NOT usable as
+   the signal: Claude acts through Gonzalo's `gh` auth, so PRs are
+   self-authored and GitHub forbids approving your own PR. Never infer
+   approval from silence, resolved threads, or green CI.
 2. CI checks are green (`backend`, `frontend`, `openapi`).
-3. Unresolved review threads are addressed or explicitly rebutted.
+3. Review threads are resolved (ruleset-enforced), each one addressed or
+   explicitly rebutted first.
 
 Then:
 

--- a/.claude/skills/pr-review-cycle/SKILL.md
+++ b/.claude/skills/pr-review-cycle/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: pr-review-cycle
+description: Process Copilot review comments on a PR - assess findings, fix on-point medium/high ones, push, let Copilot re-review (max 3 automated iterations), and merge on Gonzalo's approval. Use when asked to process a PR's review comments, run the review cycle, or check whether a PR is mergeable.
+---
+
+# PR Review Cycle
+
+Automated review-response protocol for agent-authored PRs on nuchi. Copilot is
+the default first reviewer; Gonzalo owns approval. Claude executes this cycle.
+
+## Inputs
+
+A PR number. Resolve the linked `[Backend Migration NN]` ticket from the PR
+title/body before starting.
+
+## Iteration tracking
+
+Count prior automated iterations by scanning PR comments for the marker
+`<!-- claude-review-iteration: N -->`. If N >= 3, do NOT process further
+review comments automatically: comment that the automated cap is reached and
+that Gonzalo re-triggers Copilot manually or reviews directly. Stop.
+
+## Cycle (one iteration)
+
+1. Fetch review state:
+   - `gh pr view <n> --json reviews,reviewDecision,statusCheckRollup`
+   - `gh api repos/{owner}/{repo}/pulls/<n>/comments` for inline comments.
+   Only process comments newer than the last iteration marker.
+2. Classify each unresolved Copilot comment by severity. Copilot sometimes
+   tags severity in the comment body; when untagged, judge it yourself:
+   - high: correctness, security, data loss, money math, ownership/auth gaps
+   - medium: behavior divergence from fixtures/contract, error-shape
+     mismatches, missing test coverage for acceptance criteria
+   - low: style, naming, micro-optimizations, subjective preferences
+3. Assess on-pointness against the ticket, spec, and
+   `docs/specs/18-go-backend-replacement/api-parity-fixtures.md`. A comment is
+   NOT on point if it contradicts the fixtures, the OpenAPI contract, or a
+   documented intentional migration change.
+4. Act:
+   - high/medium and on point: fix in the PR branch.
+   - high/medium but wrong: reply on the thread quoting the fixture/spec line
+     that decides it. Do not change code.
+   - low: reply briefly; fix only if trivial and riskless.
+5. Verify: run the ticket's verification commands (minimum
+   `cd backend && go test ./...` for Go changes, `bun run lint` for TS).
+6. Push to the PR branch. Post a PR comment summarizing: findings addressed,
+   findings rebutted (with reasons), verification output, and the marker
+   `<!-- claude-review-iteration: N+1 -->`.
+7. Copilot re-reviews automatically on push (repo ruleset). If it does not,
+   re-request: `gh api -X POST repos/{owner}/{repo}/pulls/<n>/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"`.
+
+## Merge protocol
+
+Merge ONLY when all of these hold:
+
+1. Gonzalo has approved the PR (`reviewDecision: APPROVED`).
+2. CI checks are green (`backend`, `frontend`, `openapi`).
+3. Unresolved review threads are addressed or explicitly rebutted.
+
+Then:
+
+- `gh pr merge <n> --merge` (merge commit, never squash-delete). NEVER pass
+  `--delete-branch`; branches are retained.
+- Write a descriptive merge commit subject/body: what shipped, ticket ref,
+  verification evidence.
+- Comment verification evidence on the ticket, close it if the PR body's
+  `Closes #NN` did not, set its board status to Done
+  (project 1, owner GonzaloSecades).
+- Unblock the next queue ticket: remove `blocked`; add `agent:ready` only if
+  `risk:low`.
+- On master: run `graphify update .` and commit the refreshed artifacts.
+
+## Never
+
+- Never merge without Gonzalo's approval, even with green CI.
+- Never exceed 3 automated iterations.
+- Never delete the PR branch.
+- Never silence a Copilot finding by resolving the thread without a reply.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,56 @@
+# Copilot Instructions — nuchi
+
+Personal finance app mid-migration from Next.js/Hono/Drizzle/Neon/Clerk to a
+separate Go API (chi, pgxpool, sqlc, goose) with Dockerized PostgreSQL, owned
+JWT auth, and PostgreSQL RLS. OpenAPI (`openapi/nuchi.openapi.json`) is the
+contract source of truth. Behavior parity is defined by
+`docs/specs/18-go-backend-replacement/spec.md` and
+`docs/specs/18-go-backend-replacement/api-parity-fixtures.md`.
+
+## Code review: what to focus on
+
+Review comments are valuable when they identify, in descending priority:
+
+1. Money-math errors: transaction amounts are signed integer milliunits;
+   any float math on money, rounding drift, or unit confusion is a high
+   finding.
+2. Ownership/auth gaps: queries missing user-ownership predicates, identity
+   read from request bodies instead of the verified token, unprotected
+   mutating endpoints.
+3. Divergence from the parity fixtures or the OpenAPI contract: wrong status
+   codes, error shapes, missing `{ "data": ... }` envelope, missing required
+   `currency` (default `ARS`).
+4. Real correctness bugs with a concrete failing scenario.
+5. Missing tests for a ticket's stated acceptance criteria.
+
+## Code review: what NOT to comment on
+
+- Style, naming, formatting, import order: ESLint/Prettier/gofmt own these.
+- Subjective preferences or alternative designs when the implemented one is
+  documented in the spec, fixtures, or OpenAPI operation descriptions. Those
+  documents decide; do not re-litigate them.
+- Speculative issues phrased as "if X were the case" without verifying X in
+  the repo. Check the code before asserting a failure mode.
+- Generated code under `backend/internal/openapi/` and `lib/api/generated/`.
+- The dummy Clerk fallback keys in CI: intentional and documented; the Clerk
+  dependency is removed after Go parity (#27).
+- Legacy Hono/Drizzle code under `app/api/[[...route]]` and `db/`: reference
+  material scheduled for deletion; only flag changes that ADD new features
+  to it.
+- Points already rebutted in a previous review round on the same PR, unless
+  you have new evidence; repeating them stalls the merge protocol.
+
+## Comment format
+
+- Tag every comment with an explicit severity: `[high]`, `[medium]`, or
+  `[low]` at the start of the comment body.
+- Include the concrete failing scenario or the violated spec/fixture line.
+- Prefer one comment per root cause; do not fan out one issue into many
+  comments.
+
+## Repo conventions reviews should assume
+
+- Bun is the package manager; Go 1.23 for `backend/`.
+- Branch names `claude/<issue>-<slug>`; PR titles `[Issue - #<number>] ...`.
+- PRs by solo maintainer via agent tooling; review threads are processed by
+  an automated cycle capped at 3 iterations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+      - run: go vet ./...
+        working-directory: backend
+      - run: go test ./...
+        working-directory: backend
+
+  openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun ./scripts/validate-openapi.ts
+
+  frontend:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      DATABASE_URL: postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable
+      NEXT_PUBLIC_API_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,11 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     env:
-      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
-      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      # Build-safe dummies keep CI green when secrets are absent (fork PRs,
+      # fresh setup). Real secrets take precedence when configured; the Clerk
+      # dependency disappears with #51/#27.
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY || 'sk_test_ci_placeholder_not_a_real_key' }}
       DATABASE_URL: postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable
       NEXT_PUBLIC_API_URL: http://localhost:3000
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   backend:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# Nuchi — Claude Code Guide
+
+## Project
+
+Personal finance app mid-migration from Next.js/Hono/Drizzle/Neon/Clerk to a
+separate Go API (chi, pgxpool, sqlc, goose) with Dockerized PostgreSQL, owned
+JWT auth, and RLS. Port-not-redesign: freeze behavior via fixtures, swap the
+technology, refactor only after parity.
+
+Source of truth:
+
+- Spec + child issue plan: `docs/specs/18-go-backend-replacement/spec.md`
+- Behavioral oracle: `docs/specs/18-go-backend-replacement/api-parity-fixtures.md`
+- API contract: `openapi/nuchi.openapi.json` (OpenAPI-first: contract changes
+  land there first, then both sides regenerate)
+- Board: https://github.com/users/GonzaloSecades/projects/1
+
+Queue protocol: migration tickets are titled `[Backend Migration NN]`. Work the
+lowest open NN not labeled `blocked`. Only `risk:low` tickets may run
+unattended; `risk:high` tickets are attended work with human merge review.
+
+## Commands
+
+- Frontend: `bun run lint`, `bun run build`, `bun test`
+- Backend: `cd backend && go test ./...`, `go vet ./...`, `go run ./cmd/api`
+- Contract: `bun run openapi:validate`, `bun run openapi:gen:go`, `bun run openapi:gen:ts`
+- Services: `docker compose up -d postgres` (Mailpit included in dev compose)
+- Graph: `graphify update .` after code changes (AST-only, no API cost)
+
+## Hard Invariants
+
+- Transaction amounts are signed integer milliunits. Never floats for money.
+- App resource success responses use the `{ "data": ... }` envelope.
+- Default transaction currency is `ARS`; currency is required on transactions.
+- Auth-sensitive reads/writes derive identity from the verified token, never
+  from request body fields.
+- RLS is the security backstop; SQL still includes ownership predicates.
+- Generated code (`backend/internal/openapi/`, `lib/api/generated/`) is never
+  hand-edited.
+
+## Risk Policy
+
+`risk:high` (attended only): money math, SQL migrations, auth, RLS policies,
+bulk import, secrets, data deletion, production deploy changes.
+`risk:low` (unattended after calibration): docs, isolated tests, UI copy,
+dev scripts, CI config, codegen.
+
+## Branch And PR Hard Rules
+
+- Branch names: `claude/<issue-number>-<short-slug>`.
+- PR titles: `[Issue - #<number>] <PR title>`.
+- Never delete a branch after merge.
+- Never merge without green CI and Gonzalo's explicit PR approval.
+- Copilot is the default first reviewer. Its comments are processed by the
+  `pr-review-cycle` skill: address medium/high findings that are on point,
+  reply to the rest with reasoning, push, let Copilot re-review. Hard cap of
+  3 automated iterations per PR; after that, only Gonzalo re-triggers.
+- On Gonzalo's approval: merge with a merge commit and a descriptive message,
+  comment verification evidence on the ticket, close the ticket, set its board
+  status to Done, unblock the next queue ticket, and refresh graphify on
+  master.
+
+## Model Orchestration
+
+- Main session (Fable) is the tech lead/PM: picks tickets, writes briefings
+  (ticket + spec section + fixtures section + Hono reference source + OpenAPI
+  operations), makes design decisions, gates reviews and merges.
+- `.claude/agents/go-migrator.md` (Sonnet) implements one ticket per dispatch,
+  in an isolated worktree.
+- `.claude/agents/researcher.md` (Haiku) does web/docs lookups.
+- `.claude/agents/parity-reviewer.md` reviews diffs against fixtures before
+  human review.
+
+## Graphify
+
+`graphify-out/` is the repo knowledge graph. For codebase questions run
+`graphify query "<question>"` first; use `graphify path`/`explain` for
+relationships and concepts. Dirty `graphify-out/` files are expected and not a
+reason to skip it. Refresh with `graphify update .` after code changes and
+before handing in a ticket. Full rules: `AGENTS.md` (graphify section).
+
+## Legacy Code
+
+Existing Hono routes (`app/api/[[...route]]`), Drizzle schema (`db/`), and
+Clerk usage are reference material for parity work. Do not extend them with
+new features; they are removed in #27 after Go parity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ unattended; `risk:high` tickets are attended work with human merge review.
 ## Commands
 
 - Frontend: `bun run lint`, `bun run build`, `bun test`
-- Backend: `cd backend && go test ./...`, `go vet ./...`, `go run ./cmd/api`
+- Backend (run from `backend/`): `cd backend && go test ./...`,
+  `cd backend && go vet ./...`, `cd backend && go run ./cmd/api`
 - Contract: `bun run openapi:validate`, `bun run openapi:gen:go`, `bun run openapi:gen:ts`
 - Services: `docker compose up -d postgres` (Mailpit included in dev compose)
 - Graph: `graphify update .` after code changes (AST-only, no API cost)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,10 @@ dev scripts, CI config, codegen.
 - Branch names: `claude/<issue-number>-<short-slug>`.
 - PR titles: `[Issue - #<number>] <PR title>`.
 - Never delete a branch after merge.
-- Never merge without green CI and Gonzalo's explicit PR approval.
+- Never merge without green CI and Gonzalo's explicit merge instruction (in
+  session or as a PR comment). GitHub review approval cannot be the signal:
+  Claude works through Gonzalo's `gh` auth, so PRs are self-authored and
+  GitHub forbids self-approval.
 - Copilot is the default first reviewer. Its comments are processed by the
   `pr-review-cycle` skill: address medium/high findings that are on point,
   reply to the rest with reasoning, push, let Copilot re-review. Hard cap of


### PR DESCRIPTION
Closes #53

## What this adds

**CI** (`.github/workflows/ci.yml`) - three required checks on PRs and master pushes:
- `backend`: `go vet` + `go test ./...` (Go 1.23 from go.mod)
- `openapi`: dependency-free validator against `openapi/nuchi.openapi.json`
- `frontend`: `bun run lint` + `bun run build`

**PR merge hard rules**, encoded in `CLAUDE.md` + `.claude/skills/pr-review-cycle/SKILL.md`:
- Copilot is the default first reviewer (auto-requested via repo ruleset, re-reviews on push)
- Claude processes Copilot comments: fixes on-point medium/high findings, rebuts with fixture/spec citations otherwise, pushes, Copilot re-reviews - hard cap of **3 automated iterations**, then manual only
- Merge only on Gonzalo approval + green CI: merge commit, descriptive message, ticket closed, board set Done, **branch never deleted**, graphify refreshed on master

**Claude workflow config:**
- `CLAUDE.md`: project guide (invariants, risk policy, queue protocol, orchestration roles)
- `.claude/settings.json`: verification-command permission allowlist + graphify hook-check hook (invoked from PATH for portability)
- `.claude/agents/`: `go-migrator` (Sonnet, implements one ticket per dispatch), `researcher` (Haiku, web docs), `parity-reviewer` (Sonnet, fixtures-conformance review)

## Clerk keys in CI

The `frontend` job falls back to build-safe dummy Clerk keys via `${{ secrets.X || 'dummy' }}`, so **CI is green with no repo secrets configured** (including fork PRs). Real values in `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` / `CLERK_SECRET_KEY` secrets take precedence if ever added. The Clerk dependency is removed entirely at #51/#27.

## Verification

- `bun run openapi:validate` passes locally
- All three checks green on this PR (run 28990843547)

🤖 Generated with [Claude Code](https://claude.com/claude-code)