### PR TITLE
[Issue - #67] Run the backend suite under the race detector in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,24 @@ jobs:
         working-directory: backend
       - run: go test ./...
         working-directory: backend
+      # Kept as a second run rather than replacing the plain one above. The
+      # plain run is the readable signal — a failure there is a logic failure,
+      # unambiguously — while this run adds concurrency coverage the project
+      # has never had: the async email sends, the LockUser-serialized token
+      # issuance, and the concurrent one-time-token consume paths from #42, and
+      # from #43 onward the auth middleware and per-transaction RLS session
+      # binding. The usual argument against a second step is DB-backed test
+      # time, but the suite is ~20s total, so the duplication is not worth
+      # trading the separated signal for.
+      #
+      # The race detector needs cgo, which is off by default on the dev machine
+      # (Windows, no gcc — the detector cannot run there at all). ubuntu-latest
+      # has gcc, so this is the only place it executes.
+      - name: Test under the race detector
+        run: go test -race ./...
+        working-directory: backend
+        env:
+          CGO_ENABLED: 1
 
   openapi:
     runs-on: ubuntu-latest

--- a/docs/specs/18-go-backend-replacement/spec.md
+++ b/docs/specs/18-go-backend-replacement/spec.md
@@ -347,8 +347,8 @@ Active sequence:
 | 04 | [#37](https://github.com/GonzaloSecades/nuchi/issues/37) | Wire Go database foundation | high | #54 | no |
 | 05 | [#38](https://github.com/GonzaloSecades/nuchi/issues/38) | Create base SQL migrations with users and auth tables | high | #37 | no |
 | 06 | [#39](https://github.com/GonzaloSecades/nuchi/issues/39) | Create finance schema migrations with RLS | high | #38 | no |
-| 07 | [#31](https://github.com/GonzaloSecades/nuchi/issues/31) | Add backend dev scripts and explicit DB reset workflow | low | #39 | no while blocked |
-| 08 | [#40](https://github.com/GonzaloSecades/nuchi/issues/40) | Add sqlc queries for auth and owned resources | high | #31 | no |
+| 07 | [#31](https://github.com/GonzaloSecades/nuchi/issues/31) | Add backend dev scripts and explicit DB reset workflow | low | #39 | closed as obsolete — see note below |
+| 08 | [#40](https://github.com/GonzaloSecades/nuchi/issues/40) | Add sqlc queries for auth and owned resources | high | #39 | no |
 | 09 | [#41](https://github.com/GonzaloSecades/nuchi/issues/41) | Implement password auth and JWT sessions | high | #40 | no |
 | 10 | [#43](https://github.com/GonzaloSecades/nuchi/issues/43) | Add Go auth middleware and DB RLS session binding | high | #41 | no |
 | 11 | [#42](https://github.com/GonzaloSecades/nuchi/issues/42) | Implement email verification and password reset | high | #41; may run parallel to 12-16 | no |
@@ -362,6 +362,13 @@ Active sequence:
 | 19 | [#50](https://github.com/GonzaloSecades/nuchi/issues/50) | Migrate TanStack hooks to generated client | high | #49 | no |
 | 20 | [#51](https://github.com/GonzaloSecades/nuchi/issues/51) | Replace Clerk auth pages with custom auth pages | high | #50 | no |
 | 21 | [#27](https://github.com/GonzaloSecades/nuchi/issues/27) | Remove legacy Hono/Drizzle/Neon/Clerk backend after Go parity | high, blocked | #51 | no |
+
+Seq 07 (#31) was closed as obsolete rather than completed. Its only role in
+this plan was to gate #40, and #40 shipped without it, so it gated nothing. It
+sat unworked because the `blocked` label was applied when the tickets were bulk
+created and never cleared after its own dependency (#39) closed. Seq 08's
+dependency is recorded above as #39 to reflect what actually happened. No step
+in the sequence was skipped.
 
 Superseded duplicates:
 


### PR DESCRIPTION
Closes #67.

## What

Adds `go test -race ./...` to the `backend` CI job, and fixes a stale row in
the spec's active-sequence table.

## Why now

The project has never run the race detector. #42 landed goroutine-based async
email sends, `LockUser`-serialized token issuance, and concurrent
one-time-token consume paths — precisely the shapes `-race` exists to check —
and none of them are covered by it today.

#43 (auth middleware + per-transaction `set_config('app.user_id', ...)` RLS
session binding) is next on the critical path and adds more shared-state
concurrency. Landing race coverage first means that ticket gets written under
it rather than having it retrofitted.

## Second step, not a replacement

The plain `go test ./...` stays. A failure there is unambiguously a logic
failure, which keeps the signal readable; the `-race` step then adds the
concurrency coverage on top.

The usual argument for replacing rather than adding is DB-backed test time, but
the suite is small enough that it does not apply — measured locally against the
WSL Postgres:

```
ok  internal/config  1.045s
ok  internal/db      4.055s
ok  internal/http   12.602s
ok  internal/mail    1.858s
```

~20s total. Duplicating that is not worth trading the separated signal for.

## cgo

`-race` requires `CGO_ENABLED=1` and a C toolchain. The dev machine is Windows
with no gcc, so the detector cannot run there at all — CI is the only place it
executes. `CGO_ENABLED: 1` is scoped to the race step so `go vet` and the plain
test run are unaffected.

## Doc fix

The active-sequence table still listed seq 07 / #31 as a pending step. #31 was
closed as obsolete, not completed — its only role was to gate #40, and #40
shipped without it. It sat unworked because `blocked` was applied at bulk
creation and never cleared after its dependency #39 closed. The row is now
annotated, seq 08's dependency reads #39 to match what actually happened, and a
note below the table explains it so the plan does not read as though a step
were skipped.

## Verification

Pending on this PR's own CI run — that is the only place `-race` can execute.
The race step's package timings need to show real execution rather than skips;
`TEST_DATABASE_URL` is job-level `env`, so it applies to the new step.

If the detector surfaces a genuine data race, that gets reported rather than
papered over.

## Risk

`risk:low` — CI config and docs only. No application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)