### PR TITLE
[Issue - #43] Add Go auth middleware and DB RLS session binding

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -37,6 +37,17 @@ func main() {
 	defer pool.Close()
 	logger.Info("connected to database", "host", databaseHost(cfg.DatabaseURL))
 
+	// Refuse to serve if the connection role bypasses RLS (superuser or
+	// BYPASSRLS): the RLS session binding is the request path's tenant
+	// isolation, and a bypassing role silently voids it for every owned-table
+	// query. Better to fail startup than to run wide open.
+	if err := db.VerifyRLSActive(startupCtx, pool); err != nil {
+		logger.Error("refusing to start: database role bypasses row level security", "error", err)
+		pool.Close()
+		os.Exit(1)
+	}
+	logger.Info("row level security verified active for owned tables")
+
 	mailer := mail.NewSMTPMailer(cfg.SMTPAddr, cfg.MailFrom, cfg.AppBaseURL)
 	authServer := httpapi.NewAuthServer(pool, cfg, mailer)
 

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -10,12 +10,25 @@ import (
 )
 
 // ErrInvalidAccessToken is returned by VerifyAccessToken for any token that
-// fails signature verification, has expired, or does not carry a
-// well-formed user id in its subject claim. Callers should treat it as a
-// generic 401, never distinguishing the reason (that would leak information
-// about token internals to a caller who should not have a valid token in
-// the first place).
+// fails signature verification or does not carry a well-formed user id in
+// its subject claim. Callers should treat it as a generic 401, never
+// distinguishing the reason (that would leak information about token
+// internals to a caller who should not have a valid token in the first
+// place). The one deliberate carve-out is expiry: see ErrAccessTokenExpired.
 var ErrInvalidAccessToken = errors.New("auth: invalid access token")
+
+// ErrAccessTokenExpired is returned by VerifyAccessToken specifically when
+// the token's signature and structure are otherwise valid and only its exp
+// claim has passed. This is the one exception to ErrInvalidAccessToken's
+// "never distinguish the reason" rule: an expired token was validly signed
+// (its holder already proved possession of the secret's issuer-side
+// counterpart, i.e. they authenticated successfully at some point), so
+// telling the client "your token expired" leaks nothing an attacker could
+// use, and the client needs the distinction to know it should call
+// /api/auth/refresh rather than re-prompt for credentials. Every other
+// rejection reason (bad signature, disallowed alg, missing/invalid subject)
+// stays collapsed into ErrInvalidAccessToken.
+var ErrAccessTokenExpired = errors.New("auth: access token expired")
 
 // IssueAccessToken signs a short-lived HS256 JWT for userID. The claim set
 // is intentionally minimal — sub (user id), iat, and exp only, per the #41
@@ -51,6 +64,13 @@ func IssueAccessToken(secret []byte, userID uuid.UUID, ttl time.Duration) (token
 // token), expired tokens, and tokens whose subject is not a valid UUID.
 // This is the helper #43 wires into resource-route middleware to derive the
 // authenticated user.
+//
+// Carve-out (#43): an expired-but-otherwise-valid token returns
+// ErrAccessTokenExpired instead of the generic ErrInvalidAccessToken, so
+// callers (the auth middleware) can surface the contract's distinct
+// ACCESS_TOKEN_EXPIRED code. Every other failure — bad signature, wrong
+// secret, disallowed alg, missing exp, non-UUID subject, garbage input —
+// still collapses into ErrInvalidAccessToken.
 func VerifyAccessToken(secret []byte, tokenString string) (uuid.UUID, error) {
 	claims := &jwt.RegisteredClaims{}
 
@@ -59,7 +79,13 @@ func VerifyAccessToken(secret []byte, tokenString string) (uuid.UUID, error) {
 		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}),
 		jwt.WithExpirationRequired(),
 	)
-	if err != nil || !token.Valid {
+	if err != nil {
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return uuid.UUID{}, ErrAccessTokenExpired
+		}
+		return uuid.UUID{}, ErrInvalidAccessToken
+	}
+	if !token.Valid {
 		return uuid.UUID{}, ErrInvalidAccessToken
 	}
 

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -72,8 +73,42 @@ func TestVerifyAccessToken_ExpiredRejected(t *testing.T) {
 		t.Fatalf("IssueAccessToken: unexpected error: %v", err)
 	}
 
-	if _, err := VerifyAccessToken(secret, token); err == nil {
+	_, err = VerifyAccessToken(secret, token)
+	if err == nil {
 		t.Fatal("VerifyAccessToken: expected an expired token to be rejected")
+	}
+	// #43 carve-out: expiry must be distinguishable from every other
+	// rejection reason so the auth middleware can map it to the contract's
+	// ACCESS_TOKEN_EXPIRED code instead of the generic UNAUTHORIZED.
+	if !errors.Is(err, ErrAccessTokenExpired) {
+		t.Fatalf("VerifyAccessToken: expected ErrAccessTokenExpired, got %v", err)
+	}
+	if errors.Is(err, ErrInvalidAccessToken) {
+		t.Fatalf("VerifyAccessToken: expired token must not also satisfy ErrInvalidAccessToken, got %v", err)
+	}
+}
+
+// TestVerifyAccessToken_NonExpiryFailuresStayGeneric pins the other half of
+// the #43 carve-out: every rejection reason that is not expiry must
+// collapse into ErrInvalidAccessToken, never ErrAccessTokenExpired.
+func TestVerifyAccessToken_NonExpiryFailuresStayGeneric(t *testing.T) {
+	secret := []byte("test-secret-at-least-32-bytes-long!")
+	userID := uuid.New()
+
+	token, _, err := IssueAccessToken([]byte("a-different-secret-at-least-32-bytes!!"), userID, 30*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken: unexpected error: %v", err)
+	}
+
+	_, err = VerifyAccessToken(secret, token)
+	if err == nil {
+		t.Fatal("VerifyAccessToken: expected a wrong-secret token to be rejected")
+	}
+	if !errors.Is(err, ErrInvalidAccessToken) {
+		t.Fatalf("VerifyAccessToken: expected ErrInvalidAccessToken, got %v", err)
+	}
+	if errors.Is(err, ErrAccessTokenExpired) {
+		t.Fatalf("VerifyAccessToken: a wrong-secret token must not satisfy ErrAccessTokenExpired, got %v", err)
 	}
 }
 

--- a/backend/internal/db/livedb_test.go
+++ b/backend/internal/db/livedb_test.go
@@ -27,3 +27,25 @@ func liveDatabaseURL(t *testing.T, what string) string {
 	t.Skipf("TEST_DATABASE_URL not set; skipping %s", what)
 	return ""
 }
+
+// adminDatabaseURL returns ADMIN_DATABASE_URL, a connection that authenticates
+// as a role which bypasses RLS (the bootstrap superuser). Tests use it to
+// prove VerifyRLSActive rejects such a role — the negative half of the startup
+// guard, which cannot be shown with the ordinary TEST_DATABASE_URL role.
+//
+// Same skip-local / fail-in-CI contract as liveDatabaseURL: CI exports
+// ADMIN_DATABASE_URL for the whole backend job, so a missing value there means
+// the workflow broke rather than that the guard is untested.
+func adminDatabaseURL(t *testing.T, what string) string {
+	t.Helper()
+
+	databaseURL := os.Getenv("ADMIN_DATABASE_URL")
+	if databaseURL != "" {
+		return databaseURL
+	}
+	if os.Getenv("CI") != "" {
+		t.Fatalf("ADMIN_DATABASE_URL is unset in CI; %s must run against the workflow's admin role, never be skipped", what)
+	}
+	t.Skipf("ADMIN_DATABASE_URL not set; skipping %s", what)
+	return ""
+}

--- a/backend/internal/db/migration_upgrade_test.go
+++ b/backend/internal/db/migration_upgrade_test.go
@@ -1,0 +1,239 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// TestMigration00004_NullsPreexistingCrossOwnerCategory_LiveDatabase exercises
+// the data-migration path in 00004 that the post-v4 policy tests cannot reach:
+// a transaction that already references another tenant's category (legal under
+// the v3 account-only policy) must have that category_id nulled when v4 is
+// applied. It regresses the bug where the cleanup lifted FORCE RLS only on the
+// UPDATE target (transactions) and not on the joined accounts/categories, so
+// the join saw zero rows and the cleanup silently did nothing.
+//
+// It runs the real migrations with the goose binary against a throwaway
+// database, bootstrapped exactly like CI (public schema owned by the ordinary
+// app role, citext installed by the superuser) so FORCE RLS genuinely applies
+// to the migration's own role. The throwaway database keeps it from disturbing
+// the shared TEST_DATABASE_URL migration state that other packages test
+// against in parallel.
+func TestMigration00004_NullsPreexistingCrossOwnerCategory_LiveDatabase(t *testing.T) {
+	appURL := liveDatabaseURL(t, "00004 upgrade test (app role)")
+	adminURL := adminDatabaseURL(t, "00004 upgrade test (admin role)")
+	gooseBin := gooseBinary(t)
+
+	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
+	if err != nil {
+		t.Fatalf("resolve migrations dir: %v", err)
+	}
+
+	appRole := userInURL(t, appURL)
+	tempDB := "nuchi_migtest_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	tempAppURL := withDatabase(t, appURL, tempDB)
+	tempAdminURL := withDatabase(t, adminURL, tempDB)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Create the throwaway database and bootstrap it like CI: hand the public
+	// schema to the app role so the migrations it runs own their tables (which
+	// is what makes FORCE RLS apply to that role), and install citext as the
+	// superuser so 00001's CREATE EXTENSION is a no-op regardless of whether
+	// citext is a trusted extension here.
+	adminConn := connect(ctx, t, adminURL)
+	if _, err := adminConn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", pgIdent(tempDB))); err != nil {
+		adminConn.Close(ctx)
+		t.Fatalf("create throwaway database: %v", err)
+	}
+	adminConn.Close(ctx)
+
+	// Drop the throwaway database last (deferred first => runs last, after every
+	// connection below is closed). WITH (FORCE) evicts any lingering backend.
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer dropCancel()
+		cleanupConn, err := pgx.Connect(dropCtx, adminURL)
+		if err != nil {
+			t.Errorf("cleanup: connect to drop throwaway database: %v", err)
+			return
+		}
+		defer cleanupConn.Close(dropCtx)
+		if _, err := cleanupConn.Exec(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS %s WITH (FORCE)", pgIdent(tempDB))); err != nil {
+			t.Errorf("cleanup: drop throwaway database %q: %v", tempDB, err)
+		}
+	}()
+
+	bootstrapConn := connect(ctx, t, tempAdminURL)
+	for _, stmt := range []string{
+		fmt.Sprintf("ALTER SCHEMA public OWNER TO %s", pgIdent(appRole)),
+		"CREATE EXTENSION IF NOT EXISTS citext",
+	} {
+		if _, err := bootstrapConn.Exec(ctx, stmt); err != nil {
+			bootstrapConn.Close(ctx)
+			t.Fatalf("bootstrap throwaway database (%q): %v", stmt, err)
+		}
+	}
+	bootstrapConn.Close(ctx)
+
+	// Migrate to v3 (pre-fix policy), as the app role.
+	runGoose(ctx, t, gooseBin, migrationsDir, tempAppURL, "up-to", "3")
+
+	// Seed a committed cross-owner reference the v3 policy still allows: user A's
+	// transaction on user A's account pointing at user B's category. Runs on a
+	// single connection so the session-level app.user_id set between inserts
+	// sticks. The v3 transactions_owner WITH CHECK only proves account ownership,
+	// so this insert is accepted; the FK to user B's category is satisfied
+	// because FK checks bypass RLS.
+	seedConn := connect(ctx, t, tempAppURL)
+	userA := insertUpgradeUser(ctx, t, seedConn, "migup-a")
+	userB := insertUpgradeUser(ctx, t, seedConn, "migup-b")
+	setSessionAppUser(ctx, t, seedConn, userA)
+	execUpgrade(ctx, t, seedConn, `INSERT INTO accounts (id, name, user_id) VALUES ($1,$2,$3)`, "migup-acct-a", "Mig Acct A", userA)
+	execUpgrade(ctx, t, seedConn, `INSERT INTO categories (id, name, user_id) VALUES ($1,$2,$3)`, "migup-cat-a", "Mig Cat A", userA)
+	setSessionAppUser(ctx, t, seedConn, userB)
+	execUpgrade(ctx, t, seedConn, `INSERT INTO categories (id, name, user_id) VALUES ($1,$2,$3)`, "migup-cat-b", "Mig Cat B", userB)
+	setSessionAppUser(ctx, t, seedConn, userA)
+	execUpgrade(ctx, t, seedConn,
+		`INSERT INTO transactions (id, amount, payee, date, account_id, category_id, currency) VALUES ($1,$2,$3,$4,$5,$6,'ARS')`,
+		"migup-txn", 100, "mig payee", time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC), "migup-acct-a", "migup-cat-b")
+
+	// Confirm the seed really is cross-owner before the upgrade, so a later NULL
+	// can only be the cleanup's doing.
+	var before *string
+	if err := seedConn.QueryRow(ctx, `SELECT category_id FROM transactions WHERE id = $1`, "migup-txn").Scan(&before); err != nil {
+		t.Fatalf("read seeded transaction: %v", err)
+	}
+	if before == nil || *before != "migup-cat-b" {
+		t.Fatalf("expected seeded category_id 'migup-cat-b' before upgrade, got %v", before)
+	}
+	seedConn.Close(ctx)
+
+	// Apply v4 (the fix).
+	runGoose(ctx, t, gooseBin, migrationsDir, tempAppURL, "up")
+
+	// The cleanup must have nulled the cross-owner reference. Read it back over a
+	// superuser connection so RLS cannot hide the row and mask the result.
+	verifyConn := connect(ctx, t, tempAdminURL)
+	defer verifyConn.Close(ctx)
+	var after *string
+	if err := verifyConn.QueryRow(ctx, `SELECT category_id FROM transactions WHERE id = $1`, "migup-txn").Scan(&after); err != nil {
+		t.Fatalf("read transaction after upgrade: %v", err)
+	}
+	if after != nil {
+		t.Fatalf("expected the pre-existing cross-owner category_id to be nulled by 00004, got %q", *after)
+	}
+}
+
+// gooseBinary returns the path to the goose CLI, mirroring the URL helpers'
+// skip-local / fail-in-CI contract: CI installs goose before the tests, so a
+// missing binary there is a broken workflow rather than an untested path.
+func gooseBinary(t *testing.T) string {
+	t.Helper()
+
+	path, err := exec.LookPath("goose")
+	if err == nil {
+		return path
+	}
+	if os.Getenv("CI") != "" {
+		t.Fatalf("goose binary not found in CI; the 00004 upgrade test must run there: %v", err)
+	}
+	t.Skip("goose binary not found; skipping 00004 upgrade test")
+	return ""
+}
+
+func runGoose(ctx context.Context, t *testing.T, gooseBin, dir, databaseURL string, args ...string) {
+	t.Helper()
+
+	full := append([]string{"-dir", dir, "postgres", databaseURL}, args...)
+	cmd := exec.CommandContext(ctx, gooseBin, full...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("goose %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func connect(ctx context.Context, t *testing.T, databaseURL string) *pgx.Conn {
+	t.Helper()
+
+	conn, err := pgx.Connect(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	return conn
+}
+
+func insertUpgradeUser(ctx context.Context, t *testing.T, conn *pgx.Conn, label string) string {
+	t.Helper()
+
+	var id string
+	email := fmt.Sprintf("%s-%s@example.test", label, uuid.NewString())
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO users (email, password_hash) VALUES ($1, 'test-hash') RETURNING id`, email,
+	).Scan(&id); err != nil {
+		t.Fatalf("insert upgrade user %q: %v", label, err)
+	}
+	return id
+}
+
+func setSessionAppUser(ctx context.Context, t *testing.T, conn *pgx.Conn, userID string) {
+	t.Helper()
+
+	// Session-level (is_local=false) so it persists across the autocommit
+	// inserts that follow on this same connection.
+	if _, err := conn.Exec(ctx, `SELECT set_config('app.user_id', $1, false)`, userID); err != nil {
+		t.Fatalf("set session app.user_id: %v", err)
+	}
+}
+
+func execUpgrade(ctx context.Context, t *testing.T, conn *pgx.Conn, sql string, args ...any) {
+	t.Helper()
+
+	if _, err := conn.Exec(ctx, sql, args...); err != nil {
+		t.Fatalf("exec seed statement: %v", err)
+	}
+}
+
+// userInURL extracts the role name from a postgres connection URL.
+func userInURL(t *testing.T, databaseURL string) string {
+	t.Helper()
+
+	u, err := url.Parse(databaseURL)
+	if err != nil {
+		t.Fatalf("parse database url: %v", err)
+	}
+	if u.User == nil || u.User.Username() == "" {
+		t.Fatalf("database url has no user: %q", databaseURL)
+	}
+	return u.User.Username()
+}
+
+// withDatabase returns databaseURL with its database name replaced by name.
+func withDatabase(t *testing.T, databaseURL, name string) string {
+	t.Helper()
+
+	u, err := url.Parse(databaseURL)
+	if err != nil {
+		t.Fatalf("parse database url: %v", err)
+	}
+	u.Path = "/" + name
+	return u.String()
+}
+
+// pgIdent quotes a SQL identifier. The names it guards (a generated temp
+// database, the app role parsed from a trusted env var) are not attacker
+// controlled, but identifiers cannot be bind parameters, so quoting is the
+// correct way to interpolate them.
+func pgIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}

--- a/backend/internal/db/rls.go
+++ b/backend/internal/db/rls.go
@@ -1,0 +1,65 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// WithUserTx begins a transaction on pool, binds the RLS user for the
+// lifetime of that transaction, and runs fn against a *dbgen.Queries bound
+// to the transaction. It commits on success and rolls back on error or
+// panic (a panic inside fn propagates after the deferred rollback runs,
+// same as every hand-rolled tx pattern elsewhere in this codebase).
+//
+// The bind is transaction-local — set_config('app.user_id', $1, true), with
+// is_local=true as the third argument — not session-level. pgxpool reuses
+// connections across requests, so a session-level (is_local=false) bind
+// would outlive this request on its pooled connection and leak this user's
+// identity into whichever unrelated request grabs that connection next: a
+// cross-user data breach. Transaction-local scope resets automatically at
+// COMMIT or ROLLBACK, so there is nothing to leak. The user id is always
+// passed as a bind parameter (userID.String(), since set_config's value
+// argument is text), never string-interpolated into SQL.
+//
+// This is the ONLY sanctioned way to touch owned tables (accounts,
+// categories, transactions, and anything summarizing them) from here on.
+// dbgen.New(pool) called directly against the pool, outside any
+// transaction, has no transaction for a transaction-local set_config to
+// attach to — the RLS policy then sees a NULL app.user_id and silently
+// returns zero rows instead of erroring. That is not a security hole (fail
+// closed still fails closed), but it is a silent-empty-result bug that is
+// easy to ship by accident, which is why every owned-resource query must
+// route through this helper instead.
+func WithUserTx(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, fn func(*dbgen.Queries) error) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("db: begin user tx: %w", err)
+	}
+
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.user_id', $1, true)`, userID.String()); err != nil {
+		return fmt.Errorf("db: bind rls user: %w", err)
+	}
+
+	q := dbgen.New(tx)
+	if err := fn(q); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("db: commit user tx: %w", err)
+	}
+	committed = true
+
+	return nil
+}

--- a/backend/internal/db/rls.go
+++ b/backend/internal/db/rls.go
@@ -63,3 +63,57 @@ func WithUserTx(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, fn fu
 
 	return nil
 }
+
+// ownedTablesRequiringRLS lists the tables whose row-level security must be
+// active for the API's connection role before the service accepts traffic.
+// Keep it in sync with the FORCE ROW LEVEL SECURITY tables in the finance
+// migrations (00003, 00004).
+var ownedTablesRequiringRLS = []string{"accounts", "categories", "transactions"}
+
+// VerifyRLSActive returns an error unless row-level security is active, for
+// the pool's connection role, on every owned table. Call it once at startup
+// and refuse to serve if it fails.
+//
+// WithUserTx binds the right app.user_id, but a binding enforces nothing when
+// the connection authenticates as a superuser or a role with BYPASSRLS: both
+// silently ignore FORCE ROW LEVEL SECURITY, so every owned-table query would
+// read or write across all tenants regardless of the binding. CI provisions an
+// ordinary role and a fresh Compose volume does too, but production credentials
+// are arbitrary and an older local volume may still have the app role as the
+// bootstrap superuser — a single such misconfiguration silently turns this
+// otherwise-correct request path into unrestricted cross-user access. This
+// guard makes that fail loud at startup instead.
+//
+// row_security_active(table) reports whether RLS would actually be enforced for
+// the current role on that table, and returns false precisely for the
+// superuser/BYPASSRLS roles this guards against — a more direct signal than
+// inspecting role attributes, which are surfaced only to make the error
+// diagnosable.
+func VerifyRLSActive(ctx context.Context, pool *pgxpool.Pool) error {
+	for _, table := range ownedTablesRequiringRLS {
+		var active bool
+		if err := pool.QueryRow(ctx, `SELECT row_security_active($1::text)`, table).Scan(&active); err != nil {
+			return fmt.Errorf("db: check row security for %q: %w", table, err)
+		}
+		if !active {
+			role, super, bypass := connectionRoleAttributes(ctx, pool)
+			return fmt.Errorf(
+				"db: row level security is not active on %q for role %q (rolsuper=%t, rolbypassrls=%t); refusing to serve because every owned-table query would bypass RLS and read or write across tenants",
+				table, role, super, bypass,
+			)
+		}
+	}
+	return nil
+}
+
+// connectionRoleAttributes fetches the current role name and its
+// superuser/bypassrls attributes for diagnostics. Best-effort: on error it
+// returns a placeholder name so the caller's error still names the failing
+// table.
+func connectionRoleAttributes(ctx context.Context, pool *pgxpool.Pool) (role string, super, bypass bool) {
+	role = "unknown"
+	_ = pool.QueryRow(ctx,
+		`SELECT current_user, rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`,
+	).Scan(&role, &super, &bypass)
+	return role, super, bypass
+}

--- a/backend/internal/db/rls_test.go
+++ b/backend/internal/db/rls_test.go
@@ -1,0 +1,267 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// createRLSTestUser inserts a user with a unique test email and returns its
+// generated id. The users table carries no RLS (auth-layer, decided in
+// #38), so this insert needs no app.user_id binding.
+func createRLSTestUser(ctx context.Context, t *testing.T, pool *pgxpool.Pool, label string) uuid.UUID {
+	t.Helper()
+
+	var id string
+	email := fmt.Sprintf("%s-%s@example.test", label, uuid.NewString())
+	row := pool.QueryRow(ctx, `
+		INSERT INTO users (email, password_hash) VALUES ($1, 'test-hash') RETURNING id
+	`, email)
+	if err := row.Scan(&id); err != nil {
+		t.Fatalf("failed to insert test user %q: %v", label, err)
+	}
+	return uuid.MustParse(id)
+}
+
+// deleteRLSTestUsers removes test users. Deleting the user cascades to any
+// accounts/categories/transactions created for it (ON DELETE CASCADE), so
+// this alone is sufficient cleanup even though those owned-table deletes
+// would themselves be subject to RLS.
+func deleteRLSTestUsers(ctx context.Context, t *testing.T, pool *pgxpool.Pool, ids ...uuid.UUID) {
+	t.Helper()
+
+	for _, id := range ids {
+		if _, err := pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, id); err != nil {
+			t.Errorf("cleanup: failed to delete test user %q: %v", id, err)
+		}
+	}
+}
+
+func createRLSTestAccount(ctx context.Context, t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, id, name string) {
+	t.Helper()
+
+	if err := WithUserTx(ctx, pool, userID, func(q *dbgen.Queries) error {
+		_, err := q.CreateAccount(ctx, dbgen.CreateAccountParams{
+			ID:     id,
+			Name:   name,
+			UserID: pgtype.UUID{Bytes: [16]byte(userID), Valid: true},
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed account %q for user %s via WithUserTx: %v", id, userID, err)
+	}
+}
+
+// TestWithUserTx_OwnerRoundTrip_LiveDatabase proves WithUserTx's binding
+// survives the round trip through a real dbgen query: data written inside
+// one WithUserTx call for user A is readable inside a later WithUserTx call
+// for the same user, and invisible inside a WithUserTx call for a different
+// user — even though GetAccount's own SQL already carries an ownership
+// predicate (belt-and-suspenders, per the "SQL still includes ownership
+// predicates even though RLS exists" invariant). The predicate-free proof
+// that the RLS *policy* itself (not the predicate) is what blocks
+// cross-user access lives in TestWithUserTx_PolicyBlocksCrossUserAccess_LiveDatabase
+// below.
+func TestWithUserTx_OwnerRoundTrip_LiveDatabase(t *testing.T) {
+	databaseURL := liveDatabaseURL(t, "WithUserTx owner round-trip test")
+
+	ctx := context.Background()
+	pool, err := NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("expected successful connection, got error: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	userA := createRLSTestUser(ctx, t, pool, "withusertx-owner-a")
+	userB := createRLSTestUser(ctx, t, pool, "withusertx-owner-b")
+	t.Cleanup(func() { deleteRLSTestUsers(ctx, t, pool, userA, userB) })
+
+	accountID := "wut-owner-" + uuid.NewString()
+	createRLSTestAccount(ctx, t, pool, userA, accountID, "WithUserTx Owner Account")
+
+	var got dbgen.Account
+	if err := WithUserTx(ctx, pool, userA, func(q *dbgen.Queries) error {
+		var err error
+		got, err = q.GetAccount(ctx, dbgen.GetAccountParams{
+			ID:     accountID,
+			UserID: pgtype.UUID{Bytes: [16]byte(userA), Valid: true},
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("user A: expected to read own account via WithUserTx, got error: %v", err)
+	}
+	if got.ID != accountID {
+		t.Errorf("user A: expected account id %q, got %q", accountID, got.ID)
+	}
+
+	err = WithUserTx(ctx, pool, userB, func(q *dbgen.Queries) error {
+		_, err := q.GetAccount(ctx, dbgen.GetAccountParams{
+			ID:     accountID,
+			UserID: pgtype.UUID{Bytes: [16]byte(userB), Valid: true},
+		})
+		return err
+	})
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("user B: expected ErrNoRows reading user A's account via WithUserTx, got %v", err)
+	}
+}
+
+// TestWithUserTx_PolicyBlocksCrossUserAccess_LiveDatabase proves isolation
+// is enforced by the RLS POLICY itself, not by an application WHERE clause.
+// WithUserTx's fn parameter only exposes *dbgen.Queries, and every
+// generated dbgen query in this codebase deliberately carries its own
+// ownership predicate, so proving the predicate-free case requires a raw
+// statement issued directly on a transaction. This test opens its own
+// transaction and issues the exact set_config('app.user_id', $1, true)
+// statement WithUserTx runs as its first statement, then probes with SQL
+// that has no user_id predicate at all — isolating the RLS policy as the
+// only thing standing between user B and user A's row.
+func TestWithUserTx_PolicyBlocksCrossUserAccess_LiveDatabase(t *testing.T) {
+	databaseURL := liveDatabaseURL(t, "WithUserTx policy-level cross-user test")
+
+	ctx := context.Background()
+	pool, err := NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("expected successful connection, got error: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	userA := createRLSTestUser(ctx, t, pool, "withusertx-policy-a")
+	userB := createRLSTestUser(ctx, t, pool, "withusertx-policy-b")
+	t.Cleanup(func() { deleteRLSTestUsers(ctx, t, pool, userA, userB) })
+
+	accountID := "wut-policy-" + uuid.NewString()
+	createRLSTestAccount(ctx, t, pool, userA, accountID, "WithUserTx Policy Account")
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin probe transaction: %v", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("cleanup: failed to roll back probe transaction: %v", err)
+		}
+	}()
+
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.user_id', $1, true)`, userB.String()); err != nil {
+		t.Fatalf("bind app.user_id for user B: %v", err)
+	}
+
+	var probeID string
+	err = tx.QueryRow(ctx, `SELECT id FROM accounts WHERE id = $1`, accountID).Scan(&probeID)
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("user B: expected the RLS policy (not a WHERE clause) to hide user A's account, got err=%v", err)
+	}
+
+	tag, err := tx.Exec(ctx, `UPDATE accounts SET name = $1 WHERE id = $2`, "hacked-by-b", accountID)
+	if err != nil {
+		t.Fatalf("user B: UPDATE on user A's account returned an unexpected error: %v", err)
+	}
+	if tag.RowsAffected() != 0 {
+		t.Errorf("user B: expected 0 rows affected updating user A's account, got %d", tag.RowsAffected())
+	}
+
+	tag, err = tx.Exec(ctx, `DELETE FROM accounts WHERE id = $1`, accountID)
+	if err != nil {
+		t.Fatalf("user B: DELETE on user A's account returned an unexpected error: %v", err)
+	}
+	if tag.RowsAffected() != 0 {
+		t.Errorf("user B: expected 0 rows affected deleting user A's account, got %d", tag.RowsAffected())
+	}
+}
+
+// TestWithUserTx_UnboundTransactionFailsClosed_LiveDatabase pins the #43
+// fail-closed property (design decision 4c): a transaction that never runs
+// the set_config('app.user_id', ...) bind sees zero rows on an owned table
+// instead of an error or every row. current_setting('app.user_id', true)
+// (missing_ok=true) returns NULL when unset, and the policy's
+// NULLIF(...)::uuid comparison against NULL matches nothing — silent, but
+// closed. This is exactly the shape of the dbgen.New(pool)-without-a-
+// transaction bug WithUserTx exists to make impossible: an owned-table
+// query with no transaction-local binding in effect.
+func TestWithUserTx_UnboundTransactionFailsClosed_LiveDatabase(t *testing.T) {
+	databaseURL := liveDatabaseURL(t, "WithUserTx fail-closed test")
+
+	ctx := context.Background()
+	pool, err := NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("expected successful connection, got error: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	userA := createRLSTestUser(ctx, t, pool, "withusertx-failclosed")
+	t.Cleanup(func() { deleteRLSTestUsers(ctx, t, pool, userA) })
+
+	accountID := "wut-failclosed-" + uuid.NewString()
+	createRLSTestAccount(ctx, t, pool, userA, accountID, "WithUserTx Fail-Closed Account")
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin unbound transaction: %v", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("cleanup: failed to roll back unbound transaction: %v", err)
+		}
+	}()
+
+	var count int
+	if err := tx.QueryRow(ctx, `SELECT count(*) FROM accounts WHERE id = $1`, accountID).Scan(&count); err != nil {
+		t.Fatalf("unbound transaction: unexpected query error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("unbound transaction: expected 0 visible rows (fail closed), got %d", count)
+	}
+}
+
+// TestWithUserTx_RollsBackOnError_LiveDatabase proves fn's error both
+// prevents the commit and is returned to the caller: a create that
+// succeeds followed by a returned error must leave no row behind.
+func TestWithUserTx_RollsBackOnError_LiveDatabase(t *testing.T) {
+	databaseURL := liveDatabaseURL(t, "WithUserTx rollback-on-error test")
+
+	ctx := context.Background()
+	pool, err := NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("expected successful connection, got error: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	userA := createRLSTestUser(ctx, t, pool, "withusertx-rollback")
+	t.Cleanup(func() { deleteRLSTestUsers(ctx, t, pool, userA) })
+
+	accountID := "wut-rollback-" + uuid.NewString()
+	sentinel := errors.New("boom")
+
+	err = WithUserTx(ctx, pool, userA, func(q *dbgen.Queries) error {
+		if _, err := q.CreateAccount(ctx, dbgen.CreateAccountParams{
+			ID:     accountID,
+			Name:   "WithUserTx Rollback Account",
+			UserID: pgtype.UUID{Bytes: [16]byte(userA), Valid: true},
+		}); err != nil {
+			return err
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected WithUserTx to return fn's error, got %v", err)
+	}
+
+	err = WithUserTx(ctx, pool, userA, func(q *dbgen.Queries) error {
+		_, err := q.GetAccount(ctx, dbgen.GetAccountParams{
+			ID:     accountID,
+			UserID: pgtype.UUID{Bytes: [16]byte(userA), Valid: true},
+		})
+		return err
+	})
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("expected the account created before the returned error to have been rolled back, got %v", err)
+	}
+}

--- a/backend/internal/db/rls_test.go
+++ b/backend/internal/db/rls_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
@@ -263,5 +264,48 @@ func TestWithUserTx_RollsBackOnError_LiveDatabase(t *testing.T) {
 	})
 	if !errors.Is(err, pgx.ErrNoRows) {
 		t.Errorf("expected the account created before the returned error to have been rolled back, got %v", err)
+	}
+}
+
+// TestVerifyRLSActive_PassesForOrdinaryRole_LiveDatabase is the positive half
+// of the startup guard: the ordinary application role the migrations run as
+// has RLS active on every owned table, so VerifyRLSActive accepts it.
+func TestVerifyRLSActive_PassesForOrdinaryRole_LiveDatabase(t *testing.T) {
+	databaseURL := liveDatabaseURL(t, "VerifyRLSActive ordinary-role test")
+
+	ctx := context.Background()
+	pool, err := NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("expected successful connection, got error: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	if err := VerifyRLSActive(ctx, pool); err != nil {
+		t.Fatalf("expected VerifyRLSActive to pass for the ordinary application role, got %v", err)
+	}
+}
+
+// TestVerifyRLSActive_RejectsBypassingRole_LiveDatabase is the negative half:
+// a connection authenticating as a role that bypasses RLS (the bootstrap
+// superuser, reached via ADMIN_DATABASE_URL) silently voids FORCE RLS, so
+// VerifyRLSActive must refuse it. This is the exact misconfiguration the guard
+// exists to stop — a deployment whose DATABASE_URL points at a superuser would
+// otherwise serve every tenant's data to every request.
+func TestVerifyRLSActive_RejectsBypassingRole_LiveDatabase(t *testing.T) {
+	databaseURL := adminDatabaseURL(t, "VerifyRLSActive bypassing-role test")
+
+	ctx := context.Background()
+	pool, err := NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("expected successful connection, got error: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	err = VerifyRLSActive(ctx, pool)
+	if err == nil {
+		t.Fatal("expected VerifyRLSActive to reject a role that bypasses row level security, got nil")
+	}
+	if !strings.Contains(err.Error(), "row level security is not active") {
+		t.Errorf("expected the rejection to explain the RLS bypass, got %v", err)
 	}
 }

--- a/backend/internal/db/transactions_category_rls_test.go
+++ b/backend/internal/db/transactions_category_rls_test.go
@@ -1,0 +1,162 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// TestTransactionsCategoryOwnerRLS_LiveDatabase pins the 00004 policy tightening:
+// a write may reference no category or a category owned by the same
+// app.user_id, but never another tenant's category. Foreign-key checks run as
+// the table owner and bypass RLS, so without the WITH CHECK clause the FK alone
+// would happily accept the cross-owner reference — the regression this guards.
+//
+// Every probe is predicate-free (the category constraint lives only in the
+// policy, never in a WHERE clause) so a pass proves the RLS policy itself is
+// doing the work. Expected-error cases run inside pgx pseudo-nested
+// transactions (SAVEPOINTs) so the outer transaction survives; the whole test
+// rolls back, leaving the database clean.
+func TestTransactionsCategoryOwnerRLS_LiveDatabase(t *testing.T) {
+	databaseURL := liveDatabaseURL(t, "transactions category-owner RLS test")
+
+	ctx := context.Background()
+	pool, err := NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("expected successful connection, got error: %v", err)
+	}
+	defer pool.Close()
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("expected to acquire a connection, got error: %v", err)
+	}
+	defer conn.Release()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("expected to begin a transaction, got error: %v", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("cleanup: failed to roll back test transaction: %v", err)
+		}
+	}()
+
+	userA := insertTestUser(ctx, t, tx, "cat-rls-a")
+	userB := insertTestUser(ctx, t, tx, "cat-rls-b")
+
+	txDate := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	// Seed user A's account + own category, and user B's category, each under
+	// its own app.user_id so WITH CHECK accepts the seed writes.
+	accountA := uuid.NewString()
+	categoryA := uuid.NewString()
+	if err := setAppUser(ctx, tx, userA); err != nil {
+		t.Fatalf("failed to set app.user_id for user A seed: %v", err)
+	}
+	insertTestAccount(ctx, t, tx, accountA, "Cat RLS Account A", userA)
+	insertTestCategory(ctx, t, tx, categoryA, "Cat RLS Category A", userA)
+
+	categoryB := uuid.NewString()
+	if err := setAppUser(ctx, tx, userB); err != nil {
+		t.Fatalf("failed to set app.user_id for user B seed: %v", err)
+	}
+	insertTestCategory(ctx, t, tx, categoryB, "Cat RLS Category B", userB)
+
+	// Act as user A for every case below.
+	if err := setAppUser(ctx, tx, userA); err != nil {
+		t.Fatalf("failed to set app.user_id for user A cases: %v", err)
+	}
+
+	// (1) Own category → accepted.
+	ownTxnID := uuid.NewString()
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO transactions (id, amount, payee, date, account_id, category_id, currency)
+		VALUES ($1, $2, $3, $4, $5, $6, 'ARS')
+	`, ownTxnID, 1000, "own category", txDate, accountA, categoryA); err != nil {
+		t.Fatalf("user A: expected insert with own category to succeed, got %v", err)
+	}
+
+	// (2) NULL category → accepted.
+	nullTxnID := uuid.NewString()
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO transactions (id, amount, payee, date, account_id, category_id, currency)
+		VALUES ($1, $2, $3, $4, $5, NULL, 'ARS')
+	`, nullTxnID, 1000, "null category", txDate, accountA); err != nil {
+		t.Fatalf("user A: expected insert with NULL category to succeed, got %v", err)
+	}
+
+	// (3) Another tenant's category on a single insert → rejected by WITH CHECK.
+	func() {
+		nested, err := tx.Begin(ctx)
+		if err != nil {
+			t.Fatalf("nested tx for cross-owner insert: %v", err)
+		}
+		defer func() {
+			if err := nested.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+				t.Errorf("rollback nested (insert): %v", err)
+			}
+		}()
+
+		_, err = nested.Exec(ctx, `
+			INSERT INTO transactions (id, amount, payee, date, account_id, category_id, currency)
+			VALUES ($1, $2, $3, $4, $5, $6, 'ARS')
+		`, uuid.NewString(), 1000, "cross-owner category insert", txDate, accountA, categoryB)
+		assertRLSViolation(t, err, "user A inserting a transaction referencing user B's category")
+	}()
+
+	// (4) Update an owned transaction to point at another tenant's category →
+	// rejected by WITH CHECK.
+	func() {
+		nested, err := tx.Begin(ctx)
+		if err != nil {
+			t.Fatalf("nested tx for cross-owner update: %v", err)
+		}
+		defer func() {
+			if err := nested.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+				t.Errorf("rollback nested (update): %v", err)
+			}
+		}()
+
+		_, err = nested.Exec(ctx, `
+			UPDATE transactions SET category_id = $1 WHERE id = $2
+		`, categoryB, ownTxnID)
+		assertRLSViolation(t, err, "user A updating an owned transaction to user B's category")
+	}()
+
+	// (5) Bulk insert where one row references another tenant's category → the
+	// whole multi-row statement is rejected (atomic), so the sibling good row
+	// is not inserted either.
+	func() {
+		nested, err := tx.Begin(ctx)
+		if err != nil {
+			t.Fatalf("nested tx for bulk cross-owner insert: %v", err)
+		}
+		defer func() {
+			if err := nested.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+				t.Errorf("rollback nested (bulk): %v", err)
+			}
+		}()
+
+		goodID := uuid.NewString()
+		badID := uuid.NewString()
+		_, err = nested.Exec(ctx, `
+			INSERT INTO transactions (id, amount, payee, date, account_id, category_id, currency)
+			VALUES ($1, $2, $3, $4, $5, $6, 'ARS'),
+			       ($7, $8, $9, $10, $11, $12, 'ARS')
+		`,
+			goodID, 1000, "bulk good", txDate, accountA, categoryA,
+			badID, 1000, "bulk bad", txDate, accountA, categoryB,
+		)
+		assertRLSViolation(t, err, "user A bulk-inserting transactions with one cross-owner category")
+	}()
+
+	// Only the two accepted rows (own category, NULL category) exist for user A;
+	// none of the rejected single/bulk writes leaked through.
+	assertRowCount(ctx, t, tx, "transactions", 2)
+}

--- a/backend/internal/http/auth.go
+++ b/backend/internal/http/auth.go
@@ -975,13 +975,12 @@ func invalidTokenError() openapi.InvalidTokenErrorJSONResponse {
 
 // writeInternalError handles failures with no dedicated response in the
 // auth operations' documented response set (e.g. a database error talking
-// to Postgres). It is a plain ApiErrorResponse write rather than a
-// generated Visit*Response method because the contract does not declare a
-// 500 for these four operations.
+// to Postgres). It goes through the shared writeAPIError helper
+// (middleware.go) rather than a generated Visit*Response method because the
+// contract does not declare a 500 for these four operations.
 func writeInternalError(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusInternalServerError)
-	_ = json.NewEncoder(w).Encode(openapi.ApiErrorResponse{
-		Error: openapi.ApiError{Code: "INTERNAL_ERROR", Message: "Something went wrong. Please try again."},
+	writeAPIError(w, http.StatusInternalServerError, openapi.ApiError{
+		Code:    "INTERNAL_ERROR",
+		Message: "Something went wrong. Please try again.",
 	})
 }

--- a/backend/internal/http/middleware.go
+++ b/backend/internal/http/middleware.go
@@ -1,0 +1,121 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/GonzaloSecades/nuchi/backend/internal/auth"
+	"github.com/GonzaloSecades/nuchi/backend/internal/openapi"
+	"github.com/google/uuid"
+)
+
+// userIDContextKey is the unexported context key type RequireAuth stores
+// the authenticated user id under. Being a distinct, unexported type (not a
+// plain string) is the standard context-key-collision guard: no other
+// package can read or overwrite it by accident.
+type userIDContextKey struct{}
+
+// UserIDFromContext returns the authenticated user id RequireAuth placed on
+// ctx, and true. It returns the zero UUID and false if ctx carries no
+// authenticated user (RequireAuth never ran, or ran and rejected the
+// request before calling next). Callers must check the boolean: a caller
+// that used the zero UUID without checking ok would bind app.user_id to an
+// all-zeros value that matches no real user's rows, silently returning
+// empty results instead of failing loudly — the boolean makes "no user in
+// context" unmistakable.
+func UserIDFromContext(ctx context.Context) (uuid.UUID, bool) {
+	userID, ok := ctx.Value(userIDContextKey{}).(uuid.UUID)
+	return userID, ok
+}
+
+// RequireAuth returns middleware that validates a Bearer access token,
+// signed with secret, on every request it wraps. On success it places the
+// token's authenticated user id on the request context (read back with
+// UserIDFromContext) and calls next. On failure it writes a 401 and never
+// calls next.
+//
+// Identity comes ONLY from the Authorization header — never a body field,
+// a query parameter, or a header like X-User-Id — so nothing else in the
+// request can override which user a downstream handler believes it is
+// acting as.
+//
+// A missing/malformed Authorization header, or any verification failure
+// other than expiry (bad signature, wrong secret, disallowed algorithm,
+// missing/invalid subject, garbage input), responds 401 UNAUTHORIZED. An
+// expired-but-otherwise-valid token responds 401 ACCESS_TOKEN_EXPIRED
+// instead, per the contract's documented carve-out (components.responses
+// .UnauthorizedError in openapi/nuchi.openapi.json) — the client needs
+// that distinction to know whether to call /api/auth/refresh instead of
+// re-prompting for credentials. Every other rejection reason is
+// deliberately collapsed so it leaks no information about token internals
+// to a caller who should not have had a valid token to begin with.
+func RequireAuth(secret []byte) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token, ok := bearerToken(r.Header.Get("Authorization"))
+			if !ok {
+				writeUnauthorizedError(w)
+				return
+			}
+
+			userID, err := auth.VerifyAccessToken(secret, token)
+			if err != nil {
+				if errors.Is(err, auth.ErrAccessTokenExpired) {
+					writeAccessTokenExpiredError(w)
+					return
+				}
+				writeUnauthorizedError(w)
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), userIDContextKey{}, userID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// bearerToken extracts the token from a "Bearer <token>" Authorization
+// header value. It rejects anything that is not exactly that shape: a
+// missing header, a different scheme (Basic, Digest, ...), a bare "Bearer"
+// with nothing after it, or a Bearer prefix followed by an empty token.
+func bearerToken(header string) (string, bool) {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return "", false
+	}
+	token := strings.TrimPrefix(header, prefix)
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+// writeAPIError writes status and apiErr as the contract's ApiErrorResponse
+// envelope ({"error": {"code", "message", ...}}). It is the single
+// low-level JSON writer for call sites with no generated Visit*Response
+// method to call: writeInternalError's 500 (the contract declares no 500
+// for the auth operations) and RequireAuth's 401s, which run ahead of
+// whichever specific operation's generated response type would otherwise
+// apply.
+func writeAPIError(w http.ResponseWriter, status int, apiErr openapi.ApiError) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(openapi.ApiErrorResponse{Error: apiErr})
+}
+
+func writeUnauthorizedError(w http.ResponseWriter) {
+	writeAPIError(w, http.StatusUnauthorized, openapi.ApiError{
+		Code:    "UNAUTHORIZED",
+		Message: "Authentication required.",
+	})
+}
+
+func writeAccessTokenExpiredError(w http.ResponseWriter) {
+	writeAPIError(w, http.StatusUnauthorized, openapi.ApiError{
+		Code:    "ACCESS_TOKEN_EXPIRED",
+		Message: "Access token expired.",
+	})
+}

--- a/backend/internal/http/middleware_live_test.go
+++ b/backend/internal/http/middleware_live_test.go
@@ -1,0 +1,174 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GonzaloSecades/nuchi/backend/internal/auth"
+	"github.com/GonzaloSecades/nuchi/backend/internal/db"
+	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// accountProbeHandler builds a handler that runs db.WithUserTx bound to the
+// request's authenticated user (RequireAuth having already put it on the
+// context) and reports, as JSON, whether an account with the given id
+// (query param "id") is visible. This is the "minimal test-only protected
+// probe route" the #43 briefing calls for: it exercises RequireAuth ->
+// UserIDFromContext -> db.WithUserTx -> the #39 RLS policy end-to-end over
+// real HTTP, without implementing any of the #44-#48 resource handlers.
+func accountProbeHandler(pool *pgxpool.Pool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := UserIDFromContext(r.Context())
+		if !ok {
+			// Unreachable through RequireAuth, but fail loudly rather than
+			// binding a zero UUID if it ever were.
+			http.Error(w, "no authenticated user in context", http.StatusInternalServerError)
+			return
+		}
+
+		accountID := r.URL.Query().Get("id")
+
+		var visible bool
+		err := db.WithUserTx(r.Context(), pool, userID, func(q *dbgen.Queries) error {
+			_, err := q.GetAccount(r.Context(), dbgen.GetAccountParams{
+				ID:     accountID,
+				UserID: pgtype.UUID{Bytes: [16]byte(userID), Valid: true},
+			})
+			if errors.Is(err, pgx.ErrNoRows) {
+				visible = false
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			visible = true
+			return nil
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]bool{"visible": visible})
+	}
+}
+
+func newAccountProbeRouter(secret []byte, pool *pgxpool.Pool) http.Handler {
+	router := chi.NewRouter()
+	router.Group(func(r chi.Router) {
+		r.Use(RequireAuth(secret))
+		r.Get("/probe/account", accountProbeHandler(pool))
+	})
+	return router
+}
+
+// TestRequireAuth_WithUserTx_CrossUserIsolation_LiveDatabase is the full
+// stack end-to-end proof for #43: a real HTTP request carrying user A's
+// signed access token, through RequireAuth, through UserIDFromContext,
+// through db.WithUserTx, against the #39 RLS policy, can see user A's own
+// account; the identical request shape carrying user B's token cannot see
+// it at all. This is acceptance criterion 7 exercised through the actual
+// production request path, complementing the lower-level, predicate-free
+// proof in internal/db/rls_test.go.
+func TestRequireAuth_WithUserTx_CrossUserIsolation_LiveDatabase(t *testing.T) {
+	databaseURL := liveDatabaseURL(t, "RequireAuth + WithUserTx cross-user isolation test")
+
+	ctx := context.Background()
+	pool, err := db.NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("expected successful connection, got error: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	secret := []byte("middleware-live-test-secret-at-least-32-bytes!!")
+
+	userA := createProbeTestUser(ctx, t, pool, "probe-a")
+	userB := createProbeTestUser(ctx, t, pool, "probe-b")
+	t.Cleanup(func() {
+		for _, id := range []uuid.UUID{userA, userB} {
+			if _, err := pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, id); err != nil {
+				t.Errorf("cleanup: failed to delete probe test user %q: %v", id, err)
+			}
+		}
+	})
+
+	accountID := "probe-account-" + uuid.NewString()
+	if err := db.WithUserTx(ctx, pool, userA, func(q *dbgen.Queries) error {
+		_, err := q.CreateAccount(ctx, dbgen.CreateAccountParams{
+			ID:     accountID,
+			Name:   "Probe Account",
+			UserID: pgtype.UUID{Bytes: [16]byte(userA), Valid: true},
+		})
+		return err
+	}); err != nil {
+		t.Fatalf("seed account for user A: %v", err)
+	}
+
+	router := newAccountProbeRouter(secret, pool)
+
+	tokenA, _, err := auth.IssueAccessToken(secret, userA, 30*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken for user A: %v", err)
+	}
+	tokenB, _, err := auth.IssueAccessToken(secret, userB, 30*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken for user B: %v", err)
+	}
+
+	visibleToA := probeAccountVisibility(t, router, tokenA, accountID)
+	if !visibleToA {
+		t.Error("user A: expected own account to be visible through RequireAuth + WithUserTx, got not visible")
+	}
+
+	visibleToB := probeAccountVisibility(t, router, tokenB, accountID)
+	if visibleToB {
+		t.Error("user B: expected user A's account to be invisible through RequireAuth + WithUserTx, got visible")
+	}
+}
+
+func probeAccountVisibility(t *testing.T, router http.Handler, token, accountID string) bool {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/probe/account?id="+accountID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("probe request: expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var out struct {
+		Visible bool `json:"visible"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode probe response: %v (body: %s)", err, rec.Body.String())
+	}
+	return out.Visible
+}
+
+func createProbeTestUser(ctx context.Context, t *testing.T, pool *pgxpool.Pool, label string) uuid.UUID {
+	t.Helper()
+
+	var id string
+	email := fmt.Sprintf("%s-%s@example.test", label, uuid.NewString())
+	row := pool.QueryRow(ctx, `
+		INSERT INTO users (email, password_hash) VALUES ($1, 'test-hash') RETURNING id
+	`, email)
+	if err := row.Scan(&id); err != nil {
+		t.Fatalf("failed to insert probe test user %q: %v", label, err)
+	}
+	return uuid.MustParse(id)
+}

--- a/backend/internal/http/middleware_test.go
+++ b/backend/internal/http/middleware_test.go
@@ -1,0 +1,260 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GonzaloSecades/nuchi/backend/internal/auth"
+	"github.com/GonzaloSecades/nuchi/backend/internal/openapi"
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+var middlewareTestSecret = []byte("middleware-test-secret-at-least-32-bytes!!")
+
+// newProbeRouter mounts probe behind RequireAuth(secret) on both GET and
+// POST /probe, standing in for the "minimal test-only protected probe
+// route" the #43 briefing calls for: NewRouter's own RequireAuth group is
+// intentionally empty until #44-#48 mount real resource routes into it, so
+// exercising the middleware end-to-end needs its own tiny router here.
+func newProbeRouter(secret []byte, probe http.HandlerFunc) http.Handler {
+	router := chi.NewRouter()
+	router.Group(func(r chi.Router) {
+		r.Use(RequireAuth(secret))
+		r.Get("/probe", probe)
+		r.Post("/probe", probe)
+	})
+	return router
+}
+
+// contextEchoProbe writes the context user id (or "none" if absent) as the
+// response body, so tests can assert on exactly what RequireAuth put on the
+// request context.
+func contextEchoProbe(w http.ResponseWriter, r *http.Request) {
+	userID, ok := UserIDFromContext(r.Context())
+	if !ok {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("none"))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(userID.String()))
+}
+
+func decodeMiddlewareAPIError(t *testing.T, rec *httptest.ResponseRecorder) openapi.ApiErrorResponse {
+	t.Helper()
+	var out openapi.ApiErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode error response: %v (body: %s)", err, rec.Body.String())
+	}
+	return out
+}
+
+func doProbeRequest(t *testing.T, router http.Handler, method, authHeader string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(method, "/probe", bytes.NewReader(body))
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestRequireAuth_MissingHeader_Unauthorized covers acceptance criterion 1:
+// no Authorization header at all.
+func TestRequireAuth_MissingHeader_Unauthorized(t *testing.T) {
+	router := newProbeRouter(middlewareTestSecret, contextEchoProbe)
+
+	rec := doProbeRequest(t, router, http.MethodGet, "", nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	got := decodeMiddlewareAPIError(t, rec)
+	if got.Error.Code != "UNAUTHORIZED" {
+		t.Errorf("expected code UNAUTHORIZED, got %q", got.Error.Code)
+	}
+	if got.Error.Message != "Authentication required." {
+		t.Errorf("expected message %q, got %q", "Authentication required.", got.Error.Message)
+	}
+}
+
+// TestRequireAuth_MalformedHeader_Unauthorized covers acceptance criterion
+// 2: headers that are present but not a well-formed Bearer token.
+func TestRequireAuth_MalformedHeader_Unauthorized(t *testing.T) {
+	router := newProbeRouter(middlewareTestSecret, contextEchoProbe)
+
+	cases := []string{
+		"Bearer",
+		"Bearer ",
+		"Basic xyz",
+		"Bearer a.b.c",
+		"bearer sometoken",
+	}
+	for _, header := range cases {
+		t.Run(header, func(t *testing.T) {
+			rec := doProbeRequest(t, router, http.MethodGet, header, nil)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("header %q: expected 401, got %d (body: %s)", header, rec.Code, rec.Body.String())
+			}
+			got := decodeMiddlewareAPIError(t, rec)
+			if got.Error.Code != "UNAUTHORIZED" {
+				t.Errorf("header %q: expected code UNAUTHORIZED, got %q", header, got.Error.Code)
+			}
+		})
+	}
+}
+
+// TestRequireAuth_WrongSecret_Unauthorized covers acceptance criterion 3.
+func TestRequireAuth_WrongSecret_Unauthorized(t *testing.T) {
+	router := newProbeRouter(middlewareTestSecret, contextEchoProbe)
+
+	token, _, err := auth.IssueAccessToken([]byte("a-completely-different-secret-32bytes!!"), uuid.New(), 30*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken: unexpected error: %v", err)
+	}
+
+	rec := doProbeRequest(t, router, http.MethodGet, "Bearer "+token, nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	got := decodeMiddlewareAPIError(t, rec)
+	if got.Error.Code != "UNAUTHORIZED" {
+		t.Errorf("expected code UNAUTHORIZED, got %q", got.Error.Code)
+	}
+}
+
+// TestRequireAuth_ExpiredToken_AccessTokenExpired covers acceptance
+// criterion 4: the one deliberate carve-out (design decision 4e).
+func TestRequireAuth_ExpiredToken_AccessTokenExpired(t *testing.T) {
+	router := newProbeRouter(middlewareTestSecret, contextEchoProbe)
+
+	token, _, err := auth.IssueAccessToken(middlewareTestSecret, uuid.New(), -1*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken: unexpected error: %v", err)
+	}
+
+	rec := doProbeRequest(t, router, http.MethodGet, "Bearer "+token, nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	got := decodeMiddlewareAPIError(t, rec)
+	if got.Error.Code != "ACCESS_TOKEN_EXPIRED" {
+		t.Errorf("expected code ACCESS_TOKEN_EXPIRED, got %q", got.Error.Code)
+	}
+	if got.Error.Message != "Access token expired." {
+		t.Errorf("expected message %q, got %q", "Access token expired.", got.Error.Message)
+	}
+}
+
+// TestRequireAuth_RejectsAlgPolicyViolations covers acceptance criterion 5:
+// alg=none and HS512 tokens, an alg-policy regression guard riding on top
+// of VerifyAccessToken's own coverage (internal/auth/jwt_test.go).
+func TestRequireAuth_RejectsAlgPolicyViolations(t *testing.T) {
+	router := newProbeRouter(middlewareTestSecret, contextEchoProbe)
+
+	userID := uuid.New()
+	claims := jwt.RegisteredClaims{
+		Subject:   userID.String(),
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+
+	noneToken, err := jwt.NewWithClaims(jwt.SigningMethodNone, claims).SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("failed to build alg=none fixture: %v", err)
+	}
+	hs512Token, err := jwt.NewWithClaims(jwt.SigningMethodHS512, claims).SignedString(middlewareTestSecret)
+	if err != nil {
+		t.Fatalf("failed to build HS512 fixture: %v", err)
+	}
+
+	for name, token := range map[string]string{"alg=none": noneToken, "HS512": hs512Token} {
+		t.Run(name, func(t *testing.T) {
+			rec := doProbeRequest(t, router, http.MethodGet, "Bearer "+token, nil)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("%s: expected 401, got %d (body: %s)", name, rec.Code, rec.Body.String())
+			}
+			got := decodeMiddlewareAPIError(t, rec)
+			if got.Error.Code != "UNAUTHORIZED" {
+				t.Errorf("%s: expected code UNAUTHORIZED, got %q", name, got.Error.Code)
+			}
+		})
+	}
+}
+
+// TestRequireAuth_ValidToken_ExposesUserID covers acceptance criterion 6:
+// a valid token reaches the handler, which observes the exact UUID the
+// token carried.
+func TestRequireAuth_ValidToken_ExposesUserID(t *testing.T) {
+	router := newProbeRouter(middlewareTestSecret, contextEchoProbe)
+
+	userID := uuid.New()
+	token, _, err := auth.IssueAccessToken(middlewareTestSecret, userID, 30*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken: unexpected error: %v", err)
+	}
+
+	rec := doProbeRequest(t, router, http.MethodGet, "Bearer "+token, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != userID.String() {
+		t.Errorf("expected handler to observe user id %q, got %q", userID.String(), got)
+	}
+}
+
+// TestRequireAuth_BodyIdentityIsIgnored covers acceptance criterion 9: a
+// request body claiming to be a different user must not influence which
+// user the handler believes is authenticated. contextEchoProbe never reads
+// the body at all, which is itself the proof — RequireAuth's only identity
+// source is the Authorization header — but this test pins the end-to-end
+// behavior an attacker would actually attempt: send someone else's id in
+// the body under your own valid token.
+func TestRequireAuth_BodyIdentityIsIgnored(t *testing.T) {
+	router := newProbeRouter(middlewareTestSecret, contextEchoProbe)
+
+	realUser := uuid.New()
+	impersonatedUser := uuid.New()
+	token, _, err := auth.IssueAccessToken(middlewareTestSecret, realUser, 30*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken: unexpected error: %v", err)
+	}
+
+	body, err := json.Marshal(map[string]string{"user_id": impersonatedUser.String(), "userId": impersonatedUser.String()})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	rec := doProbeRequest(t, router, http.MethodPost, "Bearer "+token, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != realUser.String() {
+		t.Errorf("expected handler to observe token's user id %q, got %q (impersonation via body succeeded)", realUser.String(), got)
+	}
+}
+
+// TestRequireAuth_NoUserInContext_WhenUnauthenticated documents the
+// UserIDFromContext contract itself (design decision 4f): calling it on a
+// context RequireAuth never touched returns ok=false, not a zero UUID a
+// caller might use without checking.
+func TestRequireAuth_NoUserInContext_WhenUnauthenticated(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	userID, ok := UserIDFromContext(req.Context())
+	if ok {
+		t.Fatalf("expected ok=false for an untouched context, got ok=true, userID=%v", userID)
+	}
+	if userID != uuid.Nil {
+		t.Errorf("expected zero UUID alongside ok=false, got %v", userID)
+	}
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -10,9 +10,14 @@ import (
 // NewRouter wires the API routes owned by this service. authServer is
 // optional (nil skips mounting the /api/auth/* routes) so callers that only
 // need health/scaffold behavior — e.g. tests unrelated to auth — are not
-// forced to construct a database pool. Resource routes (accounts,
-// categories, transactions, summary) and auth middleware/RLS binding are
-// left to later issues (#43+).
+// forced to construct a database pool.
+//
+// /api/health and /api/auth/* stay public (the latter is how a client gets
+// a token in the first place). Every owned-resource route (accounts,
+// categories, transactions, summary — mounted by #44-#48) belongs inside
+// the RequireAuth group below, so the Bearer-JWT check happens once at the
+// router level instead of being repeated per handler the way the legacy
+// Hono routes each ran their own clerkMiddleware() + inline check.
 func NewRouter(authServer *AuthServer) http.Handler {
 	router := chi.NewRouter()
 	router.Use(middleware.RequestID)
@@ -29,6 +34,12 @@ func NewRouter(authServer *AuthServer) http.Handler {
 		router.Post("/api/auth/verify-email", authServer.VerifyEmail)
 		router.Post("/api/auth/password-reset/request", authServer.RequestPasswordReset)
 		router.Post("/api/auth/password-reset/confirm", authServer.ConfirmPasswordReset)
+
+		router.Group(func(r chi.Router) {
+			r.Use(RequireAuth(authServer.jwtSecret))
+			// Owned-resource routes (accounts, categories, transactions,
+			// summary) mount here in #44-#48.
+		})
 	}
 
 	return router

--- a/backend/migrations/00004_transactions_category_owner_rls.sql
+++ b/backend/migrations/00004_transactions_category_owner_rls.sql
@@ -14,15 +14,28 @@
 -- same rule, per the "RLS is the security backstop; SQL still includes
 -- ownership predicates" invariant.
 
--- The cleanup UPDATE must run with FORCE RLS momentarily lifted: goose applies
--- this migration as the ordinary table-owning role, which FORCE RLS otherwise
--- subjects to the (unset app.user_id => zero visible rows) policy, making the
--- UPDATE a silent no-op. The whole migration runs in one transaction and the
--- ALTER takes an ACCESS EXCLUSIVE lock, so the lifted window is atomic and not
--- observable to any concurrent session. A transaction's owner is its account's
--- owner; null any category that belongs to a different user.
+-- The cleanup UPDATE must run with FORCE RLS momentarily lifted on all three
+-- tables it touches, not just the UPDATE target: goose applies this migration
+-- as the ordinary table-owning role with no app.user_id set, so FORCE RLS
+-- subjects every one of them to its (unset app.user_id => zero visible rows)
+-- policy. Lifting only transactions is not enough — the UPDATE ... FROM reads
+-- accounts and categories too, and if those stay forced the join matches
+-- nothing and the cleanup is a silent no-op. All three are lifted, the UPDATE
+-- runs, then all three are restored. The whole migration runs in one
+-- transaction and each ALTER takes an ACCESS EXCLUSIVE lock, so the lifted
+-- window is atomic and not observable to any concurrent session. A
+-- transaction's owner is its account's owner; null any category that belongs
+-- to a different user.
 -- +goose StatementBegin
 ALTER TABLE transactions NO FORCE ROW LEVEL SECURITY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE accounts NO FORCE ROW LEVEL SECURITY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE categories NO FORCE ROW LEVEL SECURITY;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
@@ -36,6 +49,14 @@ WHERE t.account_id = a.id
 
 -- +goose StatementBegin
 ALTER TABLE transactions FORCE ROW LEVEL SECURITY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE accounts FORCE ROW LEVEL SECURITY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE categories FORCE ROW LEVEL SECURITY;
 -- +goose StatementEnd
 
 -- +goose StatementBegin

--- a/backend/migrations/00004_transactions_category_owner_rls.sql
+++ b/backend/migrations/00004_transactions_category_owner_rls.sql
@@ -1,0 +1,98 @@
+-- +goose Up
+-- Tightens transactions_owner so a write must reference either no category or
+-- a category owned by the same app.user_id, and cleans up any pre-existing
+-- cross-owner references first.
+--
+-- Background: the #39 policy proved transaction ownership only through
+-- account_id. A user could therefore write a transaction on their own account
+-- while pointing category_id at another tenant's category. PostgreSQL foreign
+-- key checks run as the table owner and bypass RLS, so the FK does not reject
+-- that reference. Left unfixed it breaks tenant integrity, leaks a category
+-- existence oracle, and lets the other tenant's ON DELETE SET NULL mutate this
+-- user's row. The legacy Hono transactions handler already rejects an unowned
+-- category with 404 "Category not found"; this is the RLS backstop for that
+-- same rule, per the "RLS is the security backstop; SQL still includes
+-- ownership predicates" invariant.
+
+-- The cleanup UPDATE must run with FORCE RLS momentarily lifted: goose applies
+-- this migration as the ordinary table-owning role, which FORCE RLS otherwise
+-- subjects to the (unset app.user_id => zero visible rows) policy, making the
+-- UPDATE a silent no-op. The whole migration runs in one transaction and the
+-- ALTER takes an ACCESS EXCLUSIVE lock, so the lifted window is atomic and not
+-- observable to any concurrent session. A transaction's owner is its account's
+-- owner; null any category that belongs to a different user.
+-- +goose StatementBegin
+ALTER TABLE transactions NO FORCE ROW LEVEL SECURITY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+UPDATE transactions t
+SET category_id = NULL
+FROM accounts a, categories c
+WHERE t.account_id = a.id
+  AND t.category_id = c.id
+  AND c.user_id <> a.user_id;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE transactions FORCE ROW LEVEL SECURITY;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP POLICY transactions_owner ON transactions;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE POLICY transactions_owner ON transactions
+    FOR ALL
+    USING (
+        EXISTS (
+            SELECT 1 FROM accounts a
+            WHERE a.id = transactions.account_id
+                AND a.user_id = NULLIF(current_setting('app.user_id', true), '')::uuid
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM accounts a
+            WHERE a.id = transactions.account_id
+                AND a.user_id = NULLIF(current_setting('app.user_id', true), '')::uuid
+        )
+        AND (
+            transactions.category_id IS NULL
+            OR EXISTS (
+                SELECT 1 FROM categories c
+                WHERE c.id = transactions.category_id
+                    AND c.user_id = NULLIF(current_setting('app.user_id', true), '')::uuid
+            )
+        )
+    );
+-- +goose StatementEnd
+
+-- +goose Down
+-- Restores the account-only policy from #39. The cleanup UPDATE is not
+-- reversible (nulled categories are not recorded); Down restores the policy
+-- shape, not the data, which is the standard expectation for a data-cleanup
+-- migration.
+-- +goose StatementBegin
+DROP POLICY transactions_owner ON transactions;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE POLICY transactions_owner ON transactions
+    FOR ALL
+    USING (
+        EXISTS (
+            SELECT 1 FROM accounts a
+            WHERE a.id = transactions.account_id
+                AND a.user_id = NULLIF(current_setting('app.user_id', true), '')::uuid
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM accounts a
+            WHERE a.id = transactions.account_id
+                AND a.user_id = NULLIF(current_setting('app.user_id', true), '')::uuid
+        )
+    );
+-- +goose StatementEnd

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -538,5 +538,6 @@
   "536": "GetSummary200JSONResponse",
   "537": "extraction-spec.md",
   "538": "RegisterUser201JSONResponse",
+  "539": "GetTransaction200JSONResponse",
   "540": "API Contract and Documentation Standard"
 }

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -536,6 +536,8 @@
   "534": "graphify reference: GitHub clone and cross-repo merge",
   "535": "graphify reference: transcribe video and audio",
   "536": "GetSummary200JSONResponse",
+  "537": "RequiredHeaderError",
   "538": "RegisterUser201JSONResponse",
+  "539": "GetTransaction200JSONResponse",
   "540": "API Contract and Documentation Standard"
 }

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -536,8 +536,6 @@
   "534": "graphify reference: GitHub clone and cross-repo merge",
   "535": "graphify reference: transcribe video and audio",
   "536": "GetSummary200JSONResponse",
-  "537": "extraction-spec.md",
   "538": "RegisterUser201JSONResponse",
-  "539": "GetTransaction200JSONResponse",
   "540": "API Contract and Documentation Standard"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - nuchi  (2026-07-21)
+# Graph Report - agent-a77d2a137aa3f484d  (2026-07-23)
 
 ## Corpus Check
-- 268 files · ~119,168 words
+- 283 files · ~133,756 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2526 nodes · 4132 edges · 540 communities (142 shown, 398 thin omitted)
-- Extraction: 96% EXTRACTED · 4% INFERRED · 0% AMBIGUOUS · INFERRED: 168 edges (avg confidence: 0.8)
+- 2648 nodes · 4350 edges · 541 communities (145 shown, 396 thin omitted)
+- Extraction: 95% EXTRACTED · 5% INFERRED · 0% AMBIGUOUS · INFERRED: 206 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `1d153cd4`
+- Built from commit: `65cfd051`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -535,36 +535,37 @@
 - [[_COMMUNITY_GetSummary200JSONResponse|GetSummary200JSONResponse]]
 - [[_COMMUNITY_extraction-spec|extraction-spec.md]]
 - [[_COMMUNITY_RegisterUser201JSONResponse|RegisterUser201JSONResponse]]
+- [[_COMMUNITY_GetTransaction200JSONResponse|GetTransaction200JSONResponse]]
 - [[_COMMUNITY_API Contract and Documentation Standard|API Contract and Documentation Standard]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `cn()` - 95 edges
 2. `newAuthTestEnv()` - 41 edges
 3. `createApiError()` - 41 edges
-4. `ServerInterfaceWrapper` - 33 edges
-5. `strictHandler` - 32 edges
-6. `Unimplemented` - 29 edges
-7. `Button()` - 26 edges
-8. `New()` - 25 edges
+4. `New()` - 33 edges
+5. `ServerInterfaceWrapper` - 33 edges
+6. `strictHandler` - 32 edges
+7. `Unimplemented` - 29 edges
+8. `Button()` - 26 edges
 9. `Load()` - 24 edges
 10. `client` - 24 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `Generated Go Output` --semantically_similar_to--> `generated.gen.go`  [INFERRED] [semantically similar]
   openapi/oapi-codegen.yaml → backend/internal/openapi/README.md
-- `CardAction()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/card.tsx → lib/utils.ts
-- `CardFooter()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/card.tsx → lib/utils.ts
 - `DialogOverlay()` --calls--> `cn()`  [EXTRACTED]
   components/ui/dialog.tsx → lib/utils.ts
 - `PopoverHeader()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/popover.tsx → lib/utils.ts
+- `PopoverTitle()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/popover.tsx → lib/utils.ts
+- `PopoverDescription()` --calls--> `cn()`  [EXTRACTED]
   components/ui/popover.tsx → lib/utils.ts
 
 ## Import Cycles
 - None detected.
 
-## Communities (540 total, 398 thin omitted)
+## Communities (541 total, 396 thin omitted)
 
 ### Community 0 - "Transaction Form Tsx"
 Cohesion: 0.12
@@ -579,8 +580,8 @@ Cohesion: 0.07
 Nodes (26): 1. Unified Import Inbox, 2. Import Review, Normalization, and Deduplication, 3. Transfers, Balances, and Net Worth, 4. Budgets and Monthly Planning, 5. Recurring Transactions and Forecasting, Current roadmap principle, Nuchi Roadmap Features List, Open banking readiness (+18 more)
 
 ### Community 3 - "Page Tsx"
-Cohesion: 0.07
-Nodes (56): databaseHost(), main(), Duration, Time, UUID, IssueAccessToken(), T, TestIssueAccessToken_ClaimsAreMinimal() (+48 more)
+Cohesion: 0.06
+Nodes (72): databaseHost(), main(), Duration, Time, UUID, IssueAccessToken(), T, TestIssueAccessToken_ClaimsAreMinimal() (+64 more)
 
 ### Community 5 - "Actions Tsx"
 Cohesion: 0.07
@@ -591,8 +592,8 @@ Cohesion: 0.06
 Nodes (31): 1. Frontend - Data/State (Next.js, React hooks, mutation hooks), 2. Frontend - UI Components (Shadcn/Radix UI, table rendering), 3. State Management (Custom hooks, promise-based dialog flow), 4. Developer Experience & Configuration (Dependency and repo hygiene), API, Automated Testing Needs, Breaking Changes, Business Value (+23 more)
 
 ### Community 9 - "0004 Snapshot Json"
-Cohesion: 0.19
-Nodes (11): CategoryTooltip(), CategoryTooltipPayload, CategoryTooltipProps, COLORS, PieVariant(), Props, COLORS, Props (+3 more)
+Cohesion: 0.10
+Nodes (22): AreaVariant(), Props, BarVariant(), Props, CategoryTooltip(), CategoryTooltipPayload, CategoryTooltipProps, CustomTooltip() (+14 more)
 
 ### Community 10 - "Data Card Tsx"
 Cohesion: 0.33
@@ -607,8 +608,8 @@ Cohesion: 0.19
 Nodes (11): Props, Select(), Dialog(), DialogContent(), DialogDescription(), DialogFooter(), DialogHeader(), DialogOverlay() (+3 more)
 
 ### Community 14 - "0002 Snapshot Json"
-Cohesion: 0.17
-Nodes (16): DateFilter(), Preset, PresetKey, PRESETS, Props, Button(), buttonVariants, Calendar() (+8 more)
+Cohesion: 0.11
+Nodes (22): AccountFilter(), DateFilter(), Preset, PresetKey, PRESETS, Props, Filters(), NavButton() (+14 more)
 
 ### Community 16 - "Project Polish Pr Summary"
 Cohesion: 0.20
@@ -616,31 +617,31 @@ Nodes (9): Follow-Up Memory, Implemented Scope, Last Verified, Local Database, M
 
 ### Community 17 - "Transactions Ts"
 Cohesion: 0.01
-Nodes (144): Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody, CreateCategoryJSONRequestBody (+136 more)
+Nodes (148): Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody, CreateCategoryJSONRequestBody (+140 more)
 
 ### Community 18 - "0001 Snapshot Json"
-Cohesion: 0.21
-Nodes (7): Props, AccountFilter(), Filters(), Header(), HeaderLogo(), Navigation(), WelcomeMsg()
+Cohesion: 0.27
+Nodes (5): Props, Header(), HeaderLogo(), Navigation(), WelcomeMsg()
 
 ### Community 19 - "Json Editor Code Actions"
 Cohesion: 0.15
 Nodes (13): app, enforceJsonBodyLimit(), OwnedReferencesResult, transactions, checkTransactionMutationRateLimit(), cleanupMutationRateLimit(), DateRangeQueryOptions, DateRangeQueryResult (+5 more)
 
 ### Community 20 - "0000 Snapshot Json"
-Cohesion: 0.14
-Nodes (13): app, app, app, AppType, DELETE, GET, OPTIONS, PATCH (+5 more)
+Cohesion: 0.13
+Nodes (17): app, app, app, AppType, DELETE, GET, OPTIONS, PATCH (+9 more)
 
 ### Community 23 - "Nuchi Project Context"
-Cohesion: 0.13
-Nodes (24): DatePicker(), FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem(), FormItemContext (+16 more)
+Cohesion: 0.11
+Nodes (26): DatePicker(), FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem(), FormItemContext (+18 more)
 
 ### Community 24 - "Transactions API"
 Cohesion: 0.08
 Nodes (23): Accounts, Accounts, API Shape, Canonical Architecture, Categories, Categories, Client-to-Database Flow, Core Stack (+15 more)
 
 ### Community 28 - "Components Json"
-Cohesion: 0.06
-Nodes (74): decodeAPIError(), Cookie, Duration, Handler, authTestEnv, Pool, ResponseRecorder, T (+66 more)
+Cohesion: 0.07
+Nodes (72): decodeAPIError(), Cookie, Duration, Handler, authTestEnv, Pool, ResponseRecorder, T (+64 more)
 
 ### Community 29 - "Schema Ts"
 Cohesion: 0.10
@@ -655,8 +656,8 @@ Cohesion: 0.25
 Nodes (6): geistMono, geistSans, metadata, Toaster(), sonner, SheetProvider()
 
 ### Community 32 - "Current API Parity Fixtures"
-Cohesion: 0.09
-Nodes (41): assertCascadingUserFK(), assertUniqueColumn(), Context, Pool, T, TestAuthBaseSchema_LiveDatabase(), Context, Pool (+33 more)
+Cohesion: 0.07
+Nodes (57): assertCascadingUserFK(), assertUniqueColumn(), Context, Pool, T, TestAuthBaseSchema_LiveDatabase(), Context, Pool (+49 more)
 
 ### Community 33 - "Dev Dependencies"
 Cohesion: 0.04
@@ -667,8 +668,8 @@ Cohesion: 0.05
 Nodes (39): devDependencies, dotenv, drizzle-kit, eslint, eslint-config-next, eslint-config-prettier, openapi-typescript, postcss (+31 more)
 
 ### Community 35 - "Seed Ts"
-Cohesion: 0.17
-Nodes (10): AreaVariant(), Props, BarVariant(), Props, CustomTooltip(), CustomTooltipProps, TooltipPayloadItem, LineVariant() (+2 more)
+Cohesion: 0.11
+Nodes (28): ApiError, T, liveDatabaseURL(), bearerToken(), Context, Handler, ResponseWriter, UUID (+20 more)
 
 ### Community 37 - "Nuchi Application"
 Cohesion: 0.10
@@ -683,24 +684,24 @@ Cohesion: 0.33
 Nodes (5): 0002 — Finance tables use text cuid IDs; UUID default is v4, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 40 - "Roadmap Tech Debt Backlog"
-Cohesion: 0.31
-Nodes (10): Props, DataTableProps, Table(), TableBody(), TableCaption(), TableCell(), TableFooter(), TableHead() (+2 more)
+Cohesion: 0.13
+Nodes (21): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), Props, ImportableTransactionField, DataTableProps (+13 more)
 
 ### Community 41 - "New Router"
-Cohesion: 0.20
-Nodes (13): boxVariant, BoxVariants, DataCard(), DataCardProps, iconVariant, IconVariants, Card(), CardAction() (+5 more)
+Cohesion: 0.08
+Nodes (24): For /graphify add and --watch, For /graphify query, For the commit hook and native CLAUDE.md integration, For --update and --cluster-only, /graphify, Honesty Rules, Interpreter guard for subcommands, Part A - Structural extraction for code files (+16 more)
 
 ### Community 42 - "Api Error"
-Cohesion: 0.16
-Nodes (17): Props, Actions(), Props, Actions(), Props, CategoryColumn(), Props, DropdownMenu() (+9 more)
+Cohesion: 0.09
+Nodes (30): Actions(), Props, Actions(), Props, CategoryColumn(), Props, CardAction(), CardFooter() (+22 more)
 
 ### Community 43 - "Edit Account Sheet Tsx"
 Cohesion: 0.18
 Nodes (10): Commands, Current Risk Areas, Env, graphify, Nuchi Codex Guide, Pull Requests Hard Rules, Reference, Repo Rules (+2 more)
 
 ### Community 45 - "Indexes Columns"
-Cohesion: 0.18
-Nodes (12): AmountInput(), Props, Tooltip(), TooltipContent(), TooltipProvider(), TooltipTrigger(), db, pool (+4 more)
+Cohesion: 0.39
+Nodes (6): AmountInput(), Props, Tooltip(), TooltipContent(), TooltipProvider(), TooltipTrigger()
 
 ### Community 47 - "Plaid Id"
 Cohesion: 0.15
@@ -711,8 +712,8 @@ Cohesion: 0.09
 Nodes (26): Context, Queries, Timestamptz, UUID, Text, Timestamp, Timestamptz, UUID (+18 more)
 
 ### Community 49 - "Clerk Auth"
-Cohesion: 0.19
-Nodes (13): assertSeedAllowed(), databaseUrl, db, defaultFrom, defaultTo, generateRandomAmount(), generateTransactions(), generateTransactionsForDay() (+5 more)
+Cohesion: 0.17
+Nodes (14): getDatabaseUrl(), assertSeedAllowed(), databaseUrl, db, defaultFrom, defaultTo, generateRandomAmount(), generateTransactions() (+6 more)
 
 ### Community 50 - "Columns Plaid Id"
 Cohesion: 0.33
@@ -791,8 +792,8 @@ Cohesion: 0.33
 Nodes (5): 0011 — No resend endpoint; email delivery is fire-and-forget, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 260 - "name"
-Cohesion: 0.18
-Nodes (13): CategoriesPage(), DataTable(), useBulkDeleteCategories(), RequestType, ResponseType, useCreateCategory(), useGetCategories(), CategoryForm() (+5 more)
+Cohesion: 0.40
+Nodes (4): CategoriesPage(), useBulkDeleteCategories(), NewCategoryState, useNewCategory
 
 ### Community 293 - "name"
 Cohesion: 0.28
@@ -819,8 +820,8 @@ Cohesion: 0.05
 Nodes (21): BulkCreateTransactions500JSONResponse, BulkDeleteAccounts500JSONResponse, BulkDeleteCategories500JSONResponse, BulkDeleteTransactions500JSONResponse, CreateAccount500JSONResponse, CreateCategory500JSONResponse, CreateTransaction500JSONResponse, DatabaseErrorJSONResponse (+13 more)
 
 ### Community 317 - "notNull"
-Cohesion: 0.17
-Nodes (16): ImportableTransactionField, isImportableTransactionField(), options, Props, TableHeadSelect(), ChartEnum, Props, Select() (+8 more)
+Cohesion: 0.10
+Nodes (33): isImportableTransactionField(), options, Props, TableHeadSelect(), Chart(), ChartEnum, ChartLoading(), Props (+25 more)
 
 ### Community 320 - "name"
 Cohesion: 0.25
@@ -831,8 +832,8 @@ Cohesion: 0.40
 Nodes (3): ConfirmPasswordReset401JSONResponse, InvalidTokenErrorJSONResponse, VerifyEmail401JSONResponse
 
 ### Community 332 - "Nuchi — Claude Code Guide"
-Cohesion: 0.18
-Nodes (10): Branch And PR Hard Rules, Commands, Graphify, Hard Invariants, Legacy Code, Model Orchestration, Nuchi — Claude Code Guide, Post-Migration Improvements (+2 more)
+Cohesion: 0.20
+Nodes (9): Commands, Graphify, Hard Invariants, Legacy Code, Model Orchestration, Nuchi — Claude Code Guide, Post-Migration Improvements, Project (+1 more)
 
 ### Community 338 - "primaryKey"
 Cohesion: 0.07
@@ -843,16 +844,16 @@ Cohesion: 0.33
 Nodes (5): 0005 — Category duplicate update returns 500, create returns 409, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 348 - "type"
-Cohesion: 0.24
-Nodes (10): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), ImportedTransactionRow, ImportedTransactionRowError, parseImportedTransactionRows() (+2 more)
+Cohesion: 0.16
+Nodes (16): Actions(), Props, AccountColumn(), Props, ResponseType, useDeleteAccount(), RequestType, ResponseType (+8 more)
 
 ### Community 353 - "0006 — transactions.amount is 32-bit, capping a single transaction near ±2.1M ARS"
 Cohesion: 0.33
 Nodes (5): 0006 — transactions.amount is 32-bit, capping a single transaction near ±2.1M ARS, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 354 - "connection.ts"
-Cohesion: 0.21
-Nodes (11): buildPoolConfig(), createPool(), DatabasePoolCache, getDatabaseUrl(), getOrCreateCachedPool(), isLocalDatabaseUrl(), LOCAL_HOSTS, shouldAllowInsecureTls() (+3 more)
+Cohesion: 0.20
+Nodes (11): buildPoolConfig(), createPool(), DatabasePoolCache, getOrCreateCachedPool(), isLocalDatabaseUrl(), LOCAL_HOSTS, shouldAllowInsecureTls(), shouldUseSsl() (+3 more)
 
 ### Community 355 - "type"
 Cohesion: 0.29
@@ -883,16 +884,20 @@ Cohesion: 0.29
 Nodes (7): Categories, `DELETE /api/categories/:id`, `GET /api/categories`, `GET /api/categories/:id`, `PATCH /api/categories/:id`, `POST /api/categories`, `POST /api/categories/bulk-delete`
 
 ### Community 376 - ".GetCategory"
-Cohesion: 0.13
-Nodes (16): NavButton(), Props, DropdownMenuCheckboxItem(), DropdownMenuContent(), DropdownMenuItem(), DropdownMenuLabel(), DropdownMenuRadioItem(), DropdownMenuSeparator() (+8 more)
+Cohesion: 0.22
+Nodes (8): graphify reference: extra exports and benchmark, Step 6b - Wiki (only if --wiki flag), Step 7 - Neo4j export (only if --neo4j or --neo4j-push flag), Step 7a - FalkorDB export (only if --falkordb or --falkordb-push flag), Step 7b - SVG export (only if --svg flag), Step 7c - GraphML export (only if --graphml flag), Step 7d - MCP server (only if --mcp flag), Step 8 - Token reduction benchmark (only if total_words > 5000)
 
 ### Community 377 - "BulkCreateTransactionsRequestObject"
 Cohesion: 0.33
 Nodes (5): 0010 — Auth operations do not declare 500 responses in the contract, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
+### Community 378 - "columns.tsx"
+Cohesion: 0.33
+Nodes (5): For /graphify explain, For /graphify path, graphify reference: query, path, explain, Step 0 — Constrained query expansion (REQUIRED before traversal), Step 1 — Traversal
+
 ### Community 379 - "name"
-Cohesion: 0.13
-Nodes (16): INITIAL_IMPORT_RESULTS, TransactionsPage(), VARIANTS, CSVReaderRenderProps, CSVUploadResults, Props, UploadButton(), useSelectAccount() (+8 more)
+Cohesion: 0.14
+Nodes (14): INITIAL_IMPORT_RESULTS, TransactionsPage(), VARIANTS, CSVReaderRenderProps, CSVUploadResults, Props, UploadButton(), RequestType (+6 more)
 
 ### Community 388 - ".UpdateCategory"
 Cohesion: 0.40
@@ -931,8 +936,8 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: give it a last review of all the files changend in the pr the comments and all that is in place right now in the pr leave comments for medim-high and high issues mid-low and low forget it we mande 3 iterations so far. if something is too big then addres it consitently here so it so i can anlyze it, Source Nodes
 
 ### Community 432 - "GetSummary200JSONResponse"
-Cohesion: 0.11
-Nodes (22): ResponseType, useDeleteAccount(), RequestType, ResponseType, useEditAccount(), useGetAccount(), EditAccountSheet(), RequestType (+14 more)
+Cohesion: 0.10
+Nodes (25): RequestType, ResponseType, RequestType, ResponseType, ResponseType, useDeleteCategory(), RequestType, ResponseType (+17 more)
 
 ### Community 435 - "name"
 Cohesion: 0.38
@@ -971,8 +976,8 @@ Cohesion: 0.40
 Nodes (3): GetSummary400JSONResponse, InvalidDateQueryErrorJSONResponse, ListTransactions400JSONResponse
 
 ### Community 510 - "LogoutUser200JSONResponse"
-Cohesion: 0.14
-Nodes (20): routes, Sheet(), SheetContent(), SheetDescription(), SheetHeader(), SheetTitle(), SheetTrigger(), VisuallyHidden() (+12 more)
+Cohesion: 0.18
+Nodes (15): Sheet(), SheetContent(), SheetDescription(), SheetHeader(), SheetTitle(), accountsRelations, categoriesRelations, citext (+7 more)
 
 ### Community 511 - "BulkDeleteTransactions200JSONResponse"
 Cohesion: 0.33
@@ -983,32 +988,32 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: Review PR #64 against post-merge PR #62 comment and issue #63, Source Nodes
 
 ### Community 513 - ".CreateCategory"
-Cohesion: 0.17
-Nodes (4): RequestType, ResponseType, useCreateTransaction(), ApiError
+Cohesion: 0.14
+Nodes (5): RequestType, ResponseType, RequestType, ResponseType, ApiError
 
 ### Community 514 - "RegisterUser201JSONResponse"
-Cohesion: 0.21
-Nodes (9): Chart(), ChartLoading(), Props, RadarVariant(), Props, SpendingPie(), SpendingPieEnum, SpendingPieLoading() (+1 more)
+Cohesion: 0.50
+Nodes (3): For /graphify add, For --watch, graphify reference: add a URL and watch a folder
 
 ### Community 515 - "query-provider.tsx"
 Cohesion: 0.60
 Nodes (4): getQueryClient(), makeQueryClient(), Props, QueryProvider()
 
 ### Community 517 - "RegisterUser201JSONResponse"
-Cohesion: 0.14
-Nodes (14): Actions(), columns, ResponseType, columns, ResponseType, AccountColumn(), Props, columns (+6 more)
+Cohesion: 0.20
+Nodes (9): columns, ResponseType, columns, ResponseType, columns, ResponseType, Badge(), badgeVariants (+1 more)
 
 ### Community 518 - "graphify reference: query, path, explain"
-Cohesion: 0.26
-Nodes (9): RequestType, ResponseType, useCreateAccount(), useEditTransaction(), useGetTransaction(), EditTransactionSheet(), FormValues, TransactionForm() (+1 more)
+Cohesion: 0.18
+Nodes (18): InsertTransactionSchema, useCreateAccount(), useGetAccounts(), NewAccountSheet(), useSelectAccount(), useCreateCategory(), useGetCategories(), NewCategorySheet() (+10 more)
 
 ### Community 519 - "README.md"
 Cohesion: 0.22
 Nodes (5): Codex Backend Improvements, Decision hierarchy, Definition of done for an endpoint, How to use this set, Source set
 
 ### Community 520 - "amount-input.tsx"
-Cohesion: 0.27
-Nodes (8): AccountsPage(), RequestType, ResponseType, useBulkDeleteAccounts(), useGetAccounts(), NewAccountSheet(), NewAccountState, useNewAccount
+Cohesion: 0.40
+Nodes (4): AccountsPage(), useBulkDeleteAccounts(), NewAccountState, useNewAccount
 
 ### Community 521 - "Target Backend Architecture"
 Cohesion: 0.22
@@ -1031,8 +1036,8 @@ Cohesion: 0.25
 Nodes (7): Current State and Constraints, Deferred behavior and schema decisions already recorded, Evidence that must be refreshed before implementation, Existing strengths to preserve, Gaps this project must close, Migration boundary, Snapshot
 
 ### Community 526 - "graphify reference: add a URL and watch a folder"
-Cohesion: 0.43
-Nodes (4): DataCardLoading(), DataCharts(), DataGrid(), useGetSummary()
+Cohesion: 0.47
+Nodes (3): DataCardLoading(), DataGrid(), formatDateRange()
 
 ### Community 527 - "graphify reference: commit hook and native CLAUDE.md integration"
 Cohesion: 0.40
@@ -1050,41 +1055,40 @@ Nodes (3): Answer, Q: Review PR 65 email verification and password reset changes
 Cohesion: 0.25
 Nodes (7): Index program, Performance acceptance gate, Performance and Query Engineering, Pool and runtime tuning, Query rules, Service objectives and budgets, Summary strategy
 
+### Community 532 - "GetTransaction200JSONResponse"
+Cohesion: 0.50
+Nodes (3): For git commit hook, For native CLAUDE.md integration, graphify reference: commit hook and native CLAUDE.md integration
+
 ### Community 533 - "Robustness and Transaction Semantics"
 Cohesion: 0.25
 Nodes (7): Concurrency and retry, Domain-specific atomicity, Failure behavior, Robustness and Transaction Semantics, Testing pyramid, Time, dates, money, and IDs, Transaction policy
+
+### Community 534 - "graphify reference: GitHub clone and cross-repo merge"
+Cohesion: 0.50
+Nodes (3): For --cluster-only, For --update (incremental re-extraction), graphify reference: incremental update and cluster-only
 
 ### Community 540 - "API Contract and Documentation Standard"
 Cohesion: 0.29
 Nodes (6): API Contract and Documentation Standard, Contract workflow, Documentation acceptance gate, Internal documentation, Operational documentation, Required operation documentation
 
 ## Knowledge Gaps
-- **1040 isolated node(s):** `Props`, `ResponseType`, `Props`, `ResponseType`, `Props` (+1035 more)
+- **1081 isolated node(s):** `Props`, `ResponseType`, `Props`, `ResponseType`, `Props` (+1076 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **398 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
-
-## Work-memory lessons
-
-**Preferred sources** — corroborated by past sessions; start here.
-- `JWT Access Tokens` (3× useful, score=2.55291992)
-- `RefreshToken` (3× useful, score=2.55291992)
-- `AuthSessionResponse` (3× useful, score=2.55291992)
-- `Authentication and sessions` (3× useful, score=2.55291992)
-- `Config` (2× useful, score=1.767433669) _(code changed — re-verify)_
+- **396 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
+- **Why does `ApiErrorResponse` connect `Transactions Ts` to `Page Tsx`, `Components Json`?**
+  _High betweenness centrality (0.029) - this node is a cross-community bridge._
 - **Why does `decodeAPIError()` connect `Components Json` to `Transactions Ts`?**
-  _High betweenness centrality (0.029) - this node is a cross-community bridge._
-- **Why does `ApiErrorResponse` connect `Transactions Ts` to `Components Json`?**
-  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+  _High betweenness centrality (0.024) - this node is a cross-community bridge._
 - **Why does `toAuthUser()` connect `Page Tsx` to `notNull`, `Route Ts`?**
-  _High betweenness centrality (0.025) - this node is a cross-community bridge._
+  _High betweenness centrality (0.024) - this node is a cross-community bridge._
 - **Are the 20 inferred relationships involving `newAuthTestEnv()` (e.g. with `NewPool()` and `NewAuthServer()`) actually correct?**
   _`newAuthTestEnv()` has 20 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Props`, `ResponseType`, `Props` to the rest of the system?**
-  _1065 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1106 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Transaction Form Tsx` be split into smaller, more focused modules?**
   _Cohesion score 0.11764705882352941 - nodes in this community are weakly interconnected._
 - **Should `Dependencies Class Variance Authority` be split into smaller, more focused modules?**

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - agent-a77d2a137aa3f484d  (2026-07-27)
 
 ## Corpus Check
-- 285 files · ~135,937 words
+- 286 files · ~137,296 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2656 nodes · 4380 edges · 539 communities (143 shown, 396 thin omitted)
-- Extraction: 95% EXTRACTED · 5% INFERRED · 0% AMBIGUOUS · INFERRED: 221 edges (avg confidence: 0.8)
+- 2670 nodes · 4419 edges · 541 communities (145 shown, 396 thin omitted)
+- Extraction: 95% EXTRACTED · 5% INFERRED · 0% AMBIGUOUS · INFERRED: 223 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `3a9e429c`
+- Built from commit: `fe011303`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -533,7 +533,9 @@
 - [[_COMMUNITY_graphify reference GitHub clone and cross-repo merge|graphify reference: GitHub clone and cross-repo merge]]
 - [[_COMMUNITY_graphify reference transcribe video and audio|graphify reference: transcribe video and audio]]
 - [[_COMMUNITY_GetSummary200JSONResponse|GetSummary200JSONResponse]]
+- [[_COMMUNITY_RequiredHeaderError|RequiredHeaderError]]
 - [[_COMMUNITY_RegisterUser201JSONResponse|RegisterUser201JSONResponse]]
+- [[_COMMUNITY_GetTransaction200JSONResponse|GetTransaction200JSONResponse]]
 - [[_COMMUNITY_API Contract and Documentation Standard|API Contract and Documentation Standard]]
 
 ## God Nodes (most connected - your core abstractions)
@@ -555,15 +557,15 @@
   components/ui/card.tsx → lib/utils.ts
 - `CardFooter()` --calls--> `cn()`  [EXTRACTED]
   components/ui/card.tsx → lib/utils.ts
-- `SelectLabel()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/select.tsx → lib/utils.ts
-- `SelectSeparator()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/select.tsx → lib/utils.ts
+- `DialogOverlay()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/dialog.tsx → lib/utils.ts
+- `DropdownMenuCheckboxItem()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/dropdown-menu.tsx → lib/utils.ts
 
 ## Import Cycles
 - None detected.
 
-## Communities (539 total, 396 thin omitted)
+## Communities (541 total, 396 thin omitted)
 
 ### Community 0 - "Transaction Form Tsx"
 Cohesion: 0.12
@@ -578,8 +580,8 @@ Cohesion: 0.07
 Nodes (26): 1. Unified Import Inbox, 2. Import Review, Normalization, and Deduplication, 3. Transfers, Balances, and Net Worth, 4. Budgets and Monthly Planning, 5. Recurring Transactions and Forecasting, Current roadmap principle, Nuchi Roadmap Features List, Open banking readiness (+18 more)
 
 ### Community 3 - "Page Tsx"
-Cohesion: 0.06
-Nodes (70): Duration, Time, UUID, IssueAccessToken(), T, TestIssueAccessToken_ClaimsAreMinimal(), TestIssueAndVerifyAccessToken_RoundTrip(), TestVerifyAccessToken_ExpiredRejected() (+62 more)
+Cohesion: 0.05
+Nodes (85): ApiError, Duration, Time, UUID, IssueAccessToken(), T, TestIssueAccessToken_ClaimsAreMinimal(), TestIssueAndVerifyAccessToken_RoundTrip() (+77 more)
 
 ### Community 5 - "Actions Tsx"
 Cohesion: 0.07
@@ -590,8 +592,8 @@ Cohesion: 0.06
 Nodes (31): 1. Frontend - Data/State (Next.js, React hooks, mutation hooks), 2. Frontend - UI Components (Shadcn/Radix UI, table rendering), 3. State Management (Custom hooks, promise-based dialog flow), 4. Developer Experience & Configuration (Dependency and repo hygiene), API, Automated Testing Needs, Breaking Changes, Business Value (+23 more)
 
 ### Community 9 - "0004 Snapshot Json"
-Cohesion: 0.13
-Nodes (16): CategoryTooltip(), CategoryTooltipPayload, CategoryTooltipProps, COLORS, PieVariant(), Props, Props, RadarVariant() (+8 more)
+Cohesion: 0.08
+Nodes (32): AreaVariant(), Props, BarVariant(), Props, CategoryTooltip(), CategoryTooltipPayload, CategoryTooltipProps, CustomTooltip() (+24 more)
 
 ### Community 10 - "Data Card Tsx"
 Cohesion: 0.33
@@ -602,12 +604,12 @@ Cohesion: 0.33
 Nodes (5): 0001 — transactions.date is timestamp without time zone, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 13 - "PR Overview Descriptive Title"
-Cohesion: 0.18
-Nodes (14): ImportableTransactionField, isImportableTransactionField(), options, Props, TableHeadSelect(), Select(), SelectContent(), SelectItem() (+6 more)
+Cohesion: 0.13
+Nodes (28): ImportTable(), Props, ImportableTransactionField, isImportableTransactionField(), options, Props, TableHeadSelect(), DataTableProps (+20 more)
 
 ### Community 14 - "0002 Snapshot Json"
-Cohesion: 0.08
-Nodes (38): DateFilter(), Preset, PresetKey, PRESETS, DatePicker(), Props, NavButton(), Props (+30 more)
+Cohesion: 0.13
+Nodes (17): AccountFilter(), DateFilter(), Preset, PresetKey, PRESETS, DatePicker(), Props, Filters() (+9 more)
 
 ### Community 16 - "Project Polish Pr Summary"
 Cohesion: 0.20
@@ -615,11 +617,11 @@ Nodes (9): Follow-Up Memory, Implemented Scope, Last Verified, Local Database, M
 
 ### Community 17 - "Transactions Ts"
 Cohesion: 0.01
-Nodes (140): Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody, CreateCategoryJSONRequestBody (+132 more)
+Nodes (148): Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody, CreateCategoryJSONRequestBody (+140 more)
 
 ### Community 18 - "0001 Snapshot Json"
-Cohesion: 0.21
-Nodes (7): Props, AccountFilter(), Filters(), Header(), HeaderLogo(), Navigation(), WelcomeMsg()
+Cohesion: 0.27
+Nodes (5): Props, Header(), HeaderLogo(), Navigation(), WelcomeMsg()
 
 ### Community 19 - "Json Editor Code Actions"
 Cohesion: 0.15
@@ -630,8 +632,8 @@ Cohesion: 0.13
 Nodes (17): app, app, app, AppType, DELETE, GET, OPTIONS, PATCH (+9 more)
 
 ### Community 23 - "Nuchi Project Context"
-Cohesion: 0.08
-Nodes (35): FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem(), FormItemContext, FormItemContextValue (+27 more)
+Cohesion: 0.12
+Nodes (25): FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem(), FormItemContext, FormItemContextValue (+17 more)
 
 ### Community 24 - "Transactions API"
 Cohesion: 0.08
@@ -654,8 +656,8 @@ Cohesion: 0.25
 Nodes (6): geistMono, geistSans, metadata, Toaster(), sonner, SheetProvider()
 
 ### Community 32 - "Current API Parity Fixtures"
-Cohesion: 0.06
-Nodes (66): databaseHost(), main(), assertCascadingUserFK(), assertUniqueColumn(), Context, Pool, T, TestAuthBaseSchema_LiveDatabase() (+58 more)
+Cohesion: 0.05
+Nodes (79): databaseHost(), main(), assertCascadingUserFK(), assertUniqueColumn(), Context, Pool, T, TestAuthBaseSchema_LiveDatabase() (+71 more)
 
 ### Community 33 - "Dev Dependencies"
 Cohesion: 0.04
@@ -666,8 +668,8 @@ Cohesion: 0.05
 Nodes (39): devDependencies, dotenv, drizzle-kit, eslint, eslint-config-next, eslint-config-prettier, openapi-typescript, postcss (+31 more)
 
 ### Community 35 - "Seed Ts"
-Cohesion: 0.11
-Nodes (28): ApiError, T, liveDatabaseURL(), bearerToken(), Context, Handler, ResponseWriter, UUID (+20 more)
+Cohesion: 0.15
+Nodes (15): columns, ResponseType, columns, ResponseType, NavButton(), Props, Button(), Checkbox() (+7 more)
 
 ### Community 37 - "Nuchi Application"
 Cohesion: 0.10
@@ -682,24 +684,24 @@ Cohesion: 0.33
 Nodes (5): 0002 — Finance tables use text cuid IDs; UUID default is v4, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 40 - "Roadmap Tech Debt Backlog"
-Cohesion: 0.31
-Nodes (10): Props, DataTableProps, Table(), TableBody(), TableCaption(), TableCell(), TableFooter(), TableHead() (+2 more)
+Cohesion: 0.26
+Nodes (14): useCreateAccount(), useGetAccounts(), useSelectAccount(), useCreateCategory(), useGetCategories(), useCreateTransaction(), ResponseType, useDeleteTransaction() (+6 more)
 
 ### Community 41 - "New Router"
 Cohesion: 0.08
 Nodes (24): For /graphify add and --watch, For /graphify query, For the commit hook and native CLAUDE.md integration, For --update and --cluster-only, /graphify, Honesty Rules, Interpreter guard for subcommands, Part A - Structural extraction for code files (+16 more)
 
 ### Community 42 - "Api Error"
-Cohesion: 0.14
-Nodes (18): Actions(), Props, Actions(), Props, CategoryColumn(), Props, DropdownMenu(), DropdownMenuTrigger() (+10 more)
+Cohesion: 0.08
+Nodes (32): Actions(), Props, Actions(), Props, AccountColumn(), Props, Actions(), Props (+24 more)
 
 ### Community 43 - "Edit Account Sheet Tsx"
 Cohesion: 0.18
 Nodes (10): Commands, Current Risk Areas, Env, graphify, Nuchi Codex Guide, Pull Requests Hard Rules, Reference, Repo Rules (+2 more)
 
 ### Community 45 - "Indexes Columns"
-Cohesion: 0.20
-Nodes (10): AmountInput(), Props, Props, Select(), Tooltip(), TooltipContent(), TooltipProvider(), TooltipTrigger() (+2 more)
+Cohesion: 0.39
+Nodes (6): AmountInput(), Props, Tooltip(), TooltipContent(), TooltipProvider(), TooltipTrigger()
 
 ### Community 47 - "Plaid Id"
 Cohesion: 0.15
@@ -790,8 +792,8 @@ Cohesion: 0.33
 Nodes (5): 0011 — No resend endpoint; email delivery is fire-and-forget, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 260 - "name"
-Cohesion: 0.19
-Nodes (11): AreaVariant(), Props, BarVariant(), Props, ChartEnum, Props, CustomTooltip(), CustomTooltipProps (+3 more)
+Cohesion: 0.41
+Nodes (13): connect(), execUpgrade(), Context, T, gooseBinary(), insertUpgradeUser(), pgIdent(), runGoose() (+5 more)
 
 ### Community 293 - "name"
 Cohesion: 0.28
@@ -818,8 +820,8 @@ Cohesion: 0.05
 Nodes (21): BulkCreateTransactions500JSONResponse, BulkDeleteAccounts500JSONResponse, BulkDeleteCategories500JSONResponse, BulkDeleteTransactions500JSONResponse, CreateAccount500JSONResponse, CreateCategory500JSONResponse, CreateTransaction500JSONResponse, DatabaseErrorJSONResponse (+13 more)
 
 ### Community 317 - "notNull"
-Cohesion: 0.18
-Nodes (17): columns, columns, boxVariant, BoxVariants, DataCard(), DataCardProps, iconVariant, IconVariants (+9 more)
+Cohesion: 0.10
+Nodes (26): INITIAL_IMPORT_RESULTS, VARIANTS, CSVReaderRenderProps, CSVUploadResults, Props, UploadButton(), Chart(), ChartEnum (+18 more)
 
 ### Community 320 - "name"
 Cohesion: 0.25
@@ -842,8 +844,8 @@ Cohesion: 0.33
 Nodes (5): 0005 — Category duplicate update returns 500, create returns 409, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 348 - "type"
-Cohesion: 0.18
-Nodes (15): Actions(), Props, AccountColumn(), Props, ResponseType, useDeleteAccount(), RequestType, ResponseType (+7 more)
+Cohesion: 0.22
+Nodes (9): ResponseType, useDeleteAccount(), RequestType, ResponseType, useEditAccount(), useGetAccount(), AccountForm(), EditAccountSheet() (+1 more)
 
 ### Community 353 - "0006 — transactions.amount is 32-bit, capping a single transaction near ±2.1M ARS"
 Cohesion: 0.33
@@ -894,8 +896,8 @@ Cohesion: 0.33
 Nodes (5): For /graphify explain, For /graphify path, graphify reference: query, path, explain, Step 0 — Constrained query expansion (REQUIRED before traversal), Step 1 — Traversal
 
 ### Community 379 - "name"
-Cohesion: 0.21
-Nodes (8): columns, INITIAL_IMPORT_RESULTS, VARIANTS, CSVReaderRenderProps, CSVUploadResults, Props, UploadButton(), chunkItems()
+Cohesion: 0.23
+Nodes (9): ResponseType, useDeleteCategory(), RequestType, ResponseType, useEditCategory(), useGetCategory(), CategoryForm(), EditCategorySheet() (+1 more)
 
 ### Community 388 - ".UpdateCategory"
 Cohesion: 0.40
@@ -934,8 +936,8 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: give it a last review of all the files changend in the pr the comments and all that is in place right now in the pr leave comments for medim-high and high issues mid-low and low forget it we mande 3 iterations so far. if something is too big then addres it consitently here so it so i can anlyze it, Source Nodes
 
 ### Community 432 - "GetSummary200JSONResponse"
-Cohesion: 0.07
-Nodes (27): ResponseType, ResponseType, ResponseType, Badge(), badgeVariants, Checkbox(), RequestType, ResponseType (+19 more)
+Cohesion: 0.16
+Nodes (13): TransactionsPage(), useGetSummary(), RequestType, ResponseType, useBulkCreateTransactions(), RequestType, ResponseType, useBulkDeleteTransactions() (+5 more)
 
 ### Community 435 - "name"
 Cohesion: 0.38
@@ -974,8 +976,8 @@ Cohesion: 0.40
 Nodes (3): GetSummary400JSONResponse, InvalidDateQueryErrorJSONResponse, ListTransactions400JSONResponse
 
 ### Community 510 - "LogoutUser200JSONResponse"
-Cohesion: 0.14
-Nodes (9): ApiError, ApiErrorResponse, BulkCreateTransactions429JSONResponse, BulkDeleteTransactions429JSONResponse, CreateTransaction429JSONResponse, DeleteTransaction429JSONResponse, TransactionMutationRateLimitErrorJSONResponse, TransactionMutationRateLimitErrorResponseHeaders (+1 more)
+Cohesion: 0.22
+Nodes (7): AccountsPage(), RequestType, ResponseType, useBulkDeleteAccounts(), NewAccountSheet(), NewAccountState, useNewAccount
 
 ### Community 511 - "BulkDeleteTransactions200JSONResponse"
 Cohesion: 0.33
@@ -984,6 +986,10 @@ Nodes (5): 0012 — Residual timing oracle on password-reset request, How it was
 ### Community 512 - "GetSummary200JSONResponse"
 Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: Review PR #64 against post-merge PR #62 comment and issue #63, Source Nodes
+
+### Community 513 - ".CreateCategory"
+Cohesion: 0.10
+Nodes (10): RequestType, ResponseType, RequestType, ResponseType, RequestType, ResponseType, RequestType, ResponseType (+2 more)
 
 ### Community 514 - "RegisterUser201JSONResponse"
 Cohesion: 0.50
@@ -994,16 +1000,20 @@ Cohesion: 0.60
 Nodes (4): getQueryClient(), makeQueryClient(), Props, QueryProvider()
 
 ### Community 517 - "RegisterUser201JSONResponse"
-Cohesion: 0.26
-Nodes (9): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), ImportedTransactionRow, ImportedTransactionRowError, parseImportedTransactionRows() (+1 more)
+Cohesion: 0.27
+Nodes (9): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportedTransactionRow, ImportedTransactionRowError, parseImportedTransactionRows(), RawImportedTransactionRow (+1 more)
 
 ### Community 518 - "graphify reference: query, path, explain"
-Cohesion: 0.08
-Nodes (45): AccountsPage(), CategoriesPage(), TransactionsPage(), routes, Sheet(), SheetContent(), SheetDescription(), SheetHeader() (+37 more)
+Cohesion: 0.12
+Nodes (21): routes, Sheet(), SheetContent(), SheetDescription(), SheetHeader(), SheetTitle(), SheetTrigger(), VisuallyHidden() (+13 more)
 
 ### Community 519 - "README.md"
 Cohesion: 0.22
 Nodes (5): Codex Backend Improvements, Decision hierarchy, Definition of done for an endpoint, How to use this set, Source set
+
+### Community 520 - "amount-input.tsx"
+Cohesion: 0.22
+Nodes (7): CategoriesPage(), RequestType, ResponseType, useBulkDeleteCategories(), NewCategorySheet(), NewCategoryState, useNewCategory
 
 ### Community 521 - "Target Backend Architecture"
 Cohesion: 0.22
@@ -1026,8 +1036,8 @@ Cohesion: 0.25
 Nodes (7): Current State and Constraints, Deferred behavior and schema decisions already recorded, Evidence that must be refreshed before implementation, Existing strengths to preserve, Gaps this project must close, Migration boundary, Snapshot
 
 ### Community 526 - "graphify reference: add a URL and watch a folder"
-Cohesion: 0.24
-Nodes (8): Chart(), ChartLoading(), DataCardLoading(), DataCharts(), DataGrid(), SpendingPie(), SpendingPieLoading(), useGetSummary()
+Cohesion: 0.48
+Nodes (4): Props, Select(), mergeCreatedSelectOption(), SelectOption
 
 ### Community 527 - "graphify reference: commit hook and native CLAUDE.md integration"
 Cohesion: 0.40
@@ -1070,11 +1080,11 @@ Nodes (6): API Contract and Documentation Standard, Contract workflow, Documenta
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `New()` connect `Page Tsx` to `Current API Parity Fixtures`, `Components Json`?**
-  _High betweenness centrality (0.027) - this node is a cross-community bridge._
-- **Why does `ApiErrorResponse` connect `LogoutUser200JSONResponse` to `Transactions Ts`, `Page Tsx`, `Components Json`?**
-  _High betweenness centrality (0.026) - this node is a cross-community bridge._
+  _High betweenness centrality (0.030) - this node is a cross-community bridge._
 - **Why does `toAuthUser()` connect `Page Tsx` to `notNull`, `Route Ts`?**
   _High betweenness centrality (0.025) - this node is a cross-community bridge._
+- **Why does `ApiErrorResponse` connect `Transactions Ts` to `Page Tsx`, `Components Json`?**
+  _High betweenness centrality (0.024) - this node is a cross-community bridge._
 - **Are the 20 inferred relationships involving `newAuthTestEnv()` (e.g. with `NewPool()` and `NewAuthServer()`) actually correct?**
   _`newAuthTestEnv()` has 20 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Props`, `ResponseType`, `Props` to the rest of the system?**

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - agent-a77d2a137aa3f484d  (2026-07-23)
+# Graph Report - agent-a77d2a137aa3f484d  (2026-07-27)
 
 ## Corpus Check
-- 283 files · ~133,756 words
+- 285 files · ~135,937 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2648 nodes · 4350 edges · 541 communities (145 shown, 396 thin omitted)
-- Extraction: 95% EXTRACTED · 5% INFERRED · 0% AMBIGUOUS · INFERRED: 206 edges (avg confidence: 0.8)
+- 2656 nodes · 4380 edges · 539 communities (143 shown, 396 thin omitted)
+- Extraction: 95% EXTRACTED · 5% INFERRED · 0% AMBIGUOUS · INFERRED: 221 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `65cfd051`
+- Built from commit: `3a9e429c`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -533,9 +533,7 @@
 - [[_COMMUNITY_graphify reference GitHub clone and cross-repo merge|graphify reference: GitHub clone and cross-repo merge]]
 - [[_COMMUNITY_graphify reference transcribe video and audio|graphify reference: transcribe video and audio]]
 - [[_COMMUNITY_GetSummary200JSONResponse|GetSummary200JSONResponse]]
-- [[_COMMUNITY_extraction-spec|extraction-spec.md]]
 - [[_COMMUNITY_RegisterUser201JSONResponse|RegisterUser201JSONResponse]]
-- [[_COMMUNITY_GetTransaction200JSONResponse|GetTransaction200JSONResponse]]
 - [[_COMMUNITY_API Contract and Documentation Standard|API Contract and Documentation Standard]]
 
 ## God Nodes (most connected - your core abstractions)
@@ -553,19 +551,19 @@
 ## Surprising Connections (you probably didn't know these)
 - `Generated Go Output` --semantically_similar_to--> `generated.gen.go`  [INFERRED] [semantically similar]
   openapi/oapi-codegen.yaml → backend/internal/openapi/README.md
-- `DialogOverlay()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/dialog.tsx → lib/utils.ts
-- `PopoverHeader()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/popover.tsx → lib/utils.ts
-- `PopoverTitle()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/popover.tsx → lib/utils.ts
-- `PopoverDescription()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/popover.tsx → lib/utils.ts
+- `CardAction()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/card.tsx → lib/utils.ts
+- `CardFooter()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/card.tsx → lib/utils.ts
+- `SelectLabel()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/select.tsx → lib/utils.ts
+- `SelectSeparator()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/select.tsx → lib/utils.ts
 
 ## Import Cycles
 - None detected.
 
-## Communities (541 total, 396 thin omitted)
+## Communities (539 total, 396 thin omitted)
 
 ### Community 0 - "Transaction Form Tsx"
 Cohesion: 0.12
@@ -581,7 +579,7 @@ Nodes (26): 1. Unified Import Inbox, 2. Import Review, Normalization, and Dedupl
 
 ### Community 3 - "Page Tsx"
 Cohesion: 0.06
-Nodes (72): databaseHost(), main(), Duration, Time, UUID, IssueAccessToken(), T, TestIssueAccessToken_ClaimsAreMinimal() (+64 more)
+Nodes (70): Duration, Time, UUID, IssueAccessToken(), T, TestIssueAccessToken_ClaimsAreMinimal(), TestIssueAndVerifyAccessToken_RoundTrip(), TestVerifyAccessToken_ExpiredRejected() (+62 more)
 
 ### Community 5 - "Actions Tsx"
 Cohesion: 0.07
@@ -592,8 +590,8 @@ Cohesion: 0.06
 Nodes (31): 1. Frontend - Data/State (Next.js, React hooks, mutation hooks), 2. Frontend - UI Components (Shadcn/Radix UI, table rendering), 3. State Management (Custom hooks, promise-based dialog flow), 4. Developer Experience & Configuration (Dependency and repo hygiene), API, Automated Testing Needs, Breaking Changes, Business Value (+23 more)
 
 ### Community 9 - "0004 Snapshot Json"
-Cohesion: 0.10
-Nodes (22): AreaVariant(), Props, BarVariant(), Props, CategoryTooltip(), CategoryTooltipPayload, CategoryTooltipProps, CustomTooltip() (+14 more)
+Cohesion: 0.13
+Nodes (16): CategoryTooltip(), CategoryTooltipPayload, CategoryTooltipProps, COLORS, PieVariant(), Props, Props, RadarVariant() (+8 more)
 
 ### Community 10 - "Data Card Tsx"
 Cohesion: 0.33
@@ -604,12 +602,12 @@ Cohesion: 0.33
 Nodes (5): 0001 — transactions.date is timestamp without time zone, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 13 - "PR Overview Descriptive Title"
-Cohesion: 0.19
-Nodes (11): Props, Select(), Dialog(), DialogContent(), DialogDescription(), DialogFooter(), DialogHeader(), DialogOverlay() (+3 more)
+Cohesion: 0.18
+Nodes (14): ImportableTransactionField, isImportableTransactionField(), options, Props, TableHeadSelect(), Select(), SelectContent(), SelectItem() (+6 more)
 
 ### Community 14 - "0002 Snapshot Json"
-Cohesion: 0.11
-Nodes (22): AccountFilter(), DateFilter(), Preset, PresetKey, PRESETS, Props, Filters(), NavButton() (+14 more)
+Cohesion: 0.08
+Nodes (38): DateFilter(), Preset, PresetKey, PRESETS, DatePicker(), Props, NavButton(), Props (+30 more)
 
 ### Community 16 - "Project Polish Pr Summary"
 Cohesion: 0.20
@@ -617,11 +615,11 @@ Nodes (9): Follow-Up Memory, Implemented Scope, Last Verified, Local Database, M
 
 ### Community 17 - "Transactions Ts"
 Cohesion: 0.01
-Nodes (148): Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody, CreateCategoryJSONRequestBody (+140 more)
+Nodes (140): Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody, CreateCategoryJSONRequestBody (+132 more)
 
 ### Community 18 - "0001 Snapshot Json"
-Cohesion: 0.27
-Nodes (5): Props, Header(), HeaderLogo(), Navigation(), WelcomeMsg()
+Cohesion: 0.21
+Nodes (7): Props, AccountFilter(), Filters(), Header(), HeaderLogo(), Navigation(), WelcomeMsg()
 
 ### Community 19 - "Json Editor Code Actions"
 Cohesion: 0.15
@@ -632,8 +630,8 @@ Cohesion: 0.13
 Nodes (17): app, app, app, AppType, DELETE, GET, OPTIONS, PATCH (+9 more)
 
 ### Community 23 - "Nuchi Project Context"
-Cohesion: 0.11
-Nodes (26): DatePicker(), FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem(), FormItemContext (+18 more)
+Cohesion: 0.08
+Nodes (35): FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem(), FormItemContext, FormItemContextValue (+27 more)
 
 ### Community 24 - "Transactions API"
 Cohesion: 0.08
@@ -656,8 +654,8 @@ Cohesion: 0.25
 Nodes (6): geistMono, geistSans, metadata, Toaster(), sonner, SheetProvider()
 
 ### Community 32 - "Current API Parity Fixtures"
-Cohesion: 0.07
-Nodes (57): assertCascadingUserFK(), assertUniqueColumn(), Context, Pool, T, TestAuthBaseSchema_LiveDatabase(), Context, Pool (+49 more)
+Cohesion: 0.06
+Nodes (66): databaseHost(), main(), assertCascadingUserFK(), assertUniqueColumn(), Context, Pool, T, TestAuthBaseSchema_LiveDatabase() (+58 more)
 
 ### Community 33 - "Dev Dependencies"
 Cohesion: 0.04
@@ -684,24 +682,24 @@ Cohesion: 0.33
 Nodes (5): 0002 — Finance tables use text cuid IDs; UUID default is v4, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 40 - "Roadmap Tech Debt Backlog"
-Cohesion: 0.13
-Nodes (21): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), Props, ImportableTransactionField, DataTableProps (+13 more)
+Cohesion: 0.31
+Nodes (10): Props, DataTableProps, Table(), TableBody(), TableCaption(), TableCell(), TableFooter(), TableHead() (+2 more)
 
 ### Community 41 - "New Router"
 Cohesion: 0.08
 Nodes (24): For /graphify add and --watch, For /graphify query, For the commit hook and native CLAUDE.md integration, For --update and --cluster-only, /graphify, Honesty Rules, Interpreter guard for subcommands, Part A - Structural extraction for code files (+16 more)
 
 ### Community 42 - "Api Error"
-Cohesion: 0.09
-Nodes (30): Actions(), Props, Actions(), Props, CategoryColumn(), Props, CardAction(), CardFooter() (+22 more)
+Cohesion: 0.14
+Nodes (18): Actions(), Props, Actions(), Props, CategoryColumn(), Props, DropdownMenu(), DropdownMenuTrigger() (+10 more)
 
 ### Community 43 - "Edit Account Sheet Tsx"
 Cohesion: 0.18
 Nodes (10): Commands, Current Risk Areas, Env, graphify, Nuchi Codex Guide, Pull Requests Hard Rules, Reference, Repo Rules (+2 more)
 
 ### Community 45 - "Indexes Columns"
-Cohesion: 0.39
-Nodes (6): AmountInput(), Props, Tooltip(), TooltipContent(), TooltipProvider(), TooltipTrigger()
+Cohesion: 0.20
+Nodes (10): AmountInput(), Props, Props, Select(), Tooltip(), TooltipContent(), TooltipProvider(), TooltipTrigger() (+2 more)
 
 ### Community 47 - "Plaid Id"
 Cohesion: 0.15
@@ -792,8 +790,8 @@ Cohesion: 0.33
 Nodes (5): 0011 — No resend endpoint; email delivery is fire-and-forget, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 260 - "name"
-Cohesion: 0.40
-Nodes (4): CategoriesPage(), useBulkDeleteCategories(), NewCategoryState, useNewCategory
+Cohesion: 0.19
+Nodes (11): AreaVariant(), Props, BarVariant(), Props, ChartEnum, Props, CustomTooltip(), CustomTooltipProps (+3 more)
 
 ### Community 293 - "name"
 Cohesion: 0.28
@@ -820,8 +818,8 @@ Cohesion: 0.05
 Nodes (21): BulkCreateTransactions500JSONResponse, BulkDeleteAccounts500JSONResponse, BulkDeleteCategories500JSONResponse, BulkDeleteTransactions500JSONResponse, CreateAccount500JSONResponse, CreateCategory500JSONResponse, CreateTransaction500JSONResponse, DatabaseErrorJSONResponse (+13 more)
 
 ### Community 317 - "notNull"
-Cohesion: 0.10
-Nodes (33): isImportableTransactionField(), options, Props, TableHeadSelect(), Chart(), ChartEnum, ChartLoading(), Props (+25 more)
+Cohesion: 0.18
+Nodes (17): columns, columns, boxVariant, BoxVariants, DataCard(), DataCardProps, iconVariant, IconVariants (+9 more)
 
 ### Community 320 - "name"
 Cohesion: 0.25
@@ -844,8 +842,8 @@ Cohesion: 0.33
 Nodes (5): 0005 — Category duplicate update returns 500, create returns 409, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 348 - "type"
-Cohesion: 0.16
-Nodes (16): Actions(), Props, AccountColumn(), Props, ResponseType, useDeleteAccount(), RequestType, ResponseType (+8 more)
+Cohesion: 0.18
+Nodes (15): Actions(), Props, AccountColumn(), Props, ResponseType, useDeleteAccount(), RequestType, ResponseType (+7 more)
 
 ### Community 353 - "0006 — transactions.amount is 32-bit, capping a single transaction near ±2.1M ARS"
 Cohesion: 0.33
@@ -896,8 +894,8 @@ Cohesion: 0.33
 Nodes (5): For /graphify explain, For /graphify path, graphify reference: query, path, explain, Step 0 — Constrained query expansion (REQUIRED before traversal), Step 1 — Traversal
 
 ### Community 379 - "name"
-Cohesion: 0.14
-Nodes (14): INITIAL_IMPORT_RESULTS, TransactionsPage(), VARIANTS, CSVReaderRenderProps, CSVUploadResults, Props, UploadButton(), RequestType (+6 more)
+Cohesion: 0.21
+Nodes (8): columns, INITIAL_IMPORT_RESULTS, VARIANTS, CSVReaderRenderProps, CSVUploadResults, Props, UploadButton(), chunkItems()
 
 ### Community 388 - ".UpdateCategory"
 Cohesion: 0.40
@@ -936,8 +934,8 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: give it a last review of all the files changend in the pr the comments and all that is in place right now in the pr leave comments for medim-high and high issues mid-low and low forget it we mande 3 iterations so far. if something is too big then addres it consitently here so it so i can anlyze it, Source Nodes
 
 ### Community 432 - "GetSummary200JSONResponse"
-Cohesion: 0.10
-Nodes (25): RequestType, ResponseType, RequestType, ResponseType, ResponseType, useDeleteCategory(), RequestType, ResponseType (+17 more)
+Cohesion: 0.07
+Nodes (27): ResponseType, ResponseType, ResponseType, Badge(), badgeVariants, Checkbox(), RequestType, ResponseType (+19 more)
 
 ### Community 435 - "name"
 Cohesion: 0.38
@@ -976,8 +974,8 @@ Cohesion: 0.40
 Nodes (3): GetSummary400JSONResponse, InvalidDateQueryErrorJSONResponse, ListTransactions400JSONResponse
 
 ### Community 510 - "LogoutUser200JSONResponse"
-Cohesion: 0.18
-Nodes (15): Sheet(), SheetContent(), SheetDescription(), SheetHeader(), SheetTitle(), accountsRelations, categoriesRelations, citext (+7 more)
+Cohesion: 0.14
+Nodes (9): ApiError, ApiErrorResponse, BulkCreateTransactions429JSONResponse, BulkDeleteTransactions429JSONResponse, CreateTransaction429JSONResponse, DeleteTransaction429JSONResponse, TransactionMutationRateLimitErrorJSONResponse, TransactionMutationRateLimitErrorResponseHeaders (+1 more)
 
 ### Community 511 - "BulkDeleteTransactions200JSONResponse"
 Cohesion: 0.33
@@ -986,10 +984,6 @@ Nodes (5): 0012 — Residual timing oracle on password-reset request, How it was
 ### Community 512 - "GetSummary200JSONResponse"
 Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: Review PR #64 against post-merge PR #62 comment and issue #63, Source Nodes
-
-### Community 513 - ".CreateCategory"
-Cohesion: 0.14
-Nodes (5): RequestType, ResponseType, RequestType, ResponseType, ApiError
 
 ### Community 514 - "RegisterUser201JSONResponse"
 Cohesion: 0.50
@@ -1000,20 +994,16 @@ Cohesion: 0.60
 Nodes (4): getQueryClient(), makeQueryClient(), Props, QueryProvider()
 
 ### Community 517 - "RegisterUser201JSONResponse"
-Cohesion: 0.20
-Nodes (9): columns, ResponseType, columns, ResponseType, columns, ResponseType, Badge(), badgeVariants (+1 more)
+Cohesion: 0.26
+Nodes (9): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), ImportedTransactionRow, ImportedTransactionRowError, parseImportedTransactionRows() (+1 more)
 
 ### Community 518 - "graphify reference: query, path, explain"
-Cohesion: 0.18
-Nodes (18): InsertTransactionSchema, useCreateAccount(), useGetAccounts(), NewAccountSheet(), useSelectAccount(), useCreateCategory(), useGetCategories(), NewCategorySheet() (+10 more)
+Cohesion: 0.08
+Nodes (45): AccountsPage(), CategoriesPage(), TransactionsPage(), routes, Sheet(), SheetContent(), SheetDescription(), SheetHeader() (+37 more)
 
 ### Community 519 - "README.md"
 Cohesion: 0.22
 Nodes (5): Codex Backend Improvements, Decision hierarchy, Definition of done for an endpoint, How to use this set, Source set
-
-### Community 520 - "amount-input.tsx"
-Cohesion: 0.40
-Nodes (4): AccountsPage(), useBulkDeleteAccounts(), NewAccountState, useNewAccount
 
 ### Community 521 - "Target Backend Architecture"
 Cohesion: 0.22
@@ -1036,8 +1026,8 @@ Cohesion: 0.25
 Nodes (7): Current State and Constraints, Deferred behavior and schema decisions already recorded, Evidence that must be refreshed before implementation, Existing strengths to preserve, Gaps this project must close, Migration boundary, Snapshot
 
 ### Community 526 - "graphify reference: add a URL and watch a folder"
-Cohesion: 0.47
-Nodes (3): DataCardLoading(), DataGrid(), formatDateRange()
+Cohesion: 0.24
+Nodes (8): Chart(), ChartLoading(), DataCardLoading(), DataCharts(), DataGrid(), SpendingPie(), SpendingPieLoading(), useGetSummary()
 
 ### Community 527 - "graphify reference: commit hook and native CLAUDE.md integration"
 Cohesion: 0.40
@@ -1079,12 +1069,12 @@ Nodes (6): API Contract and Documentation Standard, Contract workflow, Documenta
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `ApiErrorResponse` connect `Transactions Ts` to `Page Tsx`, `Components Json`?**
-  _High betweenness centrality (0.029) - this node is a cross-community bridge._
-- **Why does `decodeAPIError()` connect `Components Json` to `Transactions Ts`?**
-  _High betweenness centrality (0.024) - this node is a cross-community bridge._
+- **Why does `New()` connect `Page Tsx` to `Current API Parity Fixtures`, `Components Json`?**
+  _High betweenness centrality (0.027) - this node is a cross-community bridge._
+- **Why does `ApiErrorResponse` connect `LogoutUser200JSONResponse` to `Transactions Ts`, `Page Tsx`, `Components Json`?**
+  _High betweenness centrality (0.026) - this node is a cross-community bridge._
 - **Why does `toAuthUser()` connect `Page Tsx` to `notNull`, `Route Ts`?**
-  _High betweenness centrality (0.024) - this node is a cross-community bridge._
+  _High betweenness centrality (0.025) - this node is a cross-community bridge._
 - **Are the 20 inferred relationships involving `newAuthTestEnv()` (e.g. with `NewPool()` and `NewAuthServer()`) actually correct?**
   _`newAuthTestEnv()` has 20 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Props`, `ResponseType`, `Props` to the rest of the system?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -50,7 +50,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions",
-      "community": 42,
+      "community": 348,
       "norm_label": "actions.tsx"
     },
     {
@@ -60,7 +60,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions_props",
-      "community": 42,
+      "community": 348,
       "norm_label": "props"
     },
     {
@@ -70,7 +70,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions_actions",
-      "community": 517,
+      "community": 348,
       "norm_label": "actions()"
     },
     {
@@ -110,7 +110,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_accounts_page",
-      "community": 520,
+      "community": 317,
       "norm_label": "page.tsx"
     },
     {
@@ -190,7 +190,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_categories_page",
-      "community": 260,
+      "community": 317,
       "norm_label": "page.tsx"
     },
     {
@@ -260,7 +260,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_account_column",
-      "community": 517,
+      "community": 348,
       "norm_label": "account-column.tsx"
     },
     {
@@ -270,7 +270,7 @@
       "source_location": "L2",
       "_origin": "ast",
       "id": "app_dashboard_transactions_account_column_props",
-      "community": 517,
+      "community": 348,
       "norm_label": "props"
     },
     {
@@ -280,7 +280,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "app_dashboard_transactions_account_column_accountcolumn",
-      "community": 517,
+      "community": 348,
       "norm_label": "accountcolumn()"
     },
     {
@@ -380,7 +380,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card",
-      "community": 348,
+      "community": 40,
       "norm_label": "import-card.tsx"
     },
     {
@@ -390,7 +390,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_requiredoptions",
-      "community": 348,
+      "community": 40,
       "norm_label": "requiredoptions"
     },
     {
@@ -400,7 +400,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_selectedcolumnsstate",
-      "community": 348,
+      "community": 40,
       "norm_label": "selectedcolumnsstate"
     },
     {
@@ -410,7 +410,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_props",
-      "community": 348,
+      "community": 40,
       "norm_label": "props"
     },
     {
@@ -420,7 +420,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_importcard",
-      "community": 348,
+      "community": 40,
       "norm_label": "importcard()"
     },
     {
@@ -450,7 +450,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table_importtable",
-      "community": 348,
+      "community": 40,
       "norm_label": "importtable()"
     },
     {
@@ -540,7 +540,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_importabletransactionfield",
-      "community": 317,
+      "community": 40,
       "norm_label": "importabletransactionfield"
     },
     {
@@ -640,7 +640,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_api_route_categories",
-      "community": 45,
+      "community": 20,
       "norm_label": "categories.ts"
     },
     {
@@ -760,7 +760,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_api_route_summary",
-      "community": 45,
+      "community": 20,
       "norm_label": "summary.ts"
     },
     {
@@ -949,7 +949,7 @@
       "label": "IssueAccessToken()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt.go",
-      "source_location": "L26",
+      "source_location": "L39",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_issueaccesstoken",
       "community": 3,
@@ -989,7 +989,7 @@
       "label": "VerifyAccessToken()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt.go",
-      "source_location": "L54",
+      "source_location": "L74",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_verifyaccesstoken",
       "community": 3,
@@ -1009,7 +1009,7 @@
       "label": "TestIssueAndVerifyAccessToken_RoundTrip()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L11",
+      "source_location": "L12",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_test_testissueandverifyaccesstoken_roundtrip",
       "community": 3,
@@ -1029,7 +1029,7 @@
       "label": "TestIssueAccessToken_ClaimsAreMinimal()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L35",
+      "source_location": "L36",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_test_testissueaccesstoken_claimsareminimal",
       "community": 3,
@@ -1039,17 +1039,27 @@
       "label": "TestVerifyAccessToken_ExpiredRejected()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L66",
+      "source_location": "L67",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_test_testverifyaccesstoken_expiredrejected",
       "community": 3,
       "norm_label": "testverifyaccesstoken_expiredrejected()"
     },
     {
+      "label": "TestVerifyAccessToken_NonExpiryFailuresStayGeneric()",
+      "file_type": "code",
+      "source_file": "backend/internal/auth/jwt_test.go",
+      "source_location": "L94",
+      "_origin": "ast",
+      "id": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonexpiryfailuresstaygeneric",
+      "community": 3,
+      "norm_label": "testverifyaccesstoken_nonexpiryfailuresstaygeneric()"
+    },
+    {
       "label": "TestVerifyAccessToken_WrongSecretRejected()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L80",
+      "source_location": "L115",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_test_testverifyaccesstoken_wrongsecretrejected",
       "community": 3,
@@ -1059,7 +1069,7 @@
       "label": "TestVerifyAccessToken_GarbageTokenRejected()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L92",
+      "source_location": "L127",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_test_testverifyaccesstoken_garbagetokenrejected",
       "community": 3,
@@ -1069,7 +1079,7 @@
       "label": "TestVerifyAccessToken_RejectsAlgNone()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L108",
+      "source_location": "L143",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectsalgnone",
       "community": 3,
@@ -1079,7 +1089,7 @@
       "label": "TestVerifyAccessToken_RejectsSiblingHMACAlg()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L128",
+      "source_location": "L163",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectssiblinghmacalg",
       "community": 3,
@@ -1089,7 +1099,7 @@
       "label": "TestVerifyAccessToken_MissingExpRejected()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L150",
+      "source_location": "L185",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_test_testverifyaccesstoken_missingexprejected",
       "community": 3,
@@ -1099,7 +1109,7 @@
       "label": "TestVerifyAccessToken_NonUUIDSubjectRejected()",
       "file_type": "code",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L171",
+      "source_location": "L206",
       "_origin": "ast",
       "id": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonuuidsubjectrejected",
       "community": 3,
@@ -2651,7 +2661,7 @@
       "source_file": "",
       "source_location": "",
       "_origin": "ast",
-      "id": "queries",
+      "id": "backend_internal_db_gen_db_go_queries",
       "community": 3,
       "norm_label": "queries"
     },
@@ -3394,6 +3404,186 @@
       "id": "backend_internal_db_queries_live_test_testconsumerefreshtoken_concurrent",
       "community": 32,
       "norm_label": "testconsumerefreshtoken_concurrent()"
+    },
+    {
+      "label": "rls.go",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls",
+      "community": 32,
+      "norm_label": "rls.go"
+    },
+    {
+      "label": "WithUserTx()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L37",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_withusertx",
+      "community": 32,
+      "norm_label": "withusertx()"
+    },
+    {
+      "label": "Context",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_go_context",
+      "community": 32,
+      "norm_label": "context"
+    },
+    {
+      "label": "Pool",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_go_pool",
+      "community": 32,
+      "norm_label": "pool"
+    },
+    {
+      "label": "UUID",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_go_uuid",
+      "community": 32,
+      "norm_label": "uuid"
+    },
+    {
+      "label": "Queries",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_go_queries",
+      "community": 32,
+      "norm_label": "queries"
+    },
+    {
+      "label": "rls_test.go",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test",
+      "community": 32,
+      "norm_label": "rls_test.go"
+    },
+    {
+      "label": "createRLSTestUser()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_createrlstestuser",
+      "community": 32,
+      "norm_label": "createrlstestuser()"
+    },
+    {
+      "label": "Context",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_go_context",
+      "community": 32,
+      "norm_label": "context"
+    },
+    {
+      "label": "T",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_go_t",
+      "community": 32,
+      "norm_label": "t"
+    },
+    {
+      "label": "Pool",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_go_pool",
+      "community": 32,
+      "norm_label": "pool"
+    },
+    {
+      "label": "UUID",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_go_uuid",
+      "community": 32,
+      "norm_label": "uuid"
+    },
+    {
+      "label": "deleteRLSTestUsers()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L37",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_deleterlstestusers",
+      "community": 32,
+      "norm_label": "deleterlstestusers()"
+    },
+    {
+      "label": "createRLSTestAccount()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L47",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_createrlstestaccount",
+      "community": 32,
+      "norm_label": "createrlstestaccount()"
+    },
+    {
+      "label": "TestWithUserTx_OwnerRoundTrip_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L72",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
+      "community": 32,
+      "norm_label": "testwithusertx_ownerroundtrip_livedatabase()"
+    },
+    {
+      "label": "TestWithUserTx_PolicyBlocksCrossUserAccess_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L126",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
+      "community": 32,
+      "norm_label": "testwithusertx_policyblockscrossuseraccess_livedatabase()"
+    },
+    {
+      "label": "TestWithUserTx_UnboundTransactionFailsClosed_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L189",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "community": 32,
+      "norm_label": "testwithusertx_unboundtransactionfailsclosed_livedatabase()"
+    },
+    {
+      "label": "TestWithUserTx_RollsBackOnError_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L227",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
+      "community": 32,
+      "norm_label": "testwithusertx_rollsbackonerror_livedatabase()"
     },
     {
       "label": "auth.go",
@@ -4592,7 +4782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_livedb_test",
-      "community": 28,
+      "community": 35,
       "norm_label": "livedb_test.go"
     },
     {
@@ -4602,7 +4792,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "backend_internal_http_livedb_test_livedatabaseurl",
-      "community": 28,
+      "community": 35,
       "norm_label": "livedatabaseurl()"
     },
     {
@@ -4612,8 +4802,448 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_livedb_test_go_t",
-      "community": 28,
+      "community": 35,
       "norm_label": "t"
+    },
+    {
+      "label": "middleware.go",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware",
+      "community": 35,
+      "norm_label": "middleware.go"
+    },
+    {
+      "label": "userIDContextKey",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "http_useridcontextkey",
+      "community": 35,
+      "norm_label": "useridcontextkey"
+    },
+    {
+      "label": "UserIDFromContext()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_useridfromcontext",
+      "community": 35,
+      "norm_label": "useridfromcontext()"
+    },
+    {
+      "label": "Context",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_go_context",
+      "community": 35,
+      "norm_label": "context"
+    },
+    {
+      "label": "UUID",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_go_uuid",
+      "community": 35,
+      "norm_label": "uuid"
+    },
+    {
+      "label": "RequireAuth()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L55",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_requireauth",
+      "community": 35,
+      "norm_label": "requireauth()"
+    },
+    {
+      "label": "Handler",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_go_handler",
+      "community": 35,
+      "norm_label": "handler"
+    },
+    {
+      "label": "bearerToken()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L84",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_bearertoken",
+      "community": 35,
+      "norm_label": "bearertoken()"
+    },
+    {
+      "label": "writeAPIError()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L103",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_writeapierror",
+      "community": 35,
+      "norm_label": "writeapierror()"
+    },
+    {
+      "label": "ResponseWriter",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_go_responsewriter",
+      "community": 35,
+      "norm_label": "responsewriter"
+    },
+    {
+      "label": "ApiError",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "apierror",
+      "community": 35,
+      "norm_label": "apierror"
+    },
+    {
+      "label": "writeUnauthorizedError()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L109",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_writeunauthorizederror",
+      "community": 35,
+      "norm_label": "writeunauthorizederror()"
+    },
+    {
+      "label": "writeAccessTokenExpiredError()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L116",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_writeaccesstokenexpirederror",
+      "community": 35,
+      "norm_label": "writeaccesstokenexpirederror()"
+    },
+    {
+      "label": "middleware_live_test.go",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test",
+      "community": 35,
+      "norm_label": "middleware_live_test.go"
+    },
+    {
+      "label": "accountProbeHandler()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L30",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_accountprobehandler",
+      "community": 35,
+      "norm_label": "accountprobehandler()"
+    },
+    {
+      "label": "Pool",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_go_pool",
+      "community": 35,
+      "norm_label": "pool"
+    },
+    {
+      "label": "HandlerFunc",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_go_handlerfunc",
+      "community": 35,
+      "norm_label": "handlerfunc"
+    },
+    {
+      "label": "newAccountProbeRouter()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L68",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_newaccountproberouter",
+      "community": 35,
+      "norm_label": "newaccountproberouter()"
+    },
+    {
+      "label": "Handler",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_go_handler",
+      "community": 35,
+      "norm_label": "handler"
+    },
+    {
+      "label": "TestRequireAuth_WithUserTx_CrossUserIsolation_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L85",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
+      "community": 35,
+      "norm_label": "testrequireauth_withusertx_crossuserisolation_livedatabase()"
+    },
+    {
+      "label": "T",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_go_t",
+      "community": 35,
+      "norm_label": "t"
+    },
+    {
+      "label": "probeAccountVisibility()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L141",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_probeaccountvisibility",
+      "community": 35,
+      "norm_label": "probeaccountvisibility()"
+    },
+    {
+      "label": "createProbeTestUser()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L162",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_createprobetestuser",
+      "community": 35,
+      "norm_label": "createprobetestuser()"
+    },
+    {
+      "label": "Context",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_go_context",
+      "community": 35,
+      "norm_label": "context"
+    },
+    {
+      "label": "UUID",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_live_test_go_uuid",
+      "community": 35,
+      "norm_label": "uuid"
+    },
+    {
+      "label": "middleware_test.go",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test",
+      "community": 3,
+      "norm_label": "middleware_test.go"
+    },
+    {
+      "label": "newProbeRouter()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_newproberouter",
+      "community": 3,
+      "norm_label": "newproberouter()"
+    },
+    {
+      "label": "HandlerFunc",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_go_handlerfunc",
+      "community": 3,
+      "norm_label": "handlerfunc"
+    },
+    {
+      "label": "Handler",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_go_handler",
+      "community": 3,
+      "norm_label": "handler"
+    },
+    {
+      "label": "contextEchoProbe()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L38",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_contextechoprobe",
+      "community": 35,
+      "norm_label": "contextechoprobe()"
+    },
+    {
+      "label": "ResponseWriter",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_go_responsewriter",
+      "community": 35,
+      "norm_label": "responsewriter"
+    },
+    {
+      "label": "Request",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_go_request",
+      "community": 35,
+      "norm_label": "request"
+    },
+    {
+      "label": "decodeMiddlewareAPIError()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L49",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "community": 3,
+      "norm_label": "decodemiddlewareapierror()"
+    },
+    {
+      "label": "T",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_go_t",
+      "community": 3,
+      "norm_label": "t"
+    },
+    {
+      "label": "ResponseRecorder",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_go_responserecorder",
+      "community": 3,
+      "norm_label": "responserecorder"
+    },
+    {
+      "label": "doProbeRequest()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L58",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_doproberequest",
+      "community": 3,
+      "norm_label": "doproberequest()"
+    },
+    {
+      "label": "TestRequireAuth_MissingHeader_Unauthorized()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L75",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_testrequireauth_missingheader_unauthorized",
+      "community": 3,
+      "norm_label": "testrequireauth_missingheader_unauthorized()"
+    },
+    {
+      "label": "TestRequireAuth_MalformedHeader_Unauthorized()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L93",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_testrequireauth_malformedheader_unauthorized",
+      "community": 3,
+      "norm_label": "testrequireauth_malformedheader_unauthorized()"
+    },
+    {
+      "label": "TestRequireAuth_WrongSecret_Unauthorized()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L118",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_testrequireauth_wrongsecret_unauthorized",
+      "community": 3,
+      "norm_label": "testrequireauth_wrongsecret_unauthorized()"
+    },
+    {
+      "label": "TestRequireAuth_ExpiredToken_AccessTokenExpired()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L138",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_testrequireauth_expiredtoken_accesstokenexpired",
+      "community": 3,
+      "norm_label": "testrequireauth_expiredtoken_accesstokenexpired()"
+    },
+    {
+      "label": "TestRequireAuth_RejectsAlgPolicyViolations()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L162",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_testrequireauth_rejectsalgpolicyviolations",
+      "community": 3,
+      "norm_label": "testrequireauth_rejectsalgpolicyviolations()"
+    },
+    {
+      "label": "TestRequireAuth_ValidToken_ExposesUserID()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L198",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_testrequireauth_validtoken_exposesuserid",
+      "community": 3,
+      "norm_label": "testrequireauth_validtoken_exposesuserid()"
+    },
+    {
+      "label": "TestRequireAuth_BodyIdentityIsIgnored()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L223",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_testrequireauth_bodyidentityisignored",
+      "community": 3,
+      "norm_label": "testrequireauth_bodyidentityisignored()"
+    },
+    {
+      "label": "TestRequireAuth_NoUserInContext_WhenUnauthenticated()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L251",
+      "_origin": "ast",
+      "id": "backend_internal_http_middleware_test_testrequireauth_nouserincontext_whenunauthenticated",
+      "community": 3,
+      "norm_label": "testrequireauth_nouserincontext_whenunauthenticated()"
     },
     {
       "label": "router.go",
@@ -4629,7 +5259,7 @@
       "label": "NewRouter()",
       "file_type": "code",
       "source_file": "backend/internal/http/router.go",
-      "source_location": "L16",
+      "source_location": "L21",
       "_origin": "ast",
       "id": "backend_internal_http_router_newrouter",
       "community": 28,
@@ -6212,7 +6842,7 @@
       "source_location": "L1493",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror",
-      "community": 532,
+      "community": 17,
       "norm_label": "unescapedcookieparamerror"
     },
     {
@@ -6222,7 +6852,7 @@
       "source_location": "L1498",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_error",
-      "community": 532,
+      "community": 17,
       "norm_label": ".error()"
     },
     {
@@ -6232,7 +6862,7 @@
       "source_location": "L1502",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_unwrap",
-      "community": 532,
+      "community": 17,
       "norm_label": ".unwrap()"
     },
     {
@@ -6292,7 +6922,7 @@
       "source_location": "L1527",
       "_origin": "ast",
       "id": "openapi_requiredheadererror",
-      "community": 17,
+      "community": 537,
       "norm_label": "requiredheadererror"
     },
     {
@@ -6302,7 +6932,7 @@
       "source_location": "L1532",
       "_origin": "ast",
       "id": "openapi_requiredheadererror_error",
-      "community": 17,
+      "community": 537,
       "norm_label": ".error()"
     },
     {
@@ -6312,7 +6942,7 @@
       "source_location": "L1536",
       "_origin": "ast",
       "id": "openapi_requiredheadererror_unwrap",
-      "community": 17,
+      "community": 537,
       "norm_label": ".unwrap()"
     },
     {
@@ -7772,7 +8402,7 @@
       "source_location": "L2447",
       "_origin": "ast",
       "id": "openapi_registeruser201jsonresponse",
-      "community": 538,
+      "community": 17,
       "norm_label": "registeruser201jsonresponse"
     },
     {
@@ -7782,7 +8412,7 @@
       "source_location": "L2449",
       "_origin": "ast",
       "id": "openapi_registeruser201jsonresponse_visitregisteruserresponse",
-      "community": 538,
+      "community": 17,
       "norm_label": ".visitregisteruserresponse()"
     },
     {
@@ -7942,7 +8572,7 @@
       "source_location": "L2546",
       "_origin": "ast",
       "id": "openapi_listcategories200jsonresponse",
-      "community": 537,
+      "community": 17,
       "norm_label": "listcategories200jsonresponse"
     },
     {
@@ -7952,7 +8582,7 @@
       "source_location": "L2548",
       "_origin": "ast",
       "id": "openapi_listcategories200jsonresponse_visitlistcategoriesresponse",
-      "community": 537,
+      "community": 17,
       "norm_label": ".visitlistcategoriesresponse()"
     },
     {
@@ -8162,7 +8792,7 @@
       "source_location": "L2676",
       "_origin": "ast",
       "id": "openapi_bulkdeletecategories200jsonresponse",
-      "community": 534,
+      "community": 17,
       "norm_label": "bulkdeletecategories200jsonresponse"
     },
     {
@@ -8172,7 +8802,7 @@
       "source_location": "L2678",
       "_origin": "ast",
       "id": "openapi_bulkdeletecategories200jsonresponse_visitbulkdeletecategoriesresponse",
-      "community": 534,
+      "community": 17,
       "norm_label": ".visitbulkdeletecategoriesresponse()"
     },
     {
@@ -8692,7 +9322,7 @@
       "source_location": "L3018",
       "_origin": "ast",
       "id": "openapi_getsummary200jsonresponse",
-      "community": 536,
+      "community": 17,
       "norm_label": "getsummary200jsonresponse"
     },
     {
@@ -8702,7 +9332,7 @@
       "source_location": "L3020",
       "_origin": "ast",
       "id": "openapi_getsummary200jsonresponse_visitgetsummaryresponse",
-      "community": 536,
+      "community": 17,
       "norm_label": ".visitgetsummaryresponse()"
     },
     {
@@ -9222,7 +9852,7 @@
       "source_location": "L3364",
       "_origin": "ast",
       "id": "openapi_bulkdeletetransactions200jsonresponse",
-      "community": 535,
+      "community": 17,
       "norm_label": "bulkdeletetransactions200jsonresponse"
     },
     {
@@ -9232,7 +9862,7 @@
       "source_location": "L3366",
       "_origin": "ast",
       "id": "openapi_bulkdeletetransactions200jsonresponse_visitbulkdeletetransactionsresponse",
-      "community": 535,
+      "community": 17,
       "norm_label": ".visitbulkdeletetransactionsresponse()"
     },
     {
@@ -9502,7 +10132,7 @@
       "source_location": "L3562",
       "_origin": "ast",
       "id": "openapi_gettransaction200jsonresponse",
-      "community": 17,
+      "community": 539,
       "norm_label": "gettransaction200jsonresponse"
     },
     {
@@ -9512,7 +10142,7 @@
       "source_location": "L3564",
       "_origin": "ast",
       "id": "openapi_gettransaction200jsonresponse_visitgettransactionresponse",
-      "community": 17,
+      "community": 539,
       "norm_label": ".visitgettransactionresponse()"
     },
     {
@@ -10312,7 +10942,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_account_filter_accountfilter",
-      "community": 18,
+      "community": 14,
       "norm_label": "accountfilter()"
     },
     {
@@ -10352,7 +10982,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_area_variant",
-      "community": 35,
+      "community": 9,
       "norm_label": "area-variant.tsx"
     },
     {
@@ -10362,7 +10992,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_area_variant_props",
-      "community": 35,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -10372,7 +11002,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_area_variant_areavariant",
-      "community": 35,
+      "community": 9,
       "norm_label": "areavariant()"
     },
     {
@@ -10382,7 +11012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_bar_variant",
-      "community": 35,
+      "community": 9,
       "norm_label": "bar-variant.tsx"
     },
     {
@@ -10392,7 +11022,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_bar_variant_props",
-      "community": 35,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -10402,7 +11032,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_bar_variant_barvariant",
-      "community": 35,
+      "community": 9,
       "norm_label": "barvariant()"
     },
     {
@@ -10482,7 +11112,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "components_chart_chart",
-      "community": 514,
+      "community": 317,
       "norm_label": "chart()"
     },
     {
@@ -10492,7 +11122,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "components_chart_chartloading",
-      "community": 514,
+      "community": 317,
       "norm_label": "chartloading()"
     },
     {
@@ -10502,7 +11132,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_count_up",
-      "community": 41,
+      "community": 317,
       "norm_label": "count-up.tsx"
     },
     {
@@ -10512,7 +11142,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_custom_tooltip",
-      "community": 35,
+      "community": 9,
       "norm_label": "custom-tooltip.tsx"
     },
     {
@@ -10522,7 +11152,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "components_custom_tooltip_tooltippayloaditem",
-      "community": 35,
+      "community": 9,
       "norm_label": "tooltippayloaditem"
     },
     {
@@ -10532,7 +11162,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_custom_tooltip_customtooltipprops",
-      "community": 35,
+      "community": 9,
       "norm_label": "customtooltipprops"
     },
     {
@@ -10542,7 +11172,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "components_custom_tooltip_customtooltip",
-      "community": 35,
+      "community": 9,
       "norm_label": "customtooltip()"
     },
     {
@@ -10552,7 +11182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_card",
-      "community": 41,
+      "community": 317,
       "norm_label": "data-card.tsx"
     },
     {
@@ -10562,7 +11192,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "components_data_card_boxvariant",
-      "community": 41,
+      "community": 317,
       "norm_label": "boxvariant"
     },
     {
@@ -10572,7 +11202,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "components_data_card_iconvariant",
-      "community": 41,
+      "community": 317,
       "norm_label": "iconvariant"
     },
     {
@@ -10582,7 +11212,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "components_data_card_boxvariants",
-      "community": 41,
+      "community": 317,
       "norm_label": "boxvariants"
     },
     {
@@ -10592,7 +11222,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "components_data_card_iconvariants",
-      "community": 41,
+      "community": 317,
       "norm_label": "iconvariants"
     },
     {
@@ -10602,7 +11232,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "components_data_card_datacardprops",
-      "community": 41,
+      "community": 317,
       "norm_label": "datacardprops"
     },
     {
@@ -10612,7 +11242,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "components_data_card_datacard",
-      "community": 41,
+      "community": 317,
       "norm_label": "datacard()"
     },
     {
@@ -10632,7 +11262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_charts",
-      "community": 514,
+      "community": 317,
       "norm_label": "data-charts.tsx"
     },
     {
@@ -10642,7 +11272,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_data_charts_datacharts",
-      "community": 526,
+      "community": 317,
       "norm_label": "datacharts()"
     },
     {
@@ -10692,7 +11322,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "components_data_table_datatable",
-      "community": 260,
+      "community": 317,
       "norm_label": "datatable()"
     },
     {
@@ -10782,7 +11412,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_filters",
-      "community": 18,
+      "community": 14,
       "norm_label": "filters.tsx"
     },
     {
@@ -10792,7 +11422,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "components_filters_filters",
-      "community": 18,
+      "community": 14,
       "norm_label": "filters()"
     },
     {
@@ -10842,7 +11472,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_line_variant",
-      "community": 35,
+      "community": 9,
       "norm_label": "line-variant.tsx"
     },
     {
@@ -10852,7 +11482,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_line_variant_props",
-      "community": 35,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -10862,7 +11492,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_line_variant_linevariant",
-      "community": 35,
+      "community": 9,
       "norm_label": "linevariant()"
     },
     {
@@ -10872,7 +11502,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_nav_button",
-      "community": 376,
+      "community": 14,
       "norm_label": "nav-button.tsx"
     },
     {
@@ -10882,7 +11512,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_nav_button_props",
-      "community": 376,
+      "community": 14,
       "norm_label": "props"
     },
     {
@@ -10892,7 +11522,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "components_nav_button_navbutton",
-      "community": 376,
+      "community": 14,
       "norm_label": "navbutton()"
     },
     {
@@ -10902,7 +11532,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_navigation",
-      "community": 510,
+      "community": 14,
       "norm_label": "navigation.tsx"
     },
     {
@@ -10912,7 +11542,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_navigation_routes",
-      "community": 510,
+      "community": 14,
       "norm_label": "routes"
     },
     {
@@ -10982,7 +11612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_radar_variant",
-      "community": 514,
+      "community": 317,
       "norm_label": "radar-variant.tsx"
     },
     {
@@ -10992,7 +11622,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_radar_variant_props",
-      "community": 514,
+      "community": 317,
       "norm_label": "props"
     },
     {
@@ -11002,7 +11632,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_radar_variant_radarvariant",
-      "community": 514,
+      "community": 317,
       "norm_label": "radarvariant()"
     },
     {
@@ -11082,7 +11712,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_spending_pie",
-      "community": 514,
+      "community": 317,
       "norm_label": "spending-pie.tsx"
     },
     {
@@ -11092,7 +11722,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_spending_pie_props",
-      "community": 514,
+      "community": 317,
       "norm_label": "props"
     },
     {
@@ -11102,7 +11732,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieenum",
-      "community": 514,
+      "community": 317,
       "norm_label": "spendingpieenum"
     },
     {
@@ -11112,7 +11742,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpie",
-      "community": 514,
+      "community": 317,
       "norm_label": "spendingpie()"
     },
     {
@@ -11122,7 +11752,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieloading",
-      "community": 514,
+      "community": 317,
       "norm_label": "spendingpieloading()"
     },
     {
@@ -11222,7 +11852,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_card",
-      "community": 41,
+      "community": 317,
       "norm_label": "card.tsx"
     },
     {
@@ -11232,7 +11862,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_ui_card_card",
-      "community": 41,
+      "community": 317,
       "norm_label": "card()"
     },
     {
@@ -11242,7 +11872,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "components_ui_card_cardheader",
-      "community": 41,
+      "community": 317,
       "norm_label": "cardheader()"
     },
     {
@@ -11252,7 +11882,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "components_ui_card_cardtitle",
-      "community": 41,
+      "community": 317,
       "norm_label": "cardtitle()"
     },
     {
@@ -11262,7 +11892,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "components_ui_card_carddescription",
-      "community": 41,
+      "community": 317,
       "norm_label": "carddescription()"
     },
     {
@@ -11272,7 +11902,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "components_ui_card_cardaction",
-      "community": 41,
+      "community": 42,
       "norm_label": "cardaction()"
     },
     {
@@ -11282,7 +11912,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "components_ui_card_cardcontent",
-      "community": 41,
+      "community": 317,
       "norm_label": "cardcontent()"
     },
     {
@@ -11292,7 +11922,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "components_ui_card_cardfooter",
-      "community": 41,
+      "community": 42,
       "norm_label": "cardfooter()"
     },
     {
@@ -11432,7 +12062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdown-menu.tsx"
     },
     {
@@ -11452,7 +12082,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuportal",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenuportal()"
     },
     {
@@ -11472,7 +12102,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenucontent",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenucontent()"
     },
     {
@@ -11482,7 +12112,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenugroup",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenugroup()"
     },
     {
@@ -11492,7 +12122,7 @@
       "source_location": "L62",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuitem",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenuitem()"
     },
     {
@@ -11502,7 +12132,7 @@
       "source_location": "L85",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenucheckboxitem",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenucheckboxitem()"
     },
     {
@@ -11512,7 +12142,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuradiogroup",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenuradiogroup()"
     },
     {
@@ -11522,7 +12152,7 @@
       "source_location": "L122",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuradioitem",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenuradioitem()"
     },
     {
@@ -11532,7 +12162,7 @@
       "source_location": "L146",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenulabel",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenulabel()"
     },
     {
@@ -11542,7 +12172,7 @@
       "source_location": "L166",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuseparator",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenuseparator()"
     },
     {
@@ -11552,7 +12182,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenushortcut",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenushortcut()"
     },
     {
@@ -11562,7 +12192,7 @@
       "source_location": "L195",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenusub",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenusub()"
     },
     {
@@ -11572,7 +12202,7 @@
       "source_location": "L201",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenusubtrigger",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenusubtrigger()"
     },
     {
@@ -11582,7 +12212,7 @@
       "source_location": "L225",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenusubcontent",
-      "community": 376,
+      "community": 42,
       "norm_label": "dropdownmenusubcontent()"
     },
     {
@@ -11732,7 +12362,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_label",
-      "community": 376,
+      "community": 23,
       "norm_label": "label.tsx"
     },
     {
@@ -11742,7 +12372,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_ui_label_label",
-      "community": 376,
+      "community": 23,
       "norm_label": "label()"
     },
     {
@@ -11892,7 +12522,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "components_ui_select_selectlabel",
-      "community": 317,
+      "community": 42,
       "norm_label": "selectlabel()"
     },
     {
@@ -11912,7 +12542,7 @@
       "source_location": "L130",
       "_origin": "ast",
       "id": "components_ui_select_selectseparator",
-      "community": 317,
+      "community": 42,
       "norm_label": "selectseparator()"
     },
     {
@@ -11922,7 +12552,7 @@
       "source_location": "L143",
       "_origin": "ast",
       "id": "components_ui_select_selectscrollupbutton",
-      "community": 317,
+      "community": 42,
       "norm_label": "selectscrollupbutton()"
     },
     {
@@ -11932,7 +12562,7 @@
       "source_location": "L161",
       "_origin": "ast",
       "id": "components_ui_select_selectscrolldownbutton",
-      "community": 317,
+      "community": 42,
       "norm_label": "selectscrolldownbutton()"
     },
     {
@@ -11942,7 +12572,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_separator",
-      "community": 35,
+      "community": 9,
       "norm_label": "separator.tsx"
     },
     {
@@ -11952,7 +12582,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_ui_separator_separator",
-      "community": 35,
+      "community": 9,
       "norm_label": "separator()"
     },
     {
@@ -11982,7 +12612,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_ui_sheet_sheettrigger",
-      "community": 510,
+      "community": 14,
       "norm_label": "sheettrigger()"
     },
     {
@@ -12012,7 +12642,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetoverlay",
-      "community": 376,
+      "community": 42,
       "norm_label": "sheetoverlay()"
     },
     {
@@ -12042,7 +12672,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetfooter",
-      "community": 376,
+      "community": 42,
       "norm_label": "sheetfooter()"
     },
     {
@@ -12072,7 +12702,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_skeleton",
-      "community": 514,
+      "community": 317,
       "norm_label": "skeleton.tsx"
     },
     {
@@ -12082,7 +12712,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "components_ui_skeleton_skeleton",
-      "community": 514,
+      "community": 317,
       "norm_label": "skeleton()"
     },
     {
@@ -12202,7 +12832,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_textarea",
-      "community": 376,
+      "community": 23,
       "norm_label": "textarea.tsx"
     },
     {
@@ -12212,7 +12842,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_ui_textarea_textarea",
-      "community": 376,
+      "community": 23,
       "norm_label": "textarea()"
     },
     {
@@ -12272,7 +12902,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_visually_hidden",
-      "community": 510,
+      "community": 14,
       "norm_label": "visually-hidden.tsx"
     },
     {
@@ -12282,7 +12912,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_ui_visually_hidden_visuallyhidden",
-      "community": 510,
+      "community": 14,
       "norm_label": "visuallyhidden()"
     },
     {
@@ -12352,7 +12982,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "db_connection_getdatabaseurl",
-      "community": 354,
+      "community": 49,
       "norm_label": "getdatabaseurl()"
     },
     {
@@ -12422,7 +13052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "db_drizzle",
-      "community": 45,
+      "community": 354,
       "norm_label": "drizzle.ts"
     },
     {
@@ -12432,7 +13062,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "db_drizzle_pool",
-      "community": 45,
+      "community": 354,
       "norm_label": "pool"
     },
     {
@@ -12442,7 +13072,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "db_drizzle_db",
-      "community": 45,
+      "community": 20,
       "norm_label": "db"
     },
     {
@@ -12492,7 +13122,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "db_schema_categories",
-      "community": 45,
+      "community": 20,
       "norm_label": "categories"
     },
     {
@@ -12552,7 +13182,7 @@
       "source_location": "L108",
       "_origin": "ast",
       "id": "db_schema_inserttransactionschema",
-      "community": 510,
+      "community": 518,
       "norm_label": "inserttransactionschema"
     },
     {
@@ -12592,7 +13222,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts",
-      "community": 520,
+      "community": 432,
       "norm_label": "use-bulk-delete-accounts.ts"
     },
     {
@@ -12602,7 +13232,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_responsetype",
-      "community": 520,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -12612,7 +13242,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_requesttype",
-      "community": 520,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -12632,7 +13262,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account",
-      "community": 518,
+      "community": 513,
       "norm_label": "use-create-account.ts"
     },
     {
@@ -12642,7 +13272,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_responsetype",
-      "community": 518,
+      "community": 513,
       "norm_label": "responsetype"
     },
     {
@@ -12652,7 +13282,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_requesttype",
-      "community": 518,
+      "community": 513,
       "norm_label": "requesttype"
     },
     {
@@ -12672,7 +13302,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_delete_account",
-      "community": 432,
+      "community": 348,
       "norm_label": "use-delete-account.ts"
     },
     {
@@ -12682,7 +13312,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_delete_account_responsetype",
-      "community": 432,
+      "community": 348,
       "norm_label": "responsetype"
     },
     {
@@ -12692,7 +13322,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "features_accounts_api_use_delete_account_usedeleteaccount",
-      "community": 432,
+      "community": 348,
       "norm_label": "usedeleteaccount()"
     },
     {
@@ -12702,7 +13332,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_edit_account",
-      "community": 432,
+      "community": 348,
       "norm_label": "use-edit-account.ts"
     },
     {
@@ -12712,7 +13342,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_edit_account_responsetype",
-      "community": 432,
+      "community": 348,
       "norm_label": "responsetype"
     },
     {
@@ -12722,7 +13352,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_accounts_api_use_edit_account_requesttype",
-      "community": 432,
+      "community": 348,
       "norm_label": "requesttype"
     },
     {
@@ -12732,7 +13362,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_accounts_api_use_edit_account_useeditaccount",
-      "community": 432,
+      "community": 348,
       "norm_label": "useeditaccount()"
     },
     {
@@ -12742,7 +13372,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_account",
-      "community": 432,
+      "community": 348,
       "norm_label": "use-get-account.ts"
     },
     {
@@ -12752,7 +13382,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_account_usegetaccount",
-      "community": 432,
+      "community": 348,
       "norm_label": "usegetaccount()"
     },
     {
@@ -12762,7 +13392,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_accounts",
-      "community": 432,
+      "community": 518,
       "norm_label": "use-get-accounts.ts"
     },
     {
@@ -12772,7 +13402,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_accounts_usegetaccounts",
-      "community": 520,
+      "community": 518,
       "norm_label": "usegetaccounts()"
     },
     {
@@ -12822,7 +13452,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_accounts_components_account_form_accountform",
-      "community": 510,
+      "community": 348,
       "norm_label": "accountform()"
     },
     {
@@ -12832,7 +13462,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_components_edit_account_sheet",
-      "community": 510,
+      "community": 348,
       "norm_label": "edit-account-sheet.tsx"
     },
     {
@@ -12842,7 +13472,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "features_accounts_components_edit_account_sheet_formvalues",
-      "community": 510,
+      "community": 348,
       "norm_label": "formvalues"
     },
     {
@@ -12852,7 +13482,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "features_accounts_components_edit_account_sheet_editaccountsheet",
-      "community": 432,
+      "community": 348,
       "norm_label": "editaccountsheet()"
     },
     {
@@ -12882,7 +13512,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "features_accounts_components_new_account_sheet_newaccountsheet",
-      "community": 520,
+      "community": 518,
       "norm_label": "newaccountsheet()"
     },
     {
@@ -12922,7 +13552,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_open_account",
-      "community": 517,
+      "community": 348,
       "norm_label": "use-open-account.ts"
     },
     {
@@ -12932,7 +13562,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_open_account_openaccountstate",
-      "community": 517,
+      "community": 348,
       "norm_label": "openaccountstate"
     },
     {
@@ -12942,7 +13572,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_open_account_useopenaccount",
-      "community": 517,
+      "community": 348,
       "norm_label": "useopenaccount"
     },
     {
@@ -12962,7 +13592,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account_useselectaccount",
-      "community": 379,
+      "community": 518,
       "norm_label": "useselectaccount()"
     },
     {
@@ -13012,7 +13642,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category",
-      "community": 260,
+      "community": 513,
       "norm_label": "use-create-category.ts"
     },
     {
@@ -13022,7 +13652,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_responsetype",
-      "community": 260,
+      "community": 513,
       "norm_label": "responsetype"
     },
     {
@@ -13032,7 +13662,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_requesttype",
-      "community": 260,
+      "community": 513,
       "norm_label": "requesttype"
     },
     {
@@ -13042,7 +13672,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_usecreatecategory",
-      "community": 260,
+      "community": 518,
       "norm_label": "usecreatecategory()"
     },
     {
@@ -13072,7 +13702,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category_usedeletecategory",
-      "community": 42,
+      "community": 432,
       "norm_label": "usedeletecategory()"
     },
     {
@@ -13122,7 +13752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_get_categories",
-      "community": 432,
+      "community": 518,
       "norm_label": "use-get-categories.ts"
     },
     {
@@ -13132,7 +13762,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_categories_api_use_get_categories_usegetcategories",
-      "community": 260,
+      "community": 518,
       "norm_label": "usegetcategories()"
     },
     {
@@ -13202,7 +13832,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_categories_components_category_form_categoryform",
-      "community": 260,
+      "community": 510,
       "norm_label": "categoryform()"
     },
     {
@@ -13232,7 +13862,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet_editcategorysheet",
-      "community": 42,
+      "community": 432,
       "norm_label": "editcategorysheet()"
     },
     {
@@ -13242,7 +13872,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_components_new_category_sheet",
-      "community": 260,
+      "community": 510,
       "norm_label": "new-category-sheet.tsx"
     },
     {
@@ -13252,7 +13882,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "features_categories_components_new_category_sheet_formvalues",
-      "community": 260,
+      "community": 510,
       "norm_label": "formvalues"
     },
     {
@@ -13262,7 +13892,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "features_categories_components_new_category_sheet_newcategorysheet",
-      "community": 260,
+      "community": 518,
       "norm_label": "newcategorysheet()"
     },
     {
@@ -13342,7 +13972,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_summary_use_get_summary_usegetsummary",
-      "community": 526,
+      "community": 432,
       "norm_label": "usegetsummary()"
     },
     {
@@ -13392,7 +14022,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_delete_transactions",
-      "community": 432,
+      "community": 379,
       "norm_label": "use-bulk-delete-transactions.ts"
     },
     {
@@ -13402,7 +14032,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_delete_transactions_responsetype",
-      "community": 432,
+      "community": 379,
       "norm_label": "responsetype"
     },
     {
@@ -13412,7 +14042,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_delete_transactions_requesttype",
-      "community": 432,
+      "community": 379,
       "norm_label": "requesttype"
     },
     {
@@ -13432,7 +14062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction",
-      "community": 513,
+      "community": 432,
       "norm_label": "use-create-transaction.ts"
     },
     {
@@ -13442,7 +14072,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_responsetype",
-      "community": 513,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -13452,7 +14082,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_requesttype",
-      "community": 513,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -13462,7 +14092,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_usecreatetransaction",
-      "community": 513,
+      "community": 518,
       "norm_label": "usecreatetransaction()"
     },
     {
@@ -13492,7 +14122,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "features_transactions_api_use_delete_transaction_usedeletetransaction",
-      "community": 42,
+      "community": 518,
       "norm_label": "usedeletetransaction()"
     },
     {
@@ -13542,7 +14172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transaction",
-      "community": 518,
+      "community": 432,
       "norm_label": "use-get-transaction.ts"
     },
     {
@@ -13552,7 +14182,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transaction_usegettransaction",
-      "community": 518,
+      "community": 432,
       "norm_label": "usegettransaction()"
     },
     {
@@ -13572,7 +14202,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transactions_usegettransactions",
-      "community": 379,
+      "community": 432,
       "norm_label": "usegettransactions()"
     },
     {
@@ -13612,7 +14242,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet",
-      "community": 510,
+      "community": 518,
       "norm_label": "new-transaction-sheet.tsx"
     },
     {
@@ -13622,7 +14252,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet_formvalues",
-      "community": 510,
+      "community": 518,
       "norm_label": "formvalues"
     },
     {
@@ -13632,7 +14262,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet_newtransactionsheet",
-      "community": 260,
+      "community": 518,
       "norm_label": "newtransactionsheet()"
     },
     {
@@ -13702,7 +14332,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_new_transaction",
-      "community": 379,
+      "community": 518,
       "norm_label": "use-new-transaction.ts"
     },
     {
@@ -13712,7 +14342,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_new_transaction_newtransactionstate",
-      "community": 379,
+      "community": 518,
       "norm_label": "newtransactionstate"
     },
     {
@@ -13722,7 +14352,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_new_transaction_usenewtransaction",
-      "community": 379,
+      "community": 518,
       "norm_label": "usenewtransaction"
     },
     {
@@ -13772,7 +14402,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "hooks_use_confirm_useconfirm",
-      "community": 42,
+      "community": 348,
       "norm_label": "useconfirm()"
     },
     {
@@ -13782,7 +14412,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_base_url_test",
-      "community": 378,
+      "community": 432,
       "norm_label": "api-base-url.test.ts"
     },
     {
@@ -13792,7 +14422,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_base_url",
-      "community": 378,
+      "community": 432,
       "norm_label": "api-base-url.ts"
     },
     {
@@ -13802,7 +14432,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_base_url_resolveapibaseurloptions",
-      "community": 378,
+      "community": 432,
       "norm_label": "resolveapibaseurloptions"
     },
     {
@@ -13812,7 +14442,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "lib_api_base_url_resolveapibaseurl",
-      "community": 378,
+      "community": 432,
       "norm_label": "resolveapibaseurl()"
     },
     {
@@ -14102,7 +14732,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_import_test",
-      "community": 348,
+      "community": 40,
       "norm_label": "transaction-import.test.ts"
     },
     {
@@ -14112,7 +14742,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_import",
-      "community": 348,
+      "community": 40,
       "norm_label": "transaction-import.ts"
     },
     {
@@ -14122,7 +14752,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "lib_transaction_import_importedtransactionrow",
-      "community": 348,
+      "community": 40,
       "norm_label": "importedtransactionrow"
     },
     {
@@ -14132,7 +14762,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "lib_transaction_import_rawimportedtransactionrow",
-      "community": 348,
+      "community": 40,
       "norm_label": "rawimportedtransactionrow"
     },
     {
@@ -14142,7 +14772,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "lib_transaction_import_importedtransactionrowerror",
-      "community": 348,
+      "community": 40,
       "norm_label": "importedtransactionrowerror"
     },
     {
@@ -14152,7 +14782,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "lib_transaction_import_parseimportedtransactionrows",
-      "community": 348,
+      "community": 40,
       "norm_label": "parseimportedtransactionrows()"
     },
     {
@@ -14282,7 +14912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_utils",
-      "community": 45,
+      "community": 9,
       "norm_label": "utils.ts"
     },
     {
@@ -14292,7 +14922,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "lib_utils_cn",
-      "community": 376,
+      "community": 42,
       "norm_label": "cn()"
     },
     {
@@ -14302,7 +14932,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "lib_utils_convertamountfrommiliunits",
-      "community": 518,
+      "community": 432,
       "norm_label": "convertamountfrommiliunits()"
     },
     {
@@ -14312,7 +14942,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "lib_utils_convertamounttomiliunits",
-      "community": 348,
+      "community": 40,
       "norm_label": "convertamounttomiliunits()"
     },
     {
@@ -14332,7 +14962,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "lib_utils_calculatepercentagechange",
-      "community": 45,
+      "community": 20,
       "norm_label": "calculatepercentagechange()"
     },
     {
@@ -14342,7 +14972,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "lib_utils_fillmissingdays",
-      "community": 45,
+      "community": 20,
       "norm_label": "fillmissingdays()"
     },
     {
@@ -14352,7 +14982,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "lib_utils_period",
-      "community": 45,
+      "community": 9,
       "norm_label": "period"
     },
     {
@@ -14362,7 +14992,7 @@
       "source_location": "L76",
       "_origin": "ast",
       "id": "lib_utils_formatdaterange",
-      "community": 14,
+      "community": 526,
       "norm_label": "formatdaterange()"
     },
     {
@@ -15322,7 +15952,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "providers_sheet_provider",
-      "community": 260,
+      "community": 518,
       "norm_label": "sheet-provider.tsx"
     },
     {
@@ -15996,6 +16626,606 @@
       "norm_label": "never"
     },
     {
+      "label": "SKILL.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill",
+      "community": 41,
+      "norm_label": "skill.md"
+    },
+    {
+      "label": "/graphify",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_graphify",
+      "community": 41,
+      "norm_label": "/graphify"
+    },
+    {
+      "label": "Usage",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L10",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_usage",
+      "community": 41,
+      "norm_label": "usage"
+    },
+    {
+      "label": "What graphify is for",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L45",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_what_graphify_is_for",
+      "community": 41,
+      "norm_label": "what graphify is for"
+    },
+    {
+      "label": "What You Must Do When Invoked",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L49",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "community": 41,
+      "norm_label": "what you must do when invoked"
+    },
+    {
+      "label": "Step 0 - GitHub repos and multi-path merge (only if a URL or several paths)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L61",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_0_github_repos_and_multi_path_merge_only_if_a_url_or_several_paths",
+      "community": 41,
+      "norm_label": "step 0 - github repos and multi-path merge (only if a url or several paths)"
+    },
+    {
+      "label": "Step 1 - Ensure graphify is installed",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L65",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_1_ensure_graphify_is_installed",
+      "community": 41,
+      "norm_label": "step 1 - ensure graphify is installed"
+    },
+    {
+      "label": "Step 2 - Detect files",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L107",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_2_detect_files",
+      "community": 41,
+      "norm_label": "step 2 - detect files"
+    },
+    {
+      "label": "Step 2.5 - Video and audio (only if video files detected)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L144",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_2_5_video_and_audio_only_if_video_files_detected",
+      "community": 41,
+      "norm_label": "step 2.5 - video and audio (only if video files detected)"
+    },
+    {
+      "label": "Step 3 - Extract entities and relationships",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L148",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "community": 41,
+      "norm_label": "step 3 - extract entities and relationships"
+    },
+    {
+      "label": "Part A - Structural extraction for code files",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L167",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_part_a_structural_extraction_for_code_files",
+      "community": 41,
+      "norm_label": "part a - structural extraction for code files"
+    },
+    {
+      "label": "Part B - Semantic extraction (parallel subagents)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L193",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_part_b_semantic_extraction_parallel_subagents",
+      "community": 41,
+      "norm_label": "part b - semantic extraction (parallel subagents)"
+    },
+    {
+      "label": "Part C - Merge AST + semantic into final extraction",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L350",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_part_c_merge_ast_semantic_into_final_extraction",
+      "community": 41,
+      "norm_label": "part c - merge ast + semantic into final extraction"
+    },
+    {
+      "label": "Step 4 - Build graph, cluster, analyze, generate outputs",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L384",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_4_build_graph_cluster_analyze_generate_outputs",
+      "community": 41,
+      "norm_label": "step 4 - build graph, cluster, analyze, generate outputs"
+    },
+    {
+      "label": "Step 4.5 - Graph health check (read-only integrity gate)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L447",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_4_5_graph_health_check_read_only_integrity_gate",
+      "community": 41,
+      "norm_label": "step 4.5 - graph health check (read-only integrity gate)"
+    },
+    {
+      "label": "Step 5 - Label communities",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L473",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_5_label_communities",
+      "community": 41,
+      "norm_label": "step 5 - label communities"
+    },
+    {
+      "label": "Step 6 - Generate Obsidian vault (opt-in) + HTML",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L514",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_6_generate_obsidian_vault_opt_in_html",
+      "community": 41,
+      "norm_label": "step 6 - generate obsidian vault (opt-in) + html"
+    },
+    {
+      "label": "Steps 6b-8 - Wiki, Neo4j, FalkorDB, SVG, GraphML, MCP, benchmark (only on their flags)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L534",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_steps_6b_8_wiki_neo4j_falkordb_svg_graphml_mcp_benchmark_only_on_their_flags",
+      "community": 41,
+      "norm_label": "steps 6b-8 - wiki, neo4j, falkordb, svg, graphml, mcp, benchmark (only on their flags)"
+    },
+    {
+      "label": "Step 9 - Save manifest, update cost tracker, clean up, and report",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L540",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_9_save_manifest_update_cost_tracker_clean_up_and_report",
+      "community": 41,
+      "norm_label": "step 9 - save manifest, update cost tracker, clean up, and report"
+    },
+    {
+      "label": "Interpreter guard for subcommands",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L620",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_interpreter_guard_for_subcommands",
+      "community": 41,
+      "norm_label": "interpreter guard for subcommands"
+    },
+    {
+      "label": "For --update and --cluster-only",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L638",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_for_update_and_cluster_only",
+      "community": 41,
+      "norm_label": "for --update and --cluster-only"
+    },
+    {
+      "label": "For /graphify query",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L644",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_for_graphify_query",
+      "community": 41,
+      "norm_label": "for /graphify query"
+    },
+    {
+      "label": "For /graphify add and --watch",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L656",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_for_graphify_add_and_watch",
+      "community": 41,
+      "norm_label": "for /graphify add and --watch"
+    },
+    {
+      "label": "For the commit hook and native CLAUDE.md integration",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L662",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_for_the_commit_hook_and_native_claude_md_integration",
+      "community": 41,
+      "norm_label": "for the commit hook and native claude.md integration"
+    },
+    {
+      "label": "Honesty Rules",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L668",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_honesty_rules",
+      "community": 41,
+      "norm_label": "honesty rules"
+    },
+    {
+      "label": "add-watch.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_add_watch",
+      "community": 514,
+      "norm_label": "add-watch.md"
+    },
+    {
+      "label": "graphify reference: add a URL and watch a folder",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_add_watch_graphify_reference_add_a_url_and_watch_a_folder",
+      "community": 514,
+      "norm_label": "graphify reference: add a url and watch a folder"
+    },
+    {
+      "label": "For /graphify add",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_add_watch_for_graphify_add",
+      "community": 514,
+      "norm_label": "for /graphify add"
+    },
+    {
+      "label": "For --watch",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L39",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_add_watch_for_watch",
+      "community": 514,
+      "norm_label": "for --watch"
+    },
+    {
+      "label": "exports.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports",
+      "community": 376,
+      "norm_label": "exports.md"
+    },
+    {
+      "label": "graphify reference: extra exports and benchmark",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "community": 376,
+      "norm_label": "graphify reference: extra exports and benchmark"
+    },
+    {
+      "label": "Step 6b - Wiki (only if --wiki flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_6b_wiki_only_if_wiki_flag",
+      "community": 376,
+      "norm_label": "step 6b - wiki (only if --wiki flag)"
+    },
+    {
+      "label": "Step 7 - Neo4j export (only if --neo4j or --neo4j-push flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L15",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7_neo4j_export_only_if_neo4j_or_neo4j_push_flag",
+      "community": 376,
+      "norm_label": "step 7 - neo4j export (only if --neo4j or --neo4j-push flag)"
+    },
+    {
+      "label": "Step 7a - FalkorDB export (only if --falkordb or --falkordb-push flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L31",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7a_falkordb_export_only_if_falkordb_or_falkordb_push_flag",
+      "community": 376,
+      "norm_label": "step 7a - falkordb export (only if --falkordb or --falkordb-push flag)"
+    },
+    {
+      "label": "Step 7b - SVG export (only if --svg flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L47",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7b_svg_export_only_if_svg_flag",
+      "community": 376,
+      "norm_label": "step 7b - svg export (only if --svg flag)"
+    },
+    {
+      "label": "Step 7c - GraphML export (only if --graphml flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L53",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7c_graphml_export_only_if_graphml_flag",
+      "community": 376,
+      "norm_label": "step 7c - graphml export (only if --graphml flag)"
+    },
+    {
+      "label": "Step 7d - MCP server (only if --mcp flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L59",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7d_mcp_server_only_if_mcp_flag",
+      "community": 376,
+      "norm_label": "step 7d - mcp server (only if --mcp flag)"
+    },
+    {
+      "label": "Step 8 - Token reduction benchmark (only if total_words > 5000)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L79",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_8_token_reduction_benchmark_only_if_total_words_5000",
+      "community": 376,
+      "norm_label": "step 8 - token reduction benchmark (only if total_words > 5000)"
+    },
+    {
+      "label": "extraction-spec.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/extraction-spec.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_extraction_spec",
+      "community": 538,
+      "norm_label": "extraction-spec.md"
+    },
+    {
+      "label": "graphify reference: extraction subagent prompt (compact)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/extraction-spec.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_extraction_spec_graphify_reference_extraction_subagent_prompt_compact",
+      "community": 538,
+      "norm_label": "graphify reference: extraction subagent prompt (compact)"
+    },
+    {
+      "label": "github-and-merge.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_github_and_merge",
+      "community": 535,
+      "norm_label": "github-and-merge.md"
+    },
+    {
+      "label": "graphify reference: GitHub clone and cross-repo merge",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_github_and_merge_graphify_reference_github_clone_and_cross_repo_merge",
+      "community": 535,
+      "norm_label": "graphify reference: github clone and cross-repo merge"
+    },
+    {
+      "label": "Step 0 - Clone GitHub repo(s) (only if a GitHub URL was given)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_github_and_merge_step_0_clone_github_repo_s_only_if_a_github_url_was_given",
+      "community": 535,
+      "norm_label": "step 0 - clone github repo(s) (only if a github url was given)"
+    },
+    {
+      "label": "hooks.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_hooks",
+      "community": 532,
+      "norm_label": "hooks.md"
+    },
+    {
+      "label": "graphify reference: commit hook and native CLAUDE.md integration",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_hooks_graphify_reference_commit_hook_and_native_claude_md_integration",
+      "community": 532,
+      "norm_label": "graphify reference: commit hook and native claude.md integration"
+    },
+    {
+      "label": "For git commit hook",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_hooks_for_git_commit_hook",
+      "community": 532,
+      "norm_label": "for git commit hook"
+    },
+    {
+      "label": "For native CLAUDE.md integration",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L21",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_hooks_for_native_claude_md_integration",
+      "community": 532,
+      "norm_label": "for native claude.md integration"
+    },
+    {
+      "label": "query.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query",
+      "community": 378,
+      "norm_label": "query.md"
+    },
+    {
+      "label": "graphify reference: query, path, explain",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "community": 378,
+      "norm_label": "graphify reference: query, path, explain"
+    },
+    {
+      "label": "Step 0 \u2014 Constrained query expansion (REQUIRED before traversal)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L23",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_step_0_constrained_query_expansion_required_before_traversal",
+      "community": 378,
+      "norm_label": "step 0 \u2014 constrained query expansion (required before traversal)"
+    },
+    {
+      "label": "Step 1 \u2014 Traversal",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L61",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_step_1_traversal",
+      "community": 378,
+      "norm_label": "step 1 \u2014 traversal"
+    },
+    {
+      "label": "For /graphify path",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L186",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_for_graphify_path",
+      "community": 378,
+      "norm_label": "for /graphify path"
+    },
+    {
+      "label": "For /graphify explain",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L254",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_for_graphify_explain",
+      "community": 378,
+      "norm_label": "for /graphify explain"
+    },
+    {
+      "label": "transcribe.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_transcribe",
+      "community": 536,
+      "norm_label": "transcribe.md"
+    },
+    {
+      "label": "graphify reference: transcribe video and audio",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_transcribe_graphify_reference_transcribe_video_and_audio",
+      "community": 536,
+      "norm_label": "graphify reference: transcribe video and audio"
+    },
+    {
+      "label": "Step 2.5 - Transcribe video / audio files (only if video files detected)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_transcribe_step_2_5_transcribe_video_audio_files_only_if_video_files_detected",
+      "community": 536,
+      "norm_label": "step 2.5 - transcribe video / audio files (only if video files detected)"
+    },
+    {
+      "label": "update.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_update",
+      "community": 534,
+      "norm_label": "update.md"
+    },
+    {
+      "label": "graphify reference: incremental update and cluster-only",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_update_graphify_reference_incremental_update_and_cluster_only",
+      "community": 534,
+      "norm_label": "graphify reference: incremental update and cluster-only"
+    },
+    {
+      "label": "For --update (incremental re-extraction)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_update_for_update_incremental_re_extraction",
+      "community": 534,
+      "norm_label": "for --update (incremental re-extraction)"
+    },
+    {
+      "label": "For --cluster-only",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L184",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_update_for_cluster_only",
+      "community": 534,
+      "norm_label": "for --cluster-only"
+    },
+    {
       "label": "copilot-instructions.md",
       "file_type": "document",
       "source_file": ".github/copilot-instructions.md",
@@ -16199,7 +17429,7 @@
       "label": "Commands",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L22",
+      "source_location": "L24",
       "_origin": "ast",
       "id": "claude_commands",
       "community": 332,
@@ -16209,37 +17439,27 @@
       "label": "Hard Invariants",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L31",
+      "source_location": "L33",
       "_origin": "ast",
       "id": "claude_hard_invariants",
       "community": 332,
       "norm_label": "hard invariants"
     },
     {
-      "label": "Risk Policy",
+      "label": "Working Flow (streamlined 2026-07-23)",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L42",
+      "source_location": "L44",
       "_origin": "ast",
-      "id": "claude_risk_policy",
+      "id": "claude_working_flow_streamlined_2026_07_23",
       "community": 332,
-      "norm_label": "risk policy"
-    },
-    {
-      "label": "Branch And PR Hard Rules",
-      "file_type": "document",
-      "source_file": "CLAUDE.md",
-      "source_location": "L49",
-      "_origin": "ast",
-      "id": "claude_branch_and_pr_hard_rules",
-      "community": 332,
-      "norm_label": "branch and pr hard rules"
+      "norm_label": "working flow (streamlined 2026-07-23)"
     },
     {
       "label": "Model Orchestration",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L67",
+      "source_location": "L78",
       "_origin": "ast",
       "id": "claude_model_orchestration",
       "community": 332,
@@ -16249,7 +17469,7 @@
       "label": "Graphify",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L78",
+      "source_location": "L89",
       "_origin": "ast",
       "id": "claude_graphify",
       "community": 332,
@@ -16259,7 +17479,7 @@
       "label": "Legacy Code",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L86",
+      "source_location": "L97",
       "_origin": "ast",
       "id": "claude_legacy_code",
       "community": 332,
@@ -16269,7 +17489,7 @@
       "label": "Post-Migration Improvements",
       "file_type": "document",
       "source_file": "CLAUDE.md",
-      "source_location": "L92",
+      "source_location": "L103",
       "_origin": "ast",
       "id": "claude_post_migration_improvements",
       "community": 332,
@@ -29107,7 +30327,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt.go",
-      "source_location": "L26",
+      "source_location": "L39",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt",
       "target": "backend_internal_auth_jwt_issueaccesstoken",
@@ -29117,7 +30337,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt.go",
-      "source_location": "L54",
+      "source_location": "L74",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt",
       "target": "backend_internal_auth_jwt_verifyaccesstoken",
@@ -29127,7 +30347,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt.go",
-      "source_location": "L26",
+      "source_location": "L39",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_issueaccesstoken",
@@ -29138,7 +30358,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt.go",
-      "source_location": "L26",
+      "source_location": "L39",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_auth_jwt_issueaccesstoken",
@@ -29149,7 +30369,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt.go",
-      "source_location": "L26",
+      "source_location": "L39",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_issueaccesstoken",
@@ -29162,7 +30382,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testissueaccesstoken_claimsareminimal",
       "target": "backend_internal_auth_jwt_issueaccesstoken"
@@ -29173,7 +30393,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L15",
+      "source_location": "L16",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testissueandverifyaccesstoken_roundtrip",
       "target": "backend_internal_auth_jwt_issueaccesstoken"
@@ -29184,7 +30404,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L70",
+      "source_location": "L71",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_expiredrejected",
       "target": "backend_internal_auth_jwt_issueaccesstoken"
@@ -29195,9 +30415,75 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L82",
+      "source_location": "L98",
+      "weight": 1.0,
+      "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonexpiryfailuresstaygeneric",
+      "target": "backend_internal_auth_jwt_issueaccesstoken"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/auth/jwt_test.go",
+      "source_location": "L117",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_wrongsecretrejected",
+      "target": "backend_internal_auth_jwt_issueaccesstoken"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L121",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
+      "target": "backend_internal_auth_jwt_issueaccesstoken"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L228",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_bodyidentityisignored",
+      "target": "backend_internal_auth_jwt_issueaccesstoken"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L141",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_expiredtoken_accesstokenexpired",
+      "target": "backend_internal_auth_jwt_issueaccesstoken"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L202",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_validtoken_exposesuserid",
+      "target": "backend_internal_auth_jwt_issueaccesstoken"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L121",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_wrongsecret_unauthorized",
       "target": "backend_internal_auth_jwt_issueaccesstoken"
     },
     {
@@ -29226,7 +30512,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt.go",
-      "source_location": "L54",
+      "source_location": "L74",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_auth_jwt_verifyaccesstoken",
@@ -29239,7 +30525,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L26",
+      "source_location": "L27",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testissueandverifyaccesstoken_roundtrip",
       "target": "backend_internal_auth_jwt_verifyaccesstoken"
@@ -29250,7 +30536,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L75",
+      "source_location": "L76",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_expiredrejected",
       "target": "backend_internal_auth_jwt_verifyaccesstoken"
@@ -29261,7 +30547,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L102",
+      "source_location": "L137",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_garbagetokenrejected",
       "target": "backend_internal_auth_jwt_verifyaccesstoken"
@@ -29272,7 +30558,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L166",
+      "source_location": "L201",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_missingexprejected",
       "target": "backend_internal_auth_jwt_verifyaccesstoken"
@@ -29283,7 +30569,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L184",
+      "source_location": "L103",
+      "weight": 1.0,
+      "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonexpiryfailuresstaygeneric",
+      "target": "backend_internal_auth_jwt_verifyaccesstoken"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/auth/jwt_test.go",
+      "source_location": "L219",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonuuidsubjectrejected",
       "target": "backend_internal_auth_jwt_verifyaccesstoken"
@@ -29294,7 +30591,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L123",
+      "source_location": "L158",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectsalgnone",
       "target": "backend_internal_auth_jwt_verifyaccesstoken"
@@ -29305,7 +30602,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L145",
+      "source_location": "L180",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectssiblinghmacalg",
       "target": "backend_internal_auth_jwt_verifyaccesstoken"
@@ -29316,7 +30613,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L87",
+      "source_location": "L122",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_wrongsecretrejected",
       "target": "backend_internal_auth_jwt_verifyaccesstoken"
@@ -29333,10 +30630,21 @@
       "target": "backend_internal_auth_jwt_verifyaccesstoken"
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_requireauth",
+      "target": "backend_internal_auth_jwt_verifyaccesstoken"
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L35",
+      "source_location": "L36",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test",
       "target": "backend_internal_auth_jwt_test_testissueaccesstoken_claimsareminimal",
@@ -29346,7 +30654,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L11",
+      "source_location": "L12",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test",
       "target": "backend_internal_auth_jwt_test_testissueandverifyaccesstoken_roundtrip",
@@ -29356,7 +30664,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L66",
+      "source_location": "L67",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test",
       "target": "backend_internal_auth_jwt_test_testverifyaccesstoken_expiredrejected",
@@ -29366,7 +30674,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L92",
+      "source_location": "L127",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test",
       "target": "backend_internal_auth_jwt_test_testverifyaccesstoken_garbagetokenrejected",
@@ -29376,7 +30684,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L150",
+      "source_location": "L185",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test",
       "target": "backend_internal_auth_jwt_test_testverifyaccesstoken_missingexprejected",
@@ -29386,7 +30694,17 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L171",
+      "source_location": "L94",
+      "weight": 1.0,
+      "source": "backend_internal_auth_jwt_test",
+      "target": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonexpiryfailuresstaygeneric",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/auth/jwt_test.go",
+      "source_location": "L206",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test",
       "target": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonuuidsubjectrejected",
@@ -29396,7 +30714,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L108",
+      "source_location": "L143",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test",
       "target": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectsalgnone",
@@ -29406,7 +30724,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L128",
+      "source_location": "L163",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test",
       "target": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectssiblinghmacalg",
@@ -29416,7 +30734,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L80",
+      "source_location": "L115",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test",
       "target": "backend_internal_auth_jwt_test_testverifyaccesstoken_wrongsecretrejected",
@@ -29426,7 +30744,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L11",
+      "source_location": "L12",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_test_testissueandverifyaccesstoken_roundtrip",
@@ -29439,7 +30757,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L13",
+      "source_location": "L14",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testissueandverifyaccesstoken_roundtrip",
       "target": "backend_internal_db_gen_db_new"
@@ -29448,7 +30766,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L35",
+      "source_location": "L36",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_test_testissueaccesstoken_claimsareminimal",
@@ -29459,7 +30777,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L66",
+      "source_location": "L67",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_expiredrejected",
@@ -29470,7 +30788,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L92",
+      "source_location": "L127",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_garbagetokenrejected",
@@ -29481,7 +30799,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L150",
+      "source_location": "L185",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_missingexprejected",
@@ -29492,7 +30810,18 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L171",
+      "source_location": "L94",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonexpiryfailuresstaygeneric",
+      "target": "backend_internal_auth_jwt_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/auth/jwt_test.go",
+      "source_location": "L206",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonuuidsubjectrejected",
@@ -29503,7 +30832,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L108",
+      "source_location": "L143",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectsalgnone",
@@ -29514,7 +30843,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L128",
+      "source_location": "L163",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectssiblinghmacalg",
@@ -29525,7 +30854,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L80",
+      "source_location": "L115",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_wrongsecretrejected",
@@ -29538,7 +30867,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testissueaccesstoken_claimsareminimal",
       "target": "backend_internal_db_gen_db_new"
@@ -29549,7 +30878,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L68",
+      "source_location": "L69",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_expiredrejected",
       "target": "backend_internal_db_gen_db_new"
@@ -29560,7 +30889,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L81",
+      "source_location": "L96",
+      "weight": 1.0,
+      "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_nonexpiryfailuresstaygeneric",
+      "target": "backend_internal_db_gen_db_new"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/auth/jwt_test.go",
+      "source_location": "L116",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_wrongsecretrejected",
       "target": "backend_internal_db_gen_db_new"
@@ -29571,7 +30911,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L110",
+      "source_location": "L145",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectsalgnone",
       "target": "backend_internal_db_gen_db_new"
@@ -29582,7 +30922,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L130",
+      "source_location": "L165",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_rejectssiblinghmacalg",
       "target": "backend_internal_db_gen_db_new"
@@ -29593,7 +30933,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/auth/jwt_test.go",
-      "source_location": "L152",
+      "source_location": "L187",
       "weight": 1.0,
       "source": "backend_internal_auth_jwt_test_testverifyaccesstoken_missingexprejected",
       "target": "backend_internal_db_gen_db_new"
@@ -31491,10 +32831,65 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L76",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
+      "target": "backend_internal_db_db_newpool"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L130",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
+      "target": "backend_internal_db_db_newpool"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L231",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
+      "target": "backend_internal_db_db_newpool"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L193",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_db_newpool"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/auth_live_test.go",
       "source_location": "L43",
       "weight": 1.0,
       "source": "backend_internal_http_auth_live_test_newauthtestenv",
+      "target": "backend_internal_db_db_newpool"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L89",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
       "target": "backend_internal_db_db_newpool"
     },
     {
@@ -33589,7 +34984,7 @@
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_db_gen_db_new",
-      "target": "queries",
+      "target": "backend_internal_db_gen_db_go_queries",
       "confidence_score": 1.0
     },
     {
@@ -33601,6 +34996,28 @@
       "source_location": "L470",
       "weight": 1.0,
       "source": "backend_internal_db_queries_live_test_newpguuid",
+      "target": "backend_internal_db_gen_db_new"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L241",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
+      "target": "backend_internal_db_gen_db_new"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L54",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_withusertx",
       "target": "backend_internal_db_gen_db_new"
     },
     {
@@ -33645,6 +35062,61 @@
       "source_location": "L273",
       "weight": 1.0,
       "source": "backend_internal_http_email_flows_live_test_testauthlive_verifyemail_expiredtokenunauthorized",
+      "target": "backend_internal_db_gen_db_new"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L226",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_bodyidentityisignored",
+      "target": "backend_internal_db_gen_db_new"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L141",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_expiredtoken_accesstokenexpired",
+      "target": "backend_internal_db_gen_db_new"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L165",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_rejectsalgpolicyviolations",
+      "target": "backend_internal_db_gen_db_new"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L201",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_validtoken_exposesuserid",
+      "target": "backend_internal_db_gen_db_new"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L121",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_wrongsecret_unauthorized",
       "target": "backend_internal_db_gen_db_new"
     },
     {
@@ -35094,6 +36566,50 @@
       "target": "backend_internal_db_livedb_test_livedatabaseurl"
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
+      "target": "backend_internal_db_livedb_test_livedatabaseurl"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L127",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
+      "target": "backend_internal_db_livedb_test_livedatabaseurl"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L228",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
+      "target": "backend_internal_db_livedb_test_livedatabaseurl"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L190",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_livedb_test_livedatabaseurl"
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/queries_live_test.go",
@@ -35208,6 +36724,471 @@
       "weight": 1.0,
       "source": "backend_internal_db_queries_live_test_testconsumerefreshtoken_concurrent",
       "target": "backend_internal_db_queries_live_test_uniquetestemail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls",
+      "target": "backend_internal_db_rls_withusertx",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_createrlstestaccount",
+      "target": "backend_internal_db_rls_withusertx"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
+      "target": "backend_internal_db_rls_withusertx"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L243",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
+      "target": "backend_internal_db_rls_withusertx"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_withusertx",
+      "target": "backend_internal_db_rls_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_withusertx",
+      "target": "backend_internal_db_rls_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_withusertx",
+      "target": "backend_internal_db_rls_go_queries",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_withusertx",
+      "target": "backend_internal_db_rls_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_accountprobehandler",
+      "target": "backend_internal_db_rls_withusertx"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L108",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
+      "target": "backend_internal_db_rls_withusertx"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_createrlstestaccount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_createrlstestuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_deleterlstestusers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L72",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L126",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L227",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L189",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L19",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_createrlstestuser",
+      "target": "backend_internal_db_rls_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L19",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_createrlstestuser",
+      "target": "backend_internal_db_rls_test_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L19",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_createrlstestuser",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L19",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_db_rls_test_createrlstestuser",
+      "target": "backend_internal_db_rls_test_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L82",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
+      "target": "backend_internal_db_rls_test_createrlstestuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L136",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
+      "target": "backend_internal_db_rls_test_createrlstestuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L237",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
+      "target": "backend_internal_db_rls_test_createrlstestuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L199",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_rls_test_createrlstestuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L47",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_createrlstestaccount",
+      "target": "backend_internal_db_rls_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_deleterlstestusers",
+      "target": "backend_internal_db_rls_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L47",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_createrlstestaccount",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_deleterlstestusers",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L72",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L126",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L227",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L189",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L47",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_createrlstestaccount",
+      "target": "backend_internal_db_rls_test_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_deleterlstestusers",
+      "target": "backend_internal_db_rls_test_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L47",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_createrlstestaccount",
+      "target": "backend_internal_db_rls_test_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L84",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
+      "target": "backend_internal_db_rls_test_deleterlstestusers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L138",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
+      "target": "backend_internal_db_rls_test_deleterlstestusers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L238",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
+      "target": "backend_internal_db_rls_test_deleterlstestusers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L200",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_rls_test_deleterlstestusers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L87",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
+      "target": "backend_internal_db_rls_test_createrlstestaccount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L141",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
+      "target": "backend_internal_db_rls_test_createrlstestaccount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L203",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_rls_test_createrlstestaccount",
       "confidence_score": 1.0
     },
     {
@@ -35711,7 +37692,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/router.go",
-      "source_location": "L16",
+      "source_location": "L21",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_router_newrouter",
@@ -36530,6 +38511,17 @@
       "source": "backend_internal_http_auth_invalidtokenerror",
       "target": "openapi_invalidtokenerrorjsonresponse",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/auth.go",
+      "source_location": "L982",
+      "weight": 1.0,
+      "source": "backend_internal_http_auth_writeinternalerror",
+      "target": "backend_internal_http_middleware_writeapierror"
     },
     {
       "relation": "contains",
@@ -39213,10 +41205,1053 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L86",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
+      "target": "backend_internal_http_livedb_test_livedatabaseurl"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L84",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware",
+      "target": "backend_internal_http_middleware_bearertoken",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware",
+      "target": "backend_internal_http_middleware_requireauth",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware",
+      "target": "backend_internal_http_middleware_useridfromcontext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware",
+      "target": "backend_internal_http_middleware_writeaccesstokenexpirederror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L103",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware",
+      "target": "backend_internal_http_middleware_writeapierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L109",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware",
+      "target": "backend_internal_http_middleware_writeunauthorizederror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware",
+      "target": "http_useridcontextkey",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_accountprobehandler",
+      "target": "backend_internal_http_middleware_useridfromcontext"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_contextechoprobe",
+      "target": "backend_internal_http_middleware_useridfromcontext"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L253",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_nouserincontext_whenunauthenticated",
+      "target": "backend_internal_http_middleware_useridfromcontext"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L29",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_useridfromcontext",
+      "target": "backend_internal_http_middleware_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L29",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_middleware_useridfromcontext",
+      "target": "backend_internal_http_middleware_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L74",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_requireauth",
+      "target": "backend_internal_http_middleware_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L71",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_newaccountproberouter",
+      "target": "backend_internal_http_middleware_requireauth"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_requireauth",
+      "target": "backend_internal_http_middleware_bearertoken",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L55",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_middleware_requireauth",
+      "target": "backend_internal_http_middleware_go_handler",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L67",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_requireauth",
+      "target": "backend_internal_http_middleware_writeaccesstokenexpirederror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_requireauth",
+      "target": "backend_internal_http_middleware_writeunauthorizederror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_newproberouter",
+      "target": "backend_internal_http_middleware_requireauth"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/router.go",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "backend_internal_http_router_newrouter",
+      "target": "backend_internal_http_middleware_requireauth"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L117",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_writeaccesstokenexpirederror",
+      "target": "backend_internal_http_middleware_writeapierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L103",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_writeapierror",
+      "target": "apierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L103",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_writeapierror",
+      "target": "backend_internal_http_middleware_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L110",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_writeunauthorizederror",
+      "target": "backend_internal_http_middleware_writeapierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L116",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_writeaccesstokenexpirederror",
+      "target": "backend_internal_http_middleware_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware.go",
+      "source_location": "L109",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_writeunauthorizederror",
+      "target": "backend_internal_http_middleware_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test",
+      "target": "backend_internal_http_middleware_live_test_accountprobehandler",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test",
+      "target": "backend_internal_http_middleware_live_test_createprobetestuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L68",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test",
+      "target": "backend_internal_http_middleware_live_test_newaccountproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L141",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test",
+      "target": "backend_internal_http_middleware_live_test_probeaccountvisibility",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test",
+      "target": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_accountprobehandler",
+      "target": "backend_internal_http_middleware_live_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L30",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_middleware_live_test_accountprobehandler",
+      "target": "backend_internal_http_middleware_live_test_go_handlerfunc",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L30",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_live_test_accountprobehandler",
+      "target": "backend_internal_http_middleware_live_test_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L72",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_newaccountproberouter",
+      "target": "backend_internal_http_middleware_live_test_accountprobehandler",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_live_test_createprobetestuser",
+      "target": "backend_internal_http_middleware_live_test_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L68",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_live_test_newaccountproberouter",
+      "target": "backend_internal_http_middleware_live_test_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L68",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_middleware_live_test_newaccountproberouter",
+      "target": "backend_internal_http_middleware_live_test_go_handler",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L119",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
+      "target": "backend_internal_http_middleware_live_test_newaccountproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L141",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_live_test_probeaccountvisibility",
+      "target": "backend_internal_http_middleware_live_test_go_handler",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L97",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
+      "target": "backend_internal_http_middleware_live_test_createprobetestuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L85",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
+      "target": "backend_internal_http_middleware_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L130",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
+      "target": "backend_internal_http_middleware_live_test_probeaccountvisibility",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_live_test_createprobetestuser",
+      "target": "backend_internal_http_middleware_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L141",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_live_test_probeaccountvisibility",
+      "target": "backend_internal_http_middleware_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_live_test_createprobetestuser",
+      "target": "backend_internal_http_middleware_live_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_live_test.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_middleware_live_test_createprobetestuser",
+      "target": "backend_internal_http_middleware_live_test_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_contextechoprobe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_doproberequest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_newproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L223",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_testrequireauth_bodyidentityisignored",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L138",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_testrequireauth_expiredtoken_accesstokenexpired",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L93",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_testrequireauth_malformedheader_unauthorized",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L75",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_testrequireauth_missingheader_unauthorized",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L251",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_testrequireauth_nouserincontext_whenunauthenticated",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_testrequireauth_rejectsalgpolicyviolations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L198",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_testrequireauth_validtoken_exposesuserid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L118",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test",
+      "target": "backend_internal_http_middleware_test_testrequireauth_wrongsecret_unauthorized",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L25",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_middleware_test_newproberouter",
+      "target": "backend_internal_http_middleware_test_go_handler",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L25",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_newproberouter",
+      "target": "backend_internal_http_middleware_test_go_handlerfunc",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L224",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_bodyidentityisignored",
+      "target": "backend_internal_http_middleware_test_newproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L139",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_expiredtoken_accesstokenexpired",
+      "target": "backend_internal_http_middleware_test_newproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L94",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_malformedheader_unauthorized",
+      "target": "backend_internal_http_middleware_test_newproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L76",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_missingheader_unauthorized",
+      "target": "backend_internal_http_middleware_test_newproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L163",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_rejectsalgpolicyviolations",
+      "target": "backend_internal_http_middleware_test_newproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L199",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_validtoken_exposesuserid",
+      "target": "backend_internal_http_middleware_test_newproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L119",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_wrongsecret_unauthorized",
+      "target": "backend_internal_http_middleware_test_newproberouter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_doproberequest",
+      "target": "backend_internal_http_middleware_test_go_handler",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L38",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_contextechoprobe",
+      "target": "backend_internal_http_middleware_test_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L38",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_contextechoprobe",
+      "target": "backend_internal_http_middleware_test_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L49",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "target": "backend_internal_http_middleware_test_go_responserecorder",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L49",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L49",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "target": "openapi_apierrorresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_expiredtoken_accesstokenexpired",
+      "target": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L109",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_malformedheader_unauthorized",
+      "target": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L82",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_missingheader_unauthorized",
+      "target": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L187",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_rejectsalgpolicyviolations",
+      "target": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L130",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_wrongsecret_unauthorized",
+      "target": "backend_internal_http_middleware_test_decodemiddlewareapierror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_doproberequest",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L223",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_testrequireauth_bodyidentityisignored",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L138",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_testrequireauth_expiredtoken_accesstokenexpired",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L93",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_testrequireauth_malformedheader_unauthorized",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L75",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_testrequireauth_missingheader_unauthorized",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L251",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_testrequireauth_nouserincontext_whenunauthenticated",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_testrequireauth_rejectsalgpolicyviolations",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L198",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_testrequireauth_validtoken_exposesuserid",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L118",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_middleware_test_testrequireauth_wrongsecret_unauthorized",
+      "target": "backend_internal_http_middleware_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_middleware_test_doproberequest",
+      "target": "backend_internal_http_middleware_test_go_responserecorder",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L238",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_bodyidentityisignored",
+      "target": "backend_internal_http_middleware_test_doproberequest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L146",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_expiredtoken_accesstokenexpired",
+      "target": "backend_internal_http_middleware_test_doproberequest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L105",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_malformedheader_unauthorized",
+      "target": "backend_internal_http_middleware_test_doproberequest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_missingheader_unauthorized",
+      "target": "backend_internal_http_middleware_test_doproberequest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L183",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_rejectsalgpolicyviolations",
+      "target": "backend_internal_http_middleware_test_doproberequest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L207",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_validtoken_exposesuserid",
+      "target": "backend_internal_http_middleware_test_doproberequest",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/middleware_test.go",
+      "source_location": "L126",
+      "weight": 1.0,
+      "source": "backend_internal_http_middleware_test_testrequireauth_wrongsecret_unauthorized",
+      "target": "backend_internal_http_middleware_test_doproberequest",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/router.go",
-      "source_location": "L16",
+      "source_location": "L21",
       "weight": 1.0,
       "source": "backend_internal_http_router",
       "target": "backend_internal_http_router_newrouter",
@@ -39226,7 +42261,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/router.go",
-      "source_location": "L16",
+      "source_location": "L21",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_router_newrouter",
@@ -63899,6 +66934,516 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill",
+      "target": "codex_skills_graphify_skill_graphify",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L656",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_for_graphify_add_and_watch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L644",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_for_graphify_query",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L662",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_for_the_commit_hook_and_native_claude_md_integration",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L638",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_for_update_and_cluster_only",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L668",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_honesty_rules",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L620",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_interpreter_guard_for_subcommands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_usage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_what_graphify_is_for",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_0_github_repos_and_multi_path_merge_only_if_a_url_or_several_paths",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L65",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_1_ensure_graphify_is_installed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L144",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_2_5_video_and_audio_only_if_video_files_detected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L107",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_2_detect_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L148",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L447",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_4_5_graph_health_check_read_only_integrity_gate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L384",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_4_build_graph_cluster_analyze_generate_outputs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L473",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_5_label_communities",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L514",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_6_generate_obsidian_vault_opt_in_html",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L540",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_9_save_manifest_update_cost_tracker_clean_up_and_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L534",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_steps_6b_8_wiki_neo4j_falkordb_svg_graphml_mcp_benchmark_only_on_their_flags",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L167",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "target": "codex_skills_graphify_skill_part_a_structural_extraction_for_code_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L193",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "target": "codex_skills_graphify_skill_part_b_semantic_extraction_parallel_subagents",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L350",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "target": "codex_skills_graphify_skill_part_c_merge_ast_semantic_into_final_extraction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_add_watch",
+      "target": "codex_skills_graphify_references_add_watch_graphify_reference_add_a_url_and_watch_a_folder",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_add_watch_graphify_reference_add_a_url_and_watch_a_folder",
+      "target": "codex_skills_graphify_references_add_watch_for_graphify_add",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_add_watch_graphify_reference_add_a_url_and_watch_a_folder",
+      "target": "codex_skills_graphify_references_add_watch_for_watch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports",
+      "target": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_6b_wiki_only_if_wiki_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7_neo4j_export_only_if_neo4j_or_neo4j_push_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7a_falkordb_export_only_if_falkordb_or_falkordb_push_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7b_svg_export_only_if_svg_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7c_graphml_export_only_if_graphml_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7d_mcp_server_only_if_mcp_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_8_token_reduction_benchmark_only_if_total_words_5000",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/extraction-spec.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_extraction_spec",
+      "target": "codex_skills_graphify_references_extraction_spec_graphify_reference_extraction_subagent_prompt_compact",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_github_and_merge",
+      "target": "codex_skills_graphify_references_github_and_merge_graphify_reference_github_clone_and_cross_repo_merge",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_github_and_merge_graphify_reference_github_clone_and_cross_repo_merge",
+      "target": "codex_skills_graphify_references_github_and_merge_step_0_clone_github_repo_s_only_if_a_github_url_was_given",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_hooks",
+      "target": "codex_skills_graphify_references_hooks_graphify_reference_commit_hook_and_native_claude_md_integration",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_hooks_graphify_reference_commit_hook_and_native_claude_md_integration",
+      "target": "codex_skills_graphify_references_hooks_for_git_commit_hook",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_hooks_graphify_reference_commit_hook_and_native_claude_md_integration",
+      "target": "codex_skills_graphify_references_hooks_for_native_claude_md_integration",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query",
+      "target": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L254",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "target": "codex_skills_graphify_references_query_for_graphify_explain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L186",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "target": "codex_skills_graphify_references_query_for_graphify_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "target": "codex_skills_graphify_references_query_step_0_constrained_query_expansion_required_before_traversal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "target": "codex_skills_graphify_references_query_step_1_traversal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_transcribe",
+      "target": "codex_skills_graphify_references_transcribe_graphify_reference_transcribe_video_and_audio",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_transcribe_graphify_reference_transcribe_video_and_audio",
+      "target": "codex_skills_graphify_references_transcribe_step_2_5_transcribe_video_audio_files_only_if_video_files_detected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_update",
+      "target": "codex_skills_graphify_references_update_graphify_reference_incremental_update_and_cluster_only",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L184",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_update_graphify_reference_incremental_update_and_cluster_only",
+      "target": "codex_skills_graphify_references_update_for_cluster_only",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_update_graphify_reference_incremental_update_and_cluster_only",
+      "target": "codex_skills_graphify_references_update_for_update_incremental_re_extraction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": ".github/copilot-instructions.md",
       "source_location": "L1",
       "weight": 1.0,
@@ -64060,17 +67605,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L49",
-      "weight": 1.0,
-      "source": "claude_nuchi_claude_code_guide",
-      "target": "claude_branch_and_pr_hard_rules",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "CLAUDE.md",
-      "source_location": "L22",
+      "source_location": "L24",
       "weight": 1.0,
       "source": "claude_nuchi_claude_code_guide",
       "target": "claude_commands",
@@ -64080,7 +67615,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L78",
+      "source_location": "L89",
       "weight": 1.0,
       "source": "claude_nuchi_claude_code_guide",
       "target": "claude_graphify",
@@ -64090,7 +67625,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L31",
+      "source_location": "L33",
       "weight": 1.0,
       "source": "claude_nuchi_claude_code_guide",
       "target": "claude_hard_invariants",
@@ -64100,7 +67635,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L86",
+      "source_location": "L97",
       "weight": 1.0,
       "source": "claude_nuchi_claude_code_guide",
       "target": "claude_legacy_code",
@@ -64110,7 +67645,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L67",
+      "source_location": "L78",
       "weight": 1.0,
       "source": "claude_nuchi_claude_code_guide",
       "target": "claude_model_orchestration",
@@ -64120,7 +67655,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L92",
+      "source_location": "L103",
       "weight": 1.0,
       "source": "claude_nuchi_claude_code_guide",
       "target": "claude_post_migration_improvements",
@@ -64140,10 +67675,10 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "CLAUDE.md",
-      "source_location": "L42",
+      "source_location": "L44",
       "weight": 1.0,
       "source": "claude_nuchi_claude_code_guide",
-      "target": "claude_risk_policy",
+      "target": "claude_working_flow_streamlined_2026_07_23",
       "confidence_score": 1.0
     },
     {
@@ -68978,5 +72513,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "1d153cd48ab508fad587afefc861c920bc5d7631"
+  "built_at_commit": "65cfd0518c9506d142ecddf7b3e287291b707a60"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -50,7 +50,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions",
-      "community": 348,
+      "community": 42,
       "norm_label": "actions.tsx"
     },
     {
@@ -60,7 +60,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions_props",
-      "community": 348,
+      "community": 42,
       "norm_label": "props"
     },
     {
@@ -70,7 +70,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions_actions",
-      "community": 348,
+      "community": 42,
       "norm_label": "actions()"
     },
     {
@@ -80,7 +80,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_accounts_columns",
-      "community": 432,
+      "community": 35,
       "norm_label": "columns.tsx"
     },
     {
@@ -90,7 +90,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_dashboard_accounts_columns_responsetype",
-      "community": 432,
+      "community": 35,
       "norm_label": "responsetype"
     },
     {
@@ -100,7 +100,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_dashboard_accounts_columns_columns",
-      "community": 317,
+      "community": 35,
       "norm_label": "columns"
     },
     {
@@ -120,7 +120,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "app_dashboard_accounts_page_accountspage",
-      "community": 518,
+      "community": 510,
       "norm_label": "accountspage()"
     },
     {
@@ -160,7 +160,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_categories_columns",
-      "community": 432,
+      "community": 35,
       "norm_label": "columns.tsx"
     },
     {
@@ -170,7 +170,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_dashboard_categories_columns_responsetype",
-      "community": 432,
+      "community": 35,
       "norm_label": "responsetype"
     },
     {
@@ -180,7 +180,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_dashboard_categories_columns_columns",
-      "community": 317,
+      "community": 35,
       "norm_label": "columns"
     },
     {
@@ -200,7 +200,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "app_dashboard_categories_page_categoriespage",
-      "community": 518,
+      "community": 520,
       "norm_label": "categoriespage()"
     },
     {
@@ -240,7 +240,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_page",
-      "community": 526,
+      "community": 317,
       "norm_label": "page.tsx"
     },
     {
@@ -250,7 +250,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "app_dashboard_page_dashboardpage",
-      "community": 526,
+      "community": 317,
       "norm_label": "dashboardpage()"
     },
     {
@@ -260,7 +260,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_account_column",
-      "community": 348,
+      "community": 42,
       "norm_label": "account-column.tsx"
     },
     {
@@ -270,7 +270,7 @@
       "source_location": "L2",
       "_origin": "ast",
       "id": "app_dashboard_transactions_account_column_props",
-      "community": 348,
+      "community": 42,
       "norm_label": "props"
     },
     {
@@ -280,7 +280,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "app_dashboard_transactions_account_column_accountcolumn",
-      "community": 348,
+      "community": 42,
       "norm_label": "accountcolumn()"
     },
     {
@@ -350,7 +350,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_columns",
-      "community": 432,
+      "community": 42,
       "norm_label": "columns.tsx"
     },
     {
@@ -360,7 +360,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_dashboard_transactions_columns_responsetype",
-      "community": 432,
+      "community": 42,
       "norm_label": "responsetype"
     },
     {
@@ -370,7 +370,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_dashboard_transactions_columns_columns",
-      "community": 379,
+      "community": 42,
       "norm_label": "columns"
     },
     {
@@ -430,7 +430,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table",
-      "community": 40,
+      "community": 13,
       "norm_label": "import-table.tsx"
     },
     {
@@ -440,7 +440,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table_props",
-      "community": 40,
+      "community": 13,
       "norm_label": "props"
     },
     {
@@ -450,7 +450,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table_importtable",
-      "community": 517,
+      "community": 13,
       "norm_label": "importtable()"
     },
     {
@@ -460,7 +460,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page",
-      "community": 379,
+      "community": 317,
       "norm_label": "page.tsx"
     },
     {
@@ -470,7 +470,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_variants",
-      "community": 379,
+      "community": 317,
       "norm_label": "variants"
     },
     {
@@ -480,7 +480,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_initial_import_results",
-      "community": 379,
+      "community": 317,
       "norm_label": "initial_import_results"
     },
     {
@@ -490,7 +490,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_transactionspage",
-      "community": 518,
+      "community": 432,
       "norm_label": "transactionspage()"
     },
     {
@@ -500,7 +500,7 @@
       "source_location": "L149",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_transactionspagewrapper",
-      "community": 379,
+      "community": 317,
       "norm_label": "transactionspagewrapper()"
     },
     {
@@ -570,7 +570,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button",
-      "community": 379,
+      "community": 317,
       "norm_label": "upload-button.tsx"
     },
     {
@@ -580,7 +580,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button_props",
-      "community": 379,
+      "community": 317,
       "norm_label": "props"
     },
     {
@@ -590,7 +590,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button_csvreaderrenderprops",
-      "community": 379,
+      "community": 317,
       "norm_label": "csvreaderrenderprops"
     },
     {
@@ -600,7 +600,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button_csvuploadresults",
-      "community": 379,
+      "community": 317,
       "norm_label": "csvuploadresults"
     },
     {
@@ -610,7 +610,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button_uploadbutton",
-      "community": 379,
+      "community": 317,
       "norm_label": "uploadbutton()"
     },
     {
@@ -3346,6 +3346,146 @@
       "norm_label": "admindatabaseurl()"
     },
     {
+      "label": "migration_upgrade_test.go",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test",
+      "community": 260,
+      "norm_label": "migration_upgrade_test.go"
+    },
+    {
+      "label": "TestMigration00004_NullsPreexistingCrossOwnerCategory_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L32",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "community": 260,
+      "norm_label": "testmigration00004_nullspreexistingcrossownercategory_livedatabase()"
+    },
+    {
+      "label": "T",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_go_t",
+      "community": 260,
+      "norm_label": "t"
+    },
+    {
+      "label": "gooseBinary()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L142",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_goosebinary",
+      "community": 260,
+      "norm_label": "goosebinary()"
+    },
+    {
+      "label": "runGoose()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L156",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_rungoose",
+      "community": 260,
+      "norm_label": "rungoose()"
+    },
+    {
+      "label": "Context",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_go_context",
+      "community": 260,
+      "norm_label": "context"
+    },
+    {
+      "label": "connect()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L166",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_connect",
+      "community": 260,
+      "norm_label": "connect()"
+    },
+    {
+      "label": "Conn",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "conn",
+      "community": 260,
+      "norm_label": "conn"
+    },
+    {
+      "label": "insertUpgradeUser()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L176",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_insertupgradeuser",
+      "community": 260,
+      "norm_label": "insertupgradeuser()"
+    },
+    {
+      "label": "setSessionAppUser()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L189",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_setsessionappuser",
+      "community": 260,
+      "norm_label": "setsessionappuser()"
+    },
+    {
+      "label": "execUpgrade()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L199",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_execupgrade",
+      "community": 260,
+      "norm_label": "execupgrade()"
+    },
+    {
+      "label": "userInURL()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L208",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_userinurl",
+      "community": 260,
+      "norm_label": "userinurl()"
+    },
+    {
+      "label": "withDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L222",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_withdatabase",
+      "community": 260,
+      "norm_label": "withdatabase()"
+    },
+    {
+      "label": "pgIdent()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L237",
+      "_origin": "ast",
+      "id": "backend_internal_db_migration_upgrade_test_pgident",
+      "community": 260,
+      "norm_label": "pgident()"
+    },
+    {
       "label": "queries_live_test.go",
       "file_type": "code",
       "source_file": "backend/internal/db/queries_live_test.go",
@@ -4862,7 +5002,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_livedb_test",
-      "community": 35,
+      "community": 32,
       "norm_label": "livedb_test.go"
     },
     {
@@ -4872,7 +5012,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "backend_internal_http_livedb_test_livedatabaseurl",
-      "community": 35,
+      "community": 32,
       "norm_label": "livedatabaseurl()"
     },
     {
@@ -4882,7 +5022,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_livedb_test_go_t",
-      "community": 35,
+      "community": 32,
       "norm_label": "t"
     },
     {
@@ -4892,7 +5032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_middleware",
-      "community": 35,
+      "community": 3,
       "norm_label": "middleware.go"
     },
     {
@@ -4902,7 +5042,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "http_useridcontextkey",
-      "community": 35,
+      "community": 3,
       "norm_label": "useridcontextkey"
     },
     {
@@ -4912,7 +5052,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_useridfromcontext",
-      "community": 35,
+      "community": 3,
       "norm_label": "useridfromcontext()"
     },
     {
@@ -4922,7 +5062,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_go_context",
-      "community": 35,
+      "community": 3,
       "norm_label": "context"
     },
     {
@@ -4932,7 +5072,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_go_uuid",
-      "community": 35,
+      "community": 3,
       "norm_label": "uuid"
     },
     {
@@ -4942,7 +5082,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_requireauth",
-      "community": 35,
+      "community": 3,
       "norm_label": "requireauth()"
     },
     {
@@ -4952,7 +5092,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_go_handler",
-      "community": 35,
+      "community": 3,
       "norm_label": "handler"
     },
     {
@@ -4962,7 +5102,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_bearertoken",
-      "community": 35,
+      "community": 3,
       "norm_label": "bearertoken()"
     },
     {
@@ -4972,7 +5112,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_writeapierror",
-      "community": 35,
+      "community": 3,
       "norm_label": "writeapierror()"
     },
     {
@@ -4982,7 +5122,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_go_responsewriter",
-      "community": 35,
+      "community": 3,
       "norm_label": "responsewriter"
     },
     {
@@ -4992,7 +5132,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "apierror",
-      "community": 35,
+      "community": 3,
       "norm_label": "apierror"
     },
     {
@@ -5002,7 +5142,7 @@
       "source_location": "L109",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_writeunauthorizederror",
-      "community": 35,
+      "community": 3,
       "norm_label": "writeunauthorizederror()"
     },
     {
@@ -5012,7 +5152,7 @@
       "source_location": "L116",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_writeaccesstokenexpirederror",
-      "community": 35,
+      "community": 3,
       "norm_label": "writeaccesstokenexpirederror()"
     },
     {
@@ -5022,7 +5162,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test",
-      "community": 35,
+      "community": 32,
       "norm_label": "middleware_live_test.go"
     },
     {
@@ -5032,7 +5172,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_accountprobehandler",
-      "community": 35,
+      "community": 32,
       "norm_label": "accountprobehandler()"
     },
     {
@@ -5042,7 +5182,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_go_pool",
-      "community": 35,
+      "community": 32,
       "norm_label": "pool"
     },
     {
@@ -5052,7 +5192,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_go_handlerfunc",
-      "community": 35,
+      "community": 32,
       "norm_label": "handlerfunc"
     },
     {
@@ -5062,7 +5202,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_newaccountproberouter",
-      "community": 35,
+      "community": 32,
       "norm_label": "newaccountproberouter()"
     },
     {
@@ -5072,7 +5212,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_go_handler",
-      "community": 35,
+      "community": 32,
       "norm_label": "handler"
     },
     {
@@ -5082,7 +5222,7 @@
       "source_location": "L85",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_testrequireauth_withusertx_crossuserisolation_livedatabase",
-      "community": 35,
+      "community": 32,
       "norm_label": "testrequireauth_withusertx_crossuserisolation_livedatabase()"
     },
     {
@@ -5092,7 +5232,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_go_t",
-      "community": 35,
+      "community": 32,
       "norm_label": "t"
     },
     {
@@ -5102,7 +5242,7 @@
       "source_location": "L141",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_probeaccountvisibility",
-      "community": 35,
+      "community": 32,
       "norm_label": "probeaccountvisibility()"
     },
     {
@@ -5112,7 +5252,7 @@
       "source_location": "L162",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_createprobetestuser",
-      "community": 35,
+      "community": 32,
       "norm_label": "createprobetestuser()"
     },
     {
@@ -5122,7 +5262,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_go_context",
-      "community": 35,
+      "community": 32,
       "norm_label": "context"
     },
     {
@@ -5132,7 +5272,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_live_test_go_uuid",
-      "community": 35,
+      "community": 32,
       "norm_label": "uuid"
     },
     {
@@ -5182,7 +5322,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_test_contextechoprobe",
-      "community": 35,
+      "community": 3,
       "norm_label": "contextechoprobe()"
     },
     {
@@ -5192,7 +5332,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_test_go_responsewriter",
-      "community": 35,
+      "community": 3,
       "norm_label": "responsewriter"
     },
     {
@@ -5202,7 +5342,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_test_go_request",
-      "community": 35,
+      "community": 3,
       "norm_label": "request"
     },
     {
@@ -5872,7 +6012,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "openapi_apierror",
-      "community": 510,
+      "community": 17,
       "norm_label": "apierror"
     },
     {
@@ -5882,7 +6022,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "openapi_apierrorresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": "apierrorresponse"
     },
     {
@@ -6922,7 +7062,7 @@
       "source_location": "L1493",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror",
-      "community": 520,
+      "community": 17,
       "norm_label": "unescapedcookieparamerror"
     },
     {
@@ -6932,7 +7072,7 @@
       "source_location": "L1498",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_error",
-      "community": 520,
+      "community": 17,
       "norm_label": ".error()"
     },
     {
@@ -6942,7 +7082,7 @@
       "source_location": "L1502",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_unwrap",
-      "community": 520,
+      "community": 17,
       "norm_label": ".unwrap()"
     },
     {
@@ -7002,7 +7142,7 @@
       "source_location": "L1527",
       "_origin": "ast",
       "id": "openapi_requiredheadererror",
-      "community": 17,
+      "community": 537,
       "norm_label": "requiredheadererror"
     },
     {
@@ -7012,7 +7152,7 @@
       "source_location": "L1532",
       "_origin": "ast",
       "id": "openapi_requiredheadererror_error",
-      "community": 17,
+      "community": 537,
       "norm_label": ".error()"
     },
     {
@@ -7022,7 +7162,7 @@
       "source_location": "L1536",
       "_origin": "ast",
       "id": "openapi_requiredheadererror_unwrap",
-      "community": 17,
+      "community": 537,
       "norm_label": ".unwrap()"
     },
     {
@@ -7262,7 +7402,7 @@
       "source_location": "L1716",
       "_origin": "ast",
       "id": "openapi_transactionmutationratelimiterrorresponseheaders",
-      "community": 510,
+      "community": 17,
       "norm_label": "transactionmutationratelimiterrorresponseheaders"
     },
     {
@@ -7272,7 +7412,7 @@
       "source_location": "L1719",
       "_origin": "ast",
       "id": "openapi_transactionmutationratelimiterrorjsonresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": "transactionmutationratelimiterrorjsonresponse"
     },
     {
@@ -9692,7 +9832,7 @@
       "source_location": "L3208",
       "_origin": "ast",
       "id": "openapi_createtransaction429jsonresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": "createtransaction429jsonresponse"
     },
     {
@@ -9702,7 +9842,7 @@
       "source_location": "L3212",
       "_origin": "ast",
       "id": "openapi_createtransaction429jsonresponse_visitcreatetransactionresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": ".visitcreatetransactionresponse()"
     },
     {
@@ -9862,7 +10002,7 @@
       "source_location": "L3323",
       "_origin": "ast",
       "id": "openapi_bulkcreatetransactions429jsonresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": "bulkcreatetransactions429jsonresponse"
     },
     {
@@ -9872,7 +10012,7 @@
       "source_location": "L3327",
       "_origin": "ast",
       "id": "openapi_bulkcreatetransactions429jsonresponse_visitbulkcreatetransactionsresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": ".visitbulkcreatetransactionsresponse()"
     },
     {
@@ -10012,7 +10152,7 @@
       "source_location": "L3422",
       "_origin": "ast",
       "id": "openapi_bulkdeletetransactions429jsonresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": "bulkdeletetransactions429jsonresponse"
     },
     {
@@ -10022,7 +10162,7 @@
       "source_location": "L3426",
       "_origin": "ast",
       "id": "openapi_bulkdeletetransactions429jsonresponse_visitbulkdeletetransactionsresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": ".visitbulkdeletetransactionsresponse()"
     },
     {
@@ -10152,7 +10292,7 @@
       "source_location": "L3521",
       "_origin": "ast",
       "id": "openapi_deletetransaction429jsonresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": "deletetransaction429jsonresponse"
     },
     {
@@ -10162,7 +10302,7 @@
       "source_location": "L3525",
       "_origin": "ast",
       "id": "openapi_deletetransaction429jsonresponse_visitdeletetransactionresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": ".visitdeletetransactionresponse()"
     },
     {
@@ -10212,7 +10352,7 @@
       "source_location": "L3562",
       "_origin": "ast",
       "id": "openapi_gettransaction200jsonresponse",
-      "community": 17,
+      "community": 539,
       "norm_label": "gettransaction200jsonresponse"
     },
     {
@@ -10222,7 +10362,7 @@
       "source_location": "L3564",
       "_origin": "ast",
       "id": "openapi_gettransaction200jsonresponse_visitgettransactionresponse",
-      "community": 17,
+      "community": 539,
       "norm_label": ".visitgettransactionresponse()"
     },
     {
@@ -10422,7 +10562,7 @@
       "source_location": "L3701",
       "_origin": "ast",
       "id": "openapi_updatetransaction429jsonresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": "updatetransaction429jsonresponse"
     },
     {
@@ -10432,7 +10572,7 @@
       "source_location": "L3705",
       "_origin": "ast",
       "id": "openapi_updatetransaction429jsonresponse_visitupdatetransactionresponse",
-      "community": 510,
+      "community": 17,
       "norm_label": ".visitupdatetransactionresponse()"
     },
     {
@@ -11022,7 +11162,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_account_filter_accountfilter",
-      "community": 18,
+      "community": 14,
       "norm_label": "accountfilter()"
     },
     {
@@ -11062,7 +11202,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_area_variant",
-      "community": 260,
+      "community": 9,
       "norm_label": "area-variant.tsx"
     },
     {
@@ -11072,7 +11212,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_area_variant_props",
-      "community": 260,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -11082,7 +11222,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_area_variant_areavariant",
-      "community": 260,
+      "community": 9,
       "norm_label": "areavariant()"
     },
     {
@@ -11092,7 +11232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_bar_variant",
-      "community": 260,
+      "community": 9,
       "norm_label": "bar-variant.tsx"
     },
     {
@@ -11102,7 +11242,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_bar_variant_props",
-      "community": 260,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -11112,7 +11252,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_bar_variant_barvariant",
-      "community": 260,
+      "community": 9,
       "norm_label": "barvariant()"
     },
     {
@@ -11162,7 +11302,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_chart",
-      "community": 260,
+      "community": 317,
       "norm_label": "chart.tsx"
     },
     {
@@ -11172,7 +11312,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_chart_props",
-      "community": 260,
+      "community": 317,
       "norm_label": "props"
     },
     {
@@ -11182,7 +11322,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "components_chart_chartenum",
-      "community": 260,
+      "community": 317,
       "norm_label": "chartenum"
     },
     {
@@ -11192,7 +11332,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "components_chart_chart",
-      "community": 526,
+      "community": 317,
       "norm_label": "chart()"
     },
     {
@@ -11202,7 +11342,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "components_chart_chartloading",
-      "community": 526,
+      "community": 317,
       "norm_label": "chartloading()"
     },
     {
@@ -11212,7 +11352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_count_up",
-      "community": 317,
+      "community": 9,
       "norm_label": "count-up.tsx"
     },
     {
@@ -11222,7 +11362,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_custom_tooltip",
-      "community": 260,
+      "community": 9,
       "norm_label": "custom-tooltip.tsx"
     },
     {
@@ -11232,7 +11372,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "components_custom_tooltip_tooltippayloaditem",
-      "community": 260,
+      "community": 9,
       "norm_label": "tooltippayloaditem"
     },
     {
@@ -11242,7 +11382,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_custom_tooltip_customtooltipprops",
-      "community": 260,
+      "community": 9,
       "norm_label": "customtooltipprops"
     },
     {
@@ -11252,7 +11392,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "components_custom_tooltip_customtooltip",
-      "community": 260,
+      "community": 9,
       "norm_label": "customtooltip()"
     },
     {
@@ -11262,7 +11402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_card",
-      "community": 317,
+      "community": 9,
       "norm_label": "data-card.tsx"
     },
     {
@@ -11272,7 +11412,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "components_data_card_boxvariant",
-      "community": 317,
+      "community": 9,
       "norm_label": "boxvariant"
     },
     {
@@ -11282,7 +11422,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "components_data_card_iconvariant",
-      "community": 317,
+      "community": 9,
       "norm_label": "iconvariant"
     },
     {
@@ -11292,7 +11432,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "components_data_card_boxvariants",
-      "community": 317,
+      "community": 9,
       "norm_label": "boxvariants"
     },
     {
@@ -11302,7 +11442,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "components_data_card_iconvariants",
-      "community": 317,
+      "community": 9,
       "norm_label": "iconvariants"
     },
     {
@@ -11312,7 +11452,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "components_data_card_datacardprops",
-      "community": 317,
+      "community": 9,
       "norm_label": "datacardprops"
     },
     {
@@ -11322,7 +11462,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "components_data_card_datacard",
-      "community": 317,
+      "community": 9,
       "norm_label": "datacard()"
     },
     {
@@ -11332,7 +11472,7 @@
       "source_location": "L100",
       "_origin": "ast",
       "id": "components_data_card_datacardloading",
-      "community": 526,
+      "community": 9,
       "norm_label": "datacardloading()"
     },
     {
@@ -11342,7 +11482,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_charts",
-      "community": 526,
+      "community": 317,
       "norm_label": "data-charts.tsx"
     },
     {
@@ -11352,7 +11492,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_data_charts_datacharts",
-      "community": 526,
+      "community": 317,
       "norm_label": "datacharts()"
     },
     {
@@ -11362,7 +11502,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_grid",
-      "community": 526,
+      "community": 9,
       "norm_label": "data-grid.tsx"
     },
     {
@@ -11372,7 +11512,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_data_grid_datagrid",
-      "community": 526,
+      "community": 9,
       "norm_label": "datagrid()"
     },
     {
@@ -11382,7 +11522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_table",
-      "community": 40,
+      "community": 13,
       "norm_label": "data-table.tsx"
     },
     {
@@ -11392,7 +11532,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "components_data_table_datatableprops",
-      "community": 40,
+      "community": 13,
       "norm_label": "datatableprops"
     },
     {
@@ -11492,7 +11632,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_filters",
-      "community": 18,
+      "community": 14,
       "norm_label": "filters.tsx"
     },
     {
@@ -11502,7 +11642,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "components_filters_filters",
-      "community": 18,
+      "community": 14,
       "norm_label": "filters()"
     },
     {
@@ -11552,7 +11692,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_line_variant",
-      "community": 260,
+      "community": 9,
       "norm_label": "line-variant.tsx"
     },
     {
@@ -11562,7 +11702,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_line_variant_props",
-      "community": 260,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -11572,7 +11712,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_line_variant_linevariant",
-      "community": 260,
+      "community": 9,
       "norm_label": "linevariant()"
     },
     {
@@ -11582,7 +11722,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_nav_button",
-      "community": 14,
+      "community": 35,
       "norm_label": "nav-button.tsx"
     },
     {
@@ -11592,7 +11732,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_nav_button_props",
-      "community": 14,
+      "community": 35,
       "norm_label": "props"
     },
     {
@@ -11602,7 +11742,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "components_nav_button_navbutton",
-      "community": 14,
+      "community": 35,
       "norm_label": "navbutton()"
     },
     {
@@ -11692,7 +11832,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_radar_variant",
-      "community": 9,
+      "community": 317,
       "norm_label": "radar-variant.tsx"
     },
     {
@@ -11702,7 +11842,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_radar_variant_props",
-      "community": 9,
+      "community": 317,
       "norm_label": "props"
     },
     {
@@ -11712,7 +11852,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_radar_variant_radarvariant",
-      "community": 9,
+      "community": 317,
       "norm_label": "radarvariant()"
     },
     {
@@ -11762,7 +11902,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_select",
-      "community": 45,
+      "community": 526,
       "norm_label": "select.tsx"
     },
     {
@@ -11772,7 +11912,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "components_select_props",
-      "community": 45,
+      "community": 526,
       "norm_label": "props"
     },
     {
@@ -11782,7 +11922,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "components_select_select",
-      "community": 45,
+      "community": 526,
       "norm_label": "select()"
     },
     {
@@ -11792,7 +11932,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_spending_pie",
-      "community": 9,
+      "community": 317,
       "norm_label": "spending-pie.tsx"
     },
     {
@@ -11802,7 +11942,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_spending_pie_props",
-      "community": 9,
+      "community": 317,
       "norm_label": "props"
     },
     {
@@ -11812,7 +11952,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieenum",
-      "community": 9,
+      "community": 317,
       "norm_label": "spendingpieenum"
     },
     {
@@ -11822,7 +11962,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpie",
-      "community": 526,
+      "community": 317,
       "norm_label": "spendingpie()"
     },
     {
@@ -11832,7 +11972,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieloading",
-      "community": 526,
+      "community": 317,
       "norm_label": "spendingpieloading()"
     },
     {
@@ -11842,7 +11982,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_badge",
-      "community": 432,
+      "community": 42,
       "norm_label": "badge.tsx"
     },
     {
@@ -11852,7 +11992,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "components_ui_badge_badgevariants",
-      "community": 432,
+      "community": 42,
       "norm_label": "badgevariants"
     },
     {
@@ -11862,7 +12002,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "components_ui_badge_badge",
-      "community": 432,
+      "community": 42,
       "norm_label": "badge()"
     },
     {
@@ -11872,7 +12012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_button",
-      "community": 14,
+      "community": 35,
       "norm_label": "button.tsx"
     },
     {
@@ -11892,7 +12032,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "components_ui_button_button",
-      "community": 14,
+      "community": 35,
       "norm_label": "button()"
     },
     {
@@ -11972,7 +12112,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "components_ui_card_carddescription",
-      "community": 317,
+      "community": 9,
       "norm_label": "carddescription()"
     },
     {
@@ -12012,7 +12152,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_checkbox",
-      "community": 432,
+      "community": 35,
       "norm_label": "checkbox.tsx"
     },
     {
@@ -12022,7 +12162,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "components_ui_checkbox_checkbox",
-      "community": 432,
+      "community": 35,
       "norm_label": "checkbox()"
     },
     {
@@ -12032,7 +12172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_dialog",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialog.tsx"
     },
     {
@@ -12042,7 +12182,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_ui_dialog_dialog",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialog()"
     },
     {
@@ -12052,7 +12192,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtrigger",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogtrigger()"
     },
     {
@@ -12062,7 +12202,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogportal",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogportal()"
     },
     {
@@ -12072,7 +12212,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogclose",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogclose()"
     },
     {
@@ -12082,7 +12222,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogoverlay",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogoverlay()"
     },
     {
@@ -12092,7 +12232,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogcontent",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogcontent()"
     },
     {
@@ -12102,7 +12242,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogheader",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogheader()"
     },
     {
@@ -12112,7 +12252,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogfooter",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogfooter()"
     },
     {
@@ -12122,7 +12262,7 @@
       "source_location": "L121",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtitle",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogtitle()"
     },
     {
@@ -12132,7 +12272,7 @@
       "source_location": "L134",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogdescription",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogdescription()"
     },
     {
@@ -12142,7 +12282,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdown-menu.tsx"
     },
     {
@@ -12162,7 +12302,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuportal",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenuportal()"
     },
     {
@@ -12182,7 +12322,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenucontent",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenucontent()"
     },
     {
@@ -12192,7 +12332,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenugroup",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenugroup()"
     },
     {
@@ -12202,7 +12342,7 @@
       "source_location": "L62",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuitem",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenuitem()"
     },
     {
@@ -12212,7 +12352,7 @@
       "source_location": "L85",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenucheckboxitem",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenucheckboxitem()"
     },
     {
@@ -12222,7 +12362,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuradiogroup",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenuradiogroup()"
     },
     {
@@ -12232,7 +12372,7 @@
       "source_location": "L122",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuradioitem",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenuradioitem()"
     },
     {
@@ -12242,7 +12382,7 @@
       "source_location": "L146",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenulabel",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenulabel()"
     },
     {
@@ -12252,7 +12392,7 @@
       "source_location": "L166",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuseparator",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenuseparator()"
     },
     {
@@ -12262,7 +12402,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenushortcut",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenushortcut()"
     },
     {
@@ -12272,7 +12412,7 @@
       "source_location": "L195",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenusub",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenusub()"
     },
     {
@@ -12282,7 +12422,7 @@
       "source_location": "L201",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenusubtrigger",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenusubtrigger()"
     },
     {
@@ -12292,7 +12432,7 @@
       "source_location": "L225",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenusubcontent",
-      "community": 14,
+      "community": 42,
       "norm_label": "dropdownmenusubcontent()"
     },
     {
@@ -12722,7 +12862,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetoverlay",
-      "community": 14,
+      "community": 13,
       "norm_label": "sheetoverlay()"
     },
     {
@@ -12752,7 +12892,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetfooter",
-      "community": 14,
+      "community": 13,
       "norm_label": "sheetfooter()"
     },
     {
@@ -12822,7 +12962,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_table",
-      "community": 40,
+      "community": 13,
       "norm_label": "table.tsx"
     },
     {
@@ -12832,7 +12972,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "components_ui_table_table",
-      "community": 40,
+      "community": 13,
       "norm_label": "table()"
     },
     {
@@ -12842,7 +12982,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_ui_table_tableheader",
-      "community": 40,
+      "community": 13,
       "norm_label": "tableheader()"
     },
     {
@@ -12852,7 +12992,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "components_ui_table_tablebody",
-      "community": 40,
+      "community": 13,
       "norm_label": "tablebody()"
     },
     {
@@ -12862,7 +13002,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "components_ui_table_tablefooter",
-      "community": 40,
+      "community": 13,
       "norm_label": "tablefooter()"
     },
     {
@@ -12872,7 +13012,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "components_ui_table_tablerow",
-      "community": 40,
+      "community": 13,
       "norm_label": "tablerow()"
     },
     {
@@ -12882,7 +13022,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "components_ui_table_tablehead",
-      "community": 40,
+      "community": 13,
       "norm_label": "tablehead()"
     },
     {
@@ -12892,7 +13032,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "components_ui_table_tablecell",
-      "community": 40,
+      "community": 13,
       "norm_label": "tablecell()"
     },
     {
@@ -12902,7 +13042,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_table_tablecaption",
-      "community": 40,
+      "community": 13,
       "norm_label": "tablecaption()"
     },
     {
@@ -13162,7 +13302,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "db_schema",
-      "community": 23,
+      "community": 518,
       "norm_label": "schema.ts"
     },
     {
@@ -13172,7 +13312,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "db_schema_citext",
-      "community": 23,
+      "community": 518,
       "norm_label": "citext"
     },
     {
@@ -13192,7 +13332,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "db_schema_accountsrelations",
-      "community": 23,
+      "community": 518,
       "norm_label": "accountsrelations"
     },
     {
@@ -13212,7 +13352,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "db_schema_categoriesrelations",
-      "community": 23,
+      "community": 518,
       "norm_label": "categoriesrelations"
     },
     {
@@ -13232,7 +13372,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "db_schema_transactionsrelations",
-      "community": 23,
+      "community": 518,
       "norm_label": "transactionsrelations"
     },
     {
@@ -13242,7 +13382,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "db_schema_insertaccountschema",
-      "community": 23,
+      "community": 518,
       "norm_label": "insertaccountschema"
     },
     {
@@ -13252,7 +13392,7 @@
       "source_location": "L107",
       "_origin": "ast",
       "id": "db_schema_insertcategoryschema",
-      "community": 23,
+      "community": 518,
       "norm_label": "insertcategoryschema"
     },
     {
@@ -13302,7 +13442,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts",
-      "community": 432,
+      "community": 510,
       "norm_label": "use-bulk-delete-accounts.ts"
     },
     {
@@ -13312,7 +13452,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_responsetype",
-      "community": 432,
+      "community": 510,
       "norm_label": "responsetype"
     },
     {
@@ -13322,7 +13462,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_requesttype",
-      "community": 432,
+      "community": 510,
       "norm_label": "requesttype"
     },
     {
@@ -13332,7 +13472,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_usebulkdeleteaccounts",
-      "community": 518,
+      "community": 510,
       "norm_label": "usebulkdeleteaccounts()"
     },
     {
@@ -13342,7 +13482,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account",
-      "community": 518,
+      "community": 513,
       "norm_label": "use-create-account.ts"
     },
     {
@@ -13352,7 +13492,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_responsetype",
-      "community": 518,
+      "community": 513,
       "norm_label": "responsetype"
     },
     {
@@ -13362,7 +13502,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_requesttype",
-      "community": 518,
+      "community": 513,
       "norm_label": "requesttype"
     },
     {
@@ -13372,7 +13512,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_usecreateaccount",
-      "community": 518,
+      "community": 40,
       "norm_label": "usecreateaccount()"
     },
     {
@@ -13452,7 +13592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_account",
-      "community": 432,
+      "community": 348,
       "norm_label": "use-get-account.ts"
     },
     {
@@ -13472,7 +13612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_accounts",
-      "community": 518,
+      "community": 40,
       "norm_label": "use-get-accounts.ts"
     },
     {
@@ -13482,7 +13622,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_accounts_usegetaccounts",
-      "community": 518,
+      "community": 40,
       "norm_label": "usegetaccounts()"
     },
     {
@@ -13532,7 +13672,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_accounts_components_account_form_accountform",
-      "community": 23,
+      "community": 348,
       "norm_label": "accountform()"
     },
     {
@@ -13592,7 +13732,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "features_accounts_components_new_account_sheet_newaccountsheet",
-      "community": 518,
+      "community": 510,
       "norm_label": "newaccountsheet()"
     },
     {
@@ -13602,7 +13742,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_new_account",
-      "community": 518,
+      "community": 510,
       "norm_label": "use-new-account.ts"
     },
     {
@@ -13612,7 +13752,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_new_account_newaccountstate",
-      "community": 518,
+      "community": 510,
       "norm_label": "newaccountstate"
     },
     {
@@ -13622,7 +13762,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_new_account_usenewaccount",
-      "community": 518,
+      "community": 510,
       "norm_label": "usenewaccount"
     },
     {
@@ -13632,7 +13772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_open_account",
-      "community": 348,
+      "community": 42,
       "norm_label": "use-open-account.ts"
     },
     {
@@ -13642,7 +13782,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_open_account_openaccountstate",
-      "community": 348,
+      "community": 42,
       "norm_label": "openaccountstate"
     },
     {
@@ -13652,7 +13792,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_open_account_useopenaccount",
-      "community": 348,
+      "community": 42,
       "norm_label": "useopenaccount"
     },
     {
@@ -13662,7 +13802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account",
-      "community": 14,
+      "community": 35,
       "norm_label": "use-select-account.tsx"
     },
     {
@@ -13672,7 +13812,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account_useselectaccount",
-      "community": 518,
+      "community": 40,
       "norm_label": "useselectaccount()"
     },
     {
@@ -13682,7 +13822,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_bulk_delete_categories",
-      "community": 432,
+      "community": 520,
       "norm_label": "use-bulk-delete-categories.ts"
     },
     {
@@ -13692,7 +13832,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_bulk_delete_categories_responsetype",
-      "community": 432,
+      "community": 520,
       "norm_label": "responsetype"
     },
     {
@@ -13702,7 +13842,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_categories_api_use_bulk_delete_categories_requesttype",
-      "community": 432,
+      "community": 520,
       "norm_label": "requesttype"
     },
     {
@@ -13712,7 +13852,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_categories_api_use_bulk_delete_categories_usebulkdeletecategories",
-      "community": 518,
+      "community": 520,
       "norm_label": "usebulkdeletecategories()"
     },
     {
@@ -13722,7 +13862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category",
-      "community": 518,
+      "community": 513,
       "norm_label": "use-create-category.ts"
     },
     {
@@ -13732,7 +13872,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_responsetype",
-      "community": 518,
+      "community": 513,
       "norm_label": "responsetype"
     },
     {
@@ -13742,7 +13882,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_requesttype",
-      "community": 518,
+      "community": 513,
       "norm_label": "requesttype"
     },
     {
@@ -13752,7 +13892,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_usecreatecategory",
-      "community": 518,
+      "community": 40,
       "norm_label": "usecreatecategory()"
     },
     {
@@ -13762,7 +13902,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category",
-      "community": 42,
+      "community": 379,
       "norm_label": "use-delete-category.ts"
     },
     {
@@ -13772,7 +13912,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category_responsetype",
-      "community": 42,
+      "community": 379,
       "norm_label": "responsetype"
     },
     {
@@ -13782,7 +13922,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category_usedeletecategory",
-      "community": 42,
+      "community": 379,
       "norm_label": "usedeletecategory()"
     },
     {
@@ -13792,7 +13932,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category",
-      "community": 432,
+      "community": 379,
       "norm_label": "use-edit-category.ts"
     },
     {
@@ -13802,7 +13942,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category_responsetype",
-      "community": 432,
+      "community": 379,
       "norm_label": "responsetype"
     },
     {
@@ -13812,7 +13952,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category_requesttype",
-      "community": 432,
+      "community": 379,
       "norm_label": "requesttype"
     },
     {
@@ -13822,7 +13962,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category_useeditcategory",
-      "community": 42,
+      "community": 379,
       "norm_label": "useeditcategory()"
     },
     {
@@ -13832,7 +13972,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_get_categories",
-      "community": 518,
+      "community": 40,
       "norm_label": "use-get-categories.ts"
     },
     {
@@ -13842,7 +13982,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_categories_api_use_get_categories_usegetcategories",
-      "community": 518,
+      "community": 40,
       "norm_label": "usegetcategories()"
     },
     {
@@ -13852,7 +13992,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_get_category",
-      "community": 42,
+      "community": 379,
       "norm_label": "use-get-category.ts"
     },
     {
@@ -13862,7 +14002,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "features_categories_api_use_get_category_usegetcategory",
-      "community": 42,
+      "community": 379,
       "norm_label": "usegetcategory()"
     },
     {
@@ -13912,7 +14052,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_categories_components_category_form_categoryform",
-      "community": 23,
+      "community": 379,
       "norm_label": "categoryform()"
     },
     {
@@ -13922,7 +14062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet",
-      "community": 42,
+      "community": 379,
       "norm_label": "edit-category-sheet.tsx"
     },
     {
@@ -13932,7 +14072,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet_formvalues",
-      "community": 42,
+      "community": 379,
       "norm_label": "formvalues"
     },
     {
@@ -13942,7 +14082,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet_editcategorysheet",
-      "community": 42,
+      "community": 379,
       "norm_label": "editcategorysheet()"
     },
     {
@@ -13972,7 +14112,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "features_categories_components_new_category_sheet_newcategorysheet",
-      "community": 518,
+      "community": 520,
       "norm_label": "newcategorysheet()"
     },
     {
@@ -13982,7 +14122,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_hooks_use_new_category",
-      "community": 518,
+      "community": 520,
       "norm_label": "use-new-category.ts"
     },
     {
@@ -13992,7 +14132,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_categories_hooks_use_new_category_newcategorystate",
-      "community": 518,
+      "community": 520,
       "norm_label": "newcategorystate"
     },
     {
@@ -14002,7 +14142,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_hooks_use_new_category_usenewcategory",
-      "community": 518,
+      "community": 520,
       "norm_label": "usenewcategory"
     },
     {
@@ -14052,7 +14192,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_summary_use_get_summary_usegetsummary",
-      "community": 526,
+      "community": 432,
       "norm_label": "usegetsummary()"
     },
     {
@@ -14092,7 +14232,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_create_transactions_usebulkcreatetransactions",
-      "community": 518,
+      "community": 432,
       "norm_label": "usebulkcreatetransactions()"
     },
     {
@@ -14132,7 +14272,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_delete_transactions_usebulkdeletetransactions",
-      "community": 518,
+      "community": 432,
       "norm_label": "usebulkdeletetransactions()"
     },
     {
@@ -14142,7 +14282,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction",
-      "community": 432,
+      "community": 513,
       "norm_label": "use-create-transaction.ts"
     },
     {
@@ -14152,7 +14292,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_responsetype",
-      "community": 432,
+      "community": 513,
       "norm_label": "responsetype"
     },
     {
@@ -14162,7 +14302,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_requesttype",
-      "community": 432,
+      "community": 513,
       "norm_label": "requesttype"
     },
     {
@@ -14172,7 +14312,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_usecreatetransaction",
-      "community": 518,
+      "community": 40,
       "norm_label": "usecreatetransaction()"
     },
     {
@@ -14182,7 +14322,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_delete_transaction",
-      "community": 518,
+      "community": 40,
       "norm_label": "use-delete-transaction.ts"
     },
     {
@@ -14192,7 +14332,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_delete_transaction_responsetype",
-      "community": 518,
+      "community": 40,
       "norm_label": "responsetype"
     },
     {
@@ -14202,7 +14342,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "features_transactions_api_use_delete_transaction_usedeletetransaction",
-      "community": 518,
+      "community": 40,
       "norm_label": "usedeletetransaction()"
     },
     {
@@ -14212,7 +14352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_edit_transaction",
-      "community": 432,
+      "community": 513,
       "norm_label": "use-edit-transaction.ts"
     },
     {
@@ -14222,7 +14362,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_edit_transaction_responsetype",
-      "community": 432,
+      "community": 513,
       "norm_label": "responsetype"
     },
     {
@@ -14232,7 +14372,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_transactions_api_use_edit_transaction_requesttype",
-      "community": 432,
+      "community": 513,
       "norm_label": "requesttype"
     },
     {
@@ -14242,7 +14382,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_transactions_api_use_edit_transaction_useedittransaction",
-      "community": 518,
+      "community": 40,
       "norm_label": "useedittransaction()"
     },
     {
@@ -14252,7 +14392,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transaction",
-      "community": 432,
+      "community": 40,
       "norm_label": "use-get-transaction.ts"
     },
     {
@@ -14262,7 +14402,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transaction_usegettransaction",
-      "community": 518,
+      "community": 40,
       "norm_label": "usegettransaction()"
     },
     {
@@ -14292,7 +14432,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_components_edit_transaction_sheet",
-      "community": 518,
+      "community": 40,
       "norm_label": "edit-transaction-sheet.tsx"
     },
     {
@@ -14302,7 +14442,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "features_transactions_components_edit_transaction_sheet_formvalues",
-      "community": 518,
+      "community": 40,
       "norm_label": "formvalues"
     },
     {
@@ -14312,7 +14452,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "features_transactions_components_edit_transaction_sheet_edittransactionsheet",
-      "community": 518,
+      "community": 40,
       "norm_label": "edittransactionsheet()"
     },
     {
@@ -14342,7 +14482,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet_newtransactionsheet",
-      "community": 518,
+      "community": 40,
       "norm_label": "newtransactionsheet()"
     },
     {
@@ -14402,7 +14542,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "features_transactions_components_transaction_form_transactionform",
-      "community": 23,
+      "community": 518,
       "norm_label": "transactionform()"
     },
     {
@@ -14472,7 +14612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "hooks_use_confirm",
-      "community": 14,
+      "community": 35,
       "norm_label": "use-confirm.tsx"
     },
     {
@@ -14482,7 +14622,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "hooks_use_confirm_useconfirm",
-      "community": 348,
+      "community": 42,
       "norm_label": "useconfirm()"
     },
     {
@@ -14532,7 +14672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_error",
-      "community": 432,
+      "community": 513,
       "norm_label": "api-error.ts"
     },
     {
@@ -14542,7 +14682,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "lib_api_error_apierrordetails",
-      "community": 432,
+      "community": 513,
       "norm_label": "apierrordetails"
     },
     {
@@ -14632,7 +14772,7 @@
       "source_location": "L112",
       "_origin": "ast",
       "id": "lib_api_error_createapierror",
-      "community": 518,
+      "community": 40,
       "norm_label": "createapierror()"
     },
     {
@@ -14642,7 +14782,7 @@
       "source_location": "L149",
       "_origin": "ast",
       "id": "lib_api_error_logerror",
-      "community": 432,
+      "community": 513,
       "norm_label": "logerror()"
     },
     {
@@ -14652,7 +14792,7 @@
       "source_location": "L205",
       "_origin": "ast",
       "id": "lib_api_error_isapierror",
-      "community": 432,
+      "community": 513,
       "norm_label": "isapierror()"
     },
     {
@@ -14722,7 +14862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items_test",
-      "community": 379,
+      "community": 317,
       "norm_label": "chunk-items.test.ts"
     },
     {
@@ -14732,7 +14872,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items",
-      "community": 379,
+      "community": 317,
       "norm_label": "chunk-items.ts"
     },
     {
@@ -14742,7 +14882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items_chunkitems",
-      "community": 379,
+      "community": 317,
       "norm_label": "chunkitems()"
     },
     {
@@ -14772,7 +14912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options_test",
-      "community": 45,
+      "community": 526,
       "norm_label": "select-options.test.ts"
     },
     {
@@ -14782,7 +14922,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options",
-      "community": 45,
+      "community": 526,
       "norm_label": "select-options.ts"
     },
     {
@@ -14792,7 +14932,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options_selectoption",
-      "community": 45,
+      "community": 526,
       "norm_label": "selectoption"
     },
     {
@@ -14802,7 +14942,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "lib_select_options_mergecreatedselectoption",
-      "community": 45,
+      "community": 526,
       "norm_label": "mergecreatedselectoption()"
     },
     {
@@ -14992,7 +15132,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_utils",
-      "community": 432,
+      "community": 9,
       "norm_label": "utils.ts"
     },
     {
@@ -15002,7 +15142,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "lib_utils_cn",
-      "community": 14,
+      "community": 13,
       "norm_label": "cn()"
     },
     {
@@ -15022,7 +15162,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "lib_utils_convertamounttomiliunits",
-      "community": 23,
+      "community": 517,
       "norm_label": "convertamounttomiliunits()"
     },
     {
@@ -15062,7 +15202,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "lib_utils_period",
-      "community": 432,
+      "community": 9,
       "norm_label": "period"
     },
     {
@@ -15072,7 +15212,7 @@
       "source_location": "L76",
       "_origin": "ast",
       "id": "lib_utils_formatdaterange",
-      "community": 14,
+      "community": 9,
       "norm_label": "formatdaterange()"
     },
     {
@@ -16032,7 +16172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "providers_sheet_provider",
-      "community": 518,
+      "community": 348,
       "norm_label": "sheet-provider.tsx"
     },
     {
@@ -36748,6 +36888,17 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L33",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_livedb_test_livedatabaseurl"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/db/queries_live_test.go",
       "source_location": "L489",
       "weight": 1.0,
@@ -36847,11 +36998,419 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L34",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_livedb_test_admindatabaseurl"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
       "source_location": "L295",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
       "target": "backend_internal_db_livedb_test_admindatabaseurl"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L166",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_connect",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L199",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_execupgrade",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L142",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_goosebinary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L176",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_insertupgradeuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L237",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_pgident",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L156",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_rungoose",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L189",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_setsessionappuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L208",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_userinurl",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L222",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test",
+      "target": "backend_internal_db_migration_upgrade_test_withdatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_connect",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L103",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_execupgrade",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L32",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_goosebinary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L100",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_insertupgradeuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_pgident",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L91",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_rungoose",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L102",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_setsessionappuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_userinurl",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "backend_internal_db_migration_upgrade_test_testmigration00004_nullspreexistingcrossownercategory_livedatabase",
+      "target": "backend_internal_db_migration_upgrade_test_withdatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L166",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_connect",
+      "target": "backend_internal_db_migration_upgrade_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L199",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_execupgrade",
+      "target": "backend_internal_db_migration_upgrade_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L142",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_goosebinary",
+      "target": "backend_internal_db_migration_upgrade_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L176",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_insertupgradeuser",
+      "target": "backend_internal_db_migration_upgrade_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L156",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_rungoose",
+      "target": "backend_internal_db_migration_upgrade_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L189",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_setsessionappuser",
+      "target": "backend_internal_db_migration_upgrade_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L208",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_userinurl",
+      "target": "backend_internal_db_migration_upgrade_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L222",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_withdatabase",
+      "target": "backend_internal_db_migration_upgrade_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L156",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_rungoose",
+      "target": "backend_internal_db_migration_upgrade_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L166",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_connect",
+      "target": "backend_internal_db_migration_upgrade_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L199",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_execupgrade",
+      "target": "backend_internal_db_migration_upgrade_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L176",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_insertupgradeuser",
+      "target": "backend_internal_db_migration_upgrade_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L189",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_setsessionappuser",
+      "target": "backend_internal_db_migration_upgrade_test_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L166",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_db_migration_upgrade_test_connect",
+      "target": "conn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L199",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_execupgrade",
+      "target": "conn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L176",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_insertupgradeuser",
+      "target": "conn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/migration_upgrade_test.go",
+      "source_location": "L189",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_migration_upgrade_test_setsessionappuser",
+      "target": "conn",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -72917,5 +73476,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "3a9e429c7cc5d7b7bc6045573814ae8d651e94be"
+  "built_at_commit": "fe011303a9b911c1b173435a479957f0c0c74020"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -80,7 +80,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_accounts_columns",
-      "community": 517,
+      "community": 432,
       "norm_label": "columns.tsx"
     },
     {
@@ -90,7 +90,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_dashboard_accounts_columns_responsetype",
-      "community": 517,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -100,7 +100,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_dashboard_accounts_columns_columns",
-      "community": 517,
+      "community": 317,
       "norm_label": "columns"
     },
     {
@@ -120,7 +120,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "app_dashboard_accounts_page_accountspage",
-      "community": 520,
+      "community": 518,
       "norm_label": "accountspage()"
     },
     {
@@ -160,7 +160,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_categories_columns",
-      "community": 517,
+      "community": 432,
       "norm_label": "columns.tsx"
     },
     {
@@ -170,7 +170,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_dashboard_categories_columns_responsetype",
-      "community": 517,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -180,7 +180,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_dashboard_categories_columns_columns",
-      "community": 517,
+      "community": 317,
       "norm_label": "columns"
     },
     {
@@ -200,7 +200,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "app_dashboard_categories_page_categoriespage",
-      "community": 260,
+      "community": 518,
       "norm_label": "categoriespage()"
     },
     {
@@ -350,7 +350,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_columns",
-      "community": 517,
+      "community": 432,
       "norm_label": "columns.tsx"
     },
     {
@@ -360,7 +360,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_dashboard_transactions_columns_responsetype",
-      "community": 517,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -370,7 +370,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_dashboard_transactions_columns_columns",
-      "community": 517,
+      "community": 379,
       "norm_label": "columns"
     },
     {
@@ -380,7 +380,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card",
-      "community": 40,
+      "community": 517,
       "norm_label": "import-card.tsx"
     },
     {
@@ -390,7 +390,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_requiredoptions",
-      "community": 40,
+      "community": 517,
       "norm_label": "requiredoptions"
     },
     {
@@ -400,7 +400,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_selectedcolumnsstate",
-      "community": 40,
+      "community": 517,
       "norm_label": "selectedcolumnsstate"
     },
     {
@@ -410,7 +410,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_props",
-      "community": 40,
+      "community": 517,
       "norm_label": "props"
     },
     {
@@ -420,7 +420,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_importcard",
-      "community": 40,
+      "community": 517,
       "norm_label": "importcard()"
     },
     {
@@ -450,7 +450,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table_importtable",
-      "community": 40,
+      "community": 517,
       "norm_label": "importtable()"
     },
     {
@@ -490,7 +490,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_transactionspage",
-      "community": 379,
+      "community": 518,
       "norm_label": "transactionspage()"
     },
     {
@@ -510,7 +510,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select",
-      "community": 317,
+      "community": 13,
       "norm_label": "table-head-select.tsx"
     },
     {
@@ -520,7 +520,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_props",
-      "community": 317,
+      "community": 13,
       "norm_label": "props"
     },
     {
@@ -530,7 +530,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_options",
-      "community": 317,
+      "community": 13,
       "norm_label": "options"
     },
     {
@@ -540,7 +540,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_importabletransactionfield",
-      "community": 40,
+      "community": 13,
       "norm_label": "importabletransactionfield"
     },
     {
@@ -550,7 +550,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_isimportabletransactionfield",
-      "community": 317,
+      "community": 13,
       "norm_label": "isimportabletransactionfield()"
     },
     {
@@ -560,7 +560,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_tableheadselect",
-      "community": 317,
+      "community": 13,
       "norm_label": "tableheadselect()"
     },
     {
@@ -900,7 +900,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_cmd_api_main",
-      "community": 3,
+      "community": 32,
       "norm_label": "main.go"
     },
     {
@@ -910,17 +910,17 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "backend_cmd_api_main_main",
-      "community": 3,
+      "community": 32,
       "norm_label": "main()"
     },
     {
       "label": "databaseHost()",
       "file_type": "code",
       "source_file": "backend/cmd/api/main.go",
-      "source_location": "L85",
+      "source_location": "L96",
       "_origin": "ast",
       "id": "backend_cmd_api_main_databasehost",
-      "community": 3,
+      "community": 32,
       "norm_label": "databasehost()"
     },
     {
@@ -3336,6 +3336,16 @@
       "norm_label": "t"
     },
     {
+      "label": "adminDatabaseURL()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/livedb_test.go",
+      "source_location": "L39",
+      "_origin": "ast",
+      "id": "backend_internal_db_livedb_test_admindatabaseurl",
+      "community": 32,
+      "norm_label": "admindatabaseurl()"
+    },
+    {
       "label": "queries_live_test.go",
       "file_type": "code",
       "source_file": "backend/internal/db/queries_live_test.go",
@@ -3466,6 +3476,26 @@
       "norm_label": "queries"
     },
     {
+      "label": "VerifyRLSActive()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L92",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_verifyrlsactive",
+      "community": 32,
+      "norm_label": "verifyrlsactive()"
+    },
+    {
+      "label": "connectionRoleAttributes()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L113",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_connectionroleattributes",
+      "community": 32,
+      "norm_label": "connectionroleattributes()"
+    },
+    {
       "label": "rls_test.go",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
@@ -3479,7 +3509,7 @@
       "label": "createRLSTestUser()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L19",
+      "source_location": "L20",
       "_origin": "ast",
       "id": "backend_internal_db_rls_test_createrlstestuser",
       "community": 32,
@@ -3529,7 +3559,7 @@
       "label": "deleteRLSTestUsers()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "_origin": "ast",
       "id": "backend_internal_db_rls_test_deleterlstestusers",
       "community": 32,
@@ -3539,7 +3569,7 @@
       "label": "createRLSTestAccount()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L47",
+      "source_location": "L48",
       "_origin": "ast",
       "id": "backend_internal_db_rls_test_createrlstestaccount",
       "community": 32,
@@ -3549,7 +3579,7 @@
       "label": "TestWithUserTx_OwnerRoundTrip_LiveDatabase()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L72",
+      "source_location": "L73",
       "_origin": "ast",
       "id": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
       "community": 32,
@@ -3559,7 +3589,7 @@
       "label": "TestWithUserTx_PolicyBlocksCrossUserAccess_LiveDatabase()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L126",
+      "source_location": "L127",
       "_origin": "ast",
       "id": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
       "community": 32,
@@ -3569,7 +3599,7 @@
       "label": "TestWithUserTx_UnboundTransactionFailsClosed_LiveDatabase()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L189",
+      "source_location": "L190",
       "_origin": "ast",
       "id": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
       "community": 32,
@@ -3579,11 +3609,61 @@
       "label": "TestWithUserTx_RollsBackOnError_LiveDatabase()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L227",
+      "source_location": "L228",
       "_origin": "ast",
       "id": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
       "community": 32,
       "norm_label": "testwithusertx_rollsbackonerror_livedatabase()"
+    },
+    {
+      "label": "TestVerifyRLSActive_PassesForOrdinaryRole_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L273",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
+      "community": 32,
+      "norm_label": "testverifyrlsactive_passesforordinaryrole_livedatabase()"
+    },
+    {
+      "label": "TestVerifyRLSActive_RejectsBypassingRole_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L294",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
+      "community": 32,
+      "norm_label": "testverifyrlsactive_rejectsbypassingrole_livedatabase()"
+    },
+    {
+      "label": "transactions_category_rls_test.go",
+      "file_type": "code",
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_db_transactions_category_rls_test",
+      "community": 32,
+      "norm_label": "transactions_category_rls_test.go"
+    },
+    {
+      "label": "TestTransactionsCategoryOwnerRLS_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L24",
+      "_origin": "ast",
+      "id": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "community": 32,
+      "norm_label": "testtransactionscategoryownerrls_livedatabase()"
+    },
+    {
+      "label": "T",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_transactions_category_rls_test_go_t",
+      "community": 32,
+      "norm_label": "t"
     },
     {
       "label": "auth.go",
@@ -5792,7 +5872,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "openapi_apierror",
-      "community": 17,
+      "community": 510,
       "norm_label": "apierror"
     },
     {
@@ -5802,7 +5882,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "openapi_apierrorresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": "apierrorresponse"
     },
     {
@@ -6842,7 +6922,7 @@
       "source_location": "L1493",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror",
-      "community": 17,
+      "community": 520,
       "norm_label": "unescapedcookieparamerror"
     },
     {
@@ -6852,7 +6932,7 @@
       "source_location": "L1498",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_error",
-      "community": 17,
+      "community": 520,
       "norm_label": ".error()"
     },
     {
@@ -6862,7 +6942,7 @@
       "source_location": "L1502",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_unwrap",
-      "community": 17,
+      "community": 520,
       "norm_label": ".unwrap()"
     },
     {
@@ -6922,7 +7002,7 @@
       "source_location": "L1527",
       "_origin": "ast",
       "id": "openapi_requiredheadererror",
-      "community": 537,
+      "community": 17,
       "norm_label": "requiredheadererror"
     },
     {
@@ -6932,7 +7012,7 @@
       "source_location": "L1532",
       "_origin": "ast",
       "id": "openapi_requiredheadererror_error",
-      "community": 537,
+      "community": 17,
       "norm_label": ".error()"
     },
     {
@@ -6942,7 +7022,7 @@
       "source_location": "L1536",
       "_origin": "ast",
       "id": "openapi_requiredheadererror_unwrap",
-      "community": 537,
+      "community": 17,
       "norm_label": ".unwrap()"
     },
     {
@@ -7182,7 +7262,7 @@
       "source_location": "L1716",
       "_origin": "ast",
       "id": "openapi_transactionmutationratelimiterrorresponseheaders",
-      "community": 17,
+      "community": 510,
       "norm_label": "transactionmutationratelimiterrorresponseheaders"
     },
     {
@@ -7192,7 +7272,7 @@
       "source_location": "L1719",
       "_origin": "ast",
       "id": "openapi_transactionmutationratelimiterrorjsonresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": "transactionmutationratelimiterrorjsonresponse"
     },
     {
@@ -9612,7 +9692,7 @@
       "source_location": "L3208",
       "_origin": "ast",
       "id": "openapi_createtransaction429jsonresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": "createtransaction429jsonresponse"
     },
     {
@@ -9622,7 +9702,7 @@
       "source_location": "L3212",
       "_origin": "ast",
       "id": "openapi_createtransaction429jsonresponse_visitcreatetransactionresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": ".visitcreatetransactionresponse()"
     },
     {
@@ -9782,7 +9862,7 @@
       "source_location": "L3323",
       "_origin": "ast",
       "id": "openapi_bulkcreatetransactions429jsonresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": "bulkcreatetransactions429jsonresponse"
     },
     {
@@ -9792,7 +9872,7 @@
       "source_location": "L3327",
       "_origin": "ast",
       "id": "openapi_bulkcreatetransactions429jsonresponse_visitbulkcreatetransactionsresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": ".visitbulkcreatetransactionsresponse()"
     },
     {
@@ -9932,7 +10012,7 @@
       "source_location": "L3422",
       "_origin": "ast",
       "id": "openapi_bulkdeletetransactions429jsonresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": "bulkdeletetransactions429jsonresponse"
     },
     {
@@ -9942,7 +10022,7 @@
       "source_location": "L3426",
       "_origin": "ast",
       "id": "openapi_bulkdeletetransactions429jsonresponse_visitbulkdeletetransactionsresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": ".visitbulkdeletetransactionsresponse()"
     },
     {
@@ -10072,7 +10152,7 @@
       "source_location": "L3521",
       "_origin": "ast",
       "id": "openapi_deletetransaction429jsonresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": "deletetransaction429jsonresponse"
     },
     {
@@ -10082,7 +10162,7 @@
       "source_location": "L3525",
       "_origin": "ast",
       "id": "openapi_deletetransaction429jsonresponse_visitdeletetransactionresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": ".visitdeletetransactionresponse()"
     },
     {
@@ -10132,7 +10212,7 @@
       "source_location": "L3562",
       "_origin": "ast",
       "id": "openapi_gettransaction200jsonresponse",
-      "community": 539,
+      "community": 17,
       "norm_label": "gettransaction200jsonresponse"
     },
     {
@@ -10142,7 +10222,7 @@
       "source_location": "L3564",
       "_origin": "ast",
       "id": "openapi_gettransaction200jsonresponse_visitgettransactionresponse",
-      "community": 539,
+      "community": 17,
       "norm_label": ".visitgettransactionresponse()"
     },
     {
@@ -10342,7 +10422,7 @@
       "source_location": "L3701",
       "_origin": "ast",
       "id": "openapi_updatetransaction429jsonresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": "updatetransaction429jsonresponse"
     },
     {
@@ -10352,7 +10432,7 @@
       "source_location": "L3705",
       "_origin": "ast",
       "id": "openapi_updatetransaction429jsonresponse_visitupdatetransactionresponse",
-      "community": 17,
+      "community": 510,
       "norm_label": ".visitupdatetransactionresponse()"
     },
     {
@@ -10932,7 +11012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_account_filter",
-      "community": 317,
+      "community": 13,
       "norm_label": "account-filter.tsx"
     },
     {
@@ -10942,7 +11022,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_account_filter_accountfilter",
-      "community": 14,
+      "community": 18,
       "norm_label": "accountfilter()"
     },
     {
@@ -10982,7 +11062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_area_variant",
-      "community": 9,
+      "community": 260,
       "norm_label": "area-variant.tsx"
     },
     {
@@ -10992,7 +11072,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_area_variant_props",
-      "community": 9,
+      "community": 260,
       "norm_label": "props"
     },
     {
@@ -11002,7 +11082,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_area_variant_areavariant",
-      "community": 9,
+      "community": 260,
       "norm_label": "areavariant()"
     },
     {
@@ -11012,7 +11092,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_bar_variant",
-      "community": 9,
+      "community": 260,
       "norm_label": "bar-variant.tsx"
     },
     {
@@ -11022,7 +11102,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_bar_variant_props",
-      "community": 9,
+      "community": 260,
       "norm_label": "props"
     },
     {
@@ -11032,7 +11112,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_bar_variant_barvariant",
-      "community": 9,
+      "community": 260,
       "norm_label": "barvariant()"
     },
     {
@@ -11082,7 +11162,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_chart",
-      "community": 317,
+      "community": 260,
       "norm_label": "chart.tsx"
     },
     {
@@ -11092,7 +11172,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_chart_props",
-      "community": 317,
+      "community": 260,
       "norm_label": "props"
     },
     {
@@ -11102,7 +11182,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "components_chart_chartenum",
-      "community": 317,
+      "community": 260,
       "norm_label": "chartenum"
     },
     {
@@ -11112,7 +11192,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "components_chart_chart",
-      "community": 317,
+      "community": 526,
       "norm_label": "chart()"
     },
     {
@@ -11122,7 +11202,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "components_chart_chartloading",
-      "community": 317,
+      "community": 526,
       "norm_label": "chartloading()"
     },
     {
@@ -11142,7 +11222,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_custom_tooltip",
-      "community": 9,
+      "community": 260,
       "norm_label": "custom-tooltip.tsx"
     },
     {
@@ -11152,7 +11232,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "components_custom_tooltip_tooltippayloaditem",
-      "community": 9,
+      "community": 260,
       "norm_label": "tooltippayloaditem"
     },
     {
@@ -11162,7 +11242,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_custom_tooltip_customtooltipprops",
-      "community": 9,
+      "community": 260,
       "norm_label": "customtooltipprops"
     },
     {
@@ -11172,7 +11252,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "components_custom_tooltip_customtooltip",
-      "community": 9,
+      "community": 260,
       "norm_label": "customtooltip()"
     },
     {
@@ -11262,7 +11342,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_charts",
-      "community": 317,
+      "community": 526,
       "norm_label": "data-charts.tsx"
     },
     {
@@ -11272,7 +11352,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_data_charts_datacharts",
-      "community": 317,
+      "community": 526,
       "norm_label": "datacharts()"
     },
     {
@@ -11402,7 +11482,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_date_picker_datepicker",
-      "community": 23,
+      "community": 14,
       "norm_label": "datepicker()"
     },
     {
@@ -11412,7 +11492,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_filters",
-      "community": 14,
+      "community": 18,
       "norm_label": "filters.tsx"
     },
     {
@@ -11422,7 +11502,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "components_filters_filters",
-      "community": 14,
+      "community": 18,
       "norm_label": "filters()"
     },
     {
@@ -11472,7 +11552,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_line_variant",
-      "community": 9,
+      "community": 260,
       "norm_label": "line-variant.tsx"
     },
     {
@@ -11482,7 +11562,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_line_variant_props",
-      "community": 9,
+      "community": 260,
       "norm_label": "props"
     },
     {
@@ -11492,7 +11572,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_line_variant_linevariant",
-      "community": 9,
+      "community": 260,
       "norm_label": "linevariant()"
     },
     {
@@ -11532,7 +11612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_navigation",
-      "community": 14,
+      "community": 518,
       "norm_label": "navigation.tsx"
     },
     {
@@ -11542,7 +11622,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_navigation_routes",
-      "community": 14,
+      "community": 518,
       "norm_label": "routes"
     },
     {
@@ -11612,7 +11692,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_radar_variant",
-      "community": 317,
+      "community": 9,
       "norm_label": "radar-variant.tsx"
     },
     {
@@ -11622,7 +11702,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_radar_variant_props",
-      "community": 317,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -11632,7 +11712,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_radar_variant_radarvariant",
-      "community": 317,
+      "community": 9,
       "norm_label": "radarvariant()"
     },
     {
@@ -11682,7 +11762,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_select",
-      "community": 13,
+      "community": 45,
       "norm_label": "select.tsx"
     },
     {
@@ -11692,7 +11772,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "components_select_props",
-      "community": 13,
+      "community": 45,
       "norm_label": "props"
     },
     {
@@ -11702,7 +11782,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "components_select_select",
-      "community": 13,
+      "community": 45,
       "norm_label": "select()"
     },
     {
@@ -11712,7 +11792,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_spending_pie",
-      "community": 317,
+      "community": 9,
       "norm_label": "spending-pie.tsx"
     },
     {
@@ -11722,7 +11802,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_spending_pie_props",
-      "community": 317,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -11732,7 +11812,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieenum",
-      "community": 317,
+      "community": 9,
       "norm_label": "spendingpieenum"
     },
     {
@@ -11742,7 +11822,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpie",
-      "community": 317,
+      "community": 526,
       "norm_label": "spendingpie()"
     },
     {
@@ -11752,7 +11832,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieloading",
-      "community": 317,
+      "community": 526,
       "norm_label": "spendingpieloading()"
     },
     {
@@ -11762,7 +11842,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_badge",
-      "community": 517,
+      "community": 432,
       "norm_label": "badge.tsx"
     },
     {
@@ -11772,7 +11852,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "components_ui_badge_badgevariants",
-      "community": 517,
+      "community": 432,
       "norm_label": "badgevariants"
     },
     {
@@ -11782,7 +11862,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "components_ui_badge_badge",
-      "community": 517,
+      "community": 432,
       "norm_label": "badge()"
     },
     {
@@ -11902,7 +11982,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "components_ui_card_cardaction",
-      "community": 42,
+      "community": 317,
       "norm_label": "cardaction()"
     },
     {
@@ -11922,7 +12002,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "components_ui_card_cardfooter",
-      "community": 42,
+      "community": 317,
       "norm_label": "cardfooter()"
     },
     {
@@ -11932,7 +12012,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_checkbox",
-      "community": 517,
+      "community": 432,
       "norm_label": "checkbox.tsx"
     },
     {
@@ -11942,7 +12022,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "components_ui_checkbox_checkbox",
-      "community": 517,
+      "community": 432,
       "norm_label": "checkbox()"
     },
     {
@@ -11952,7 +12032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_dialog",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialog.tsx"
     },
     {
@@ -11962,7 +12042,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_ui_dialog_dialog",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialog()"
     },
     {
@@ -11972,7 +12052,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtrigger",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialogtrigger()"
     },
     {
@@ -11982,7 +12062,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogportal",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialogportal()"
     },
     {
@@ -11992,7 +12072,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogclose",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialogclose()"
     },
     {
@@ -12002,7 +12082,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogoverlay",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialogoverlay()"
     },
     {
@@ -12012,7 +12092,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogcontent",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialogcontent()"
     },
     {
@@ -12022,7 +12102,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogheader",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialogheader()"
     },
     {
@@ -12032,7 +12112,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogfooter",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialogfooter()"
     },
     {
@@ -12042,7 +12122,7 @@
       "source_location": "L121",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtitle",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialogtitle()"
     },
     {
@@ -12052,7 +12132,7 @@
       "source_location": "L134",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogdescription",
-      "community": 13,
+      "community": 14,
       "norm_label": "dialogdescription()"
     },
     {
@@ -12062,7 +12142,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdown-menu.tsx"
     },
     {
@@ -12082,7 +12162,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuportal",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenuportal()"
     },
     {
@@ -12102,7 +12182,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenucontent",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenucontent()"
     },
     {
@@ -12112,7 +12192,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenugroup",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenugroup()"
     },
     {
@@ -12122,7 +12202,7 @@
       "source_location": "L62",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuitem",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenuitem()"
     },
     {
@@ -12132,7 +12212,7 @@
       "source_location": "L85",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenucheckboxitem",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenucheckboxitem()"
     },
     {
@@ -12142,7 +12222,7 @@
       "source_location": "L111",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuradiogroup",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenuradiogroup()"
     },
     {
@@ -12152,7 +12232,7 @@
       "source_location": "L122",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuradioitem",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenuradioitem()"
     },
     {
@@ -12162,7 +12242,7 @@
       "source_location": "L146",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenulabel",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenulabel()"
     },
     {
@@ -12172,7 +12252,7 @@
       "source_location": "L166",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuseparator",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenuseparator()"
     },
     {
@@ -12182,7 +12262,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenushortcut",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenushortcut()"
     },
     {
@@ -12192,7 +12272,7 @@
       "source_location": "L195",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenusub",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenusub()"
     },
     {
@@ -12202,7 +12282,7 @@
       "source_location": "L201",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenusubtrigger",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenusubtrigger()"
     },
     {
@@ -12212,7 +12292,7 @@
       "source_location": "L225",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenusubcontent",
-      "community": 42,
+      "community": 14,
       "norm_label": "dropdownmenusubcontent()"
     },
     {
@@ -12462,7 +12542,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_select",
-      "community": 317,
+      "community": 13,
       "norm_label": "select.tsx"
     },
     {
@@ -12472,7 +12552,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "components_ui_select_select",
-      "community": 317,
+      "community": 13,
       "norm_label": "select()"
     },
     {
@@ -12482,7 +12562,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "components_ui_select_selectgroup",
-      "community": 317,
+      "community": 13,
       "norm_label": "selectgroup()"
     },
     {
@@ -12492,7 +12572,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_ui_select_selectvalue",
-      "community": 317,
+      "community": 13,
       "norm_label": "selectvalue()"
     },
     {
@@ -12502,7 +12582,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "components_ui_select_selecttrigger",
-      "community": 317,
+      "community": 13,
       "norm_label": "selecttrigger()"
     },
     {
@@ -12512,7 +12592,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "components_ui_select_selectcontent",
-      "community": 317,
+      "community": 13,
       "norm_label": "selectcontent()"
     },
     {
@@ -12522,7 +12602,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "components_ui_select_selectlabel",
-      "community": 42,
+      "community": 13,
       "norm_label": "selectlabel()"
     },
     {
@@ -12532,7 +12612,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "components_ui_select_selectitem",
-      "community": 317,
+      "community": 13,
       "norm_label": "selectitem()"
     },
     {
@@ -12542,7 +12622,7 @@
       "source_location": "L130",
       "_origin": "ast",
       "id": "components_ui_select_selectseparator",
-      "community": 42,
+      "community": 13,
       "norm_label": "selectseparator()"
     },
     {
@@ -12552,7 +12632,7 @@
       "source_location": "L143",
       "_origin": "ast",
       "id": "components_ui_select_selectscrollupbutton",
-      "community": 42,
+      "community": 13,
       "norm_label": "selectscrollupbutton()"
     },
     {
@@ -12562,7 +12642,7 @@
       "source_location": "L161",
       "_origin": "ast",
       "id": "components_ui_select_selectscrolldownbutton",
-      "community": 42,
+      "community": 13,
       "norm_label": "selectscrolldownbutton()"
     },
     {
@@ -12592,7 +12672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_sheet",
-      "community": 510,
+      "community": 518,
       "norm_label": "sheet.tsx"
     },
     {
@@ -12602,7 +12682,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "components_ui_sheet_sheet",
-      "community": 510,
+      "community": 518,
       "norm_label": "sheet()"
     },
     {
@@ -12612,7 +12692,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_ui_sheet_sheettrigger",
-      "community": 14,
+      "community": 518,
       "norm_label": "sheettrigger()"
     },
     {
@@ -12622,7 +12702,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetclose",
-      "community": 510,
+      "community": 518,
       "norm_label": "sheetclose()"
     },
     {
@@ -12632,7 +12712,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetportal",
-      "community": 510,
+      "community": 518,
       "norm_label": "sheetportal()"
     },
     {
@@ -12642,7 +12722,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetoverlay",
-      "community": 42,
+      "community": 14,
       "norm_label": "sheetoverlay()"
     },
     {
@@ -12652,7 +12732,7 @@
       "source_location": "L47",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetcontent",
-      "community": 510,
+      "community": 518,
       "norm_label": "sheetcontent()"
     },
     {
@@ -12662,7 +12742,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetheader",
-      "community": 510,
+      "community": 518,
       "norm_label": "sheetheader()"
     },
     {
@@ -12672,7 +12752,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetfooter",
-      "community": 42,
+      "community": 14,
       "norm_label": "sheetfooter()"
     },
     {
@@ -12682,7 +12762,7 @@
       "source_location": "L104",
       "_origin": "ast",
       "id": "components_ui_sheet_sheettitle",
-      "community": 510,
+      "community": 518,
       "norm_label": "sheettitle()"
     },
     {
@@ -12692,7 +12772,7 @@
       "source_location": "L117",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetdescription",
-      "community": 510,
+      "community": 518,
       "norm_label": "sheetdescription()"
     },
     {
@@ -12902,7 +12982,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_visually_hidden",
-      "community": 14,
+      "community": 518,
       "norm_label": "visually-hidden.tsx"
     },
     {
@@ -12912,7 +12992,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_ui_visually_hidden_visuallyhidden",
-      "community": 14,
+      "community": 518,
       "norm_label": "visuallyhidden()"
     },
     {
@@ -13082,7 +13162,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "db_schema",
-      "community": 510,
+      "community": 23,
       "norm_label": "schema.ts"
     },
     {
@@ -13092,7 +13172,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "db_schema_citext",
-      "community": 510,
+      "community": 23,
       "norm_label": "citext"
     },
     {
@@ -13112,7 +13192,7 @@
       "source_location": "L39",
       "_origin": "ast",
       "id": "db_schema_accountsrelations",
-      "community": 510,
+      "community": 23,
       "norm_label": "accountsrelations"
     },
     {
@@ -13132,7 +13212,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "db_schema_categoriesrelations",
-      "community": 510,
+      "community": 23,
       "norm_label": "categoriesrelations"
     },
     {
@@ -13152,7 +13232,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "db_schema_transactionsrelations",
-      "community": 510,
+      "community": 23,
       "norm_label": "transactionsrelations"
     },
     {
@@ -13162,7 +13242,7 @@
       "source_location": "L106",
       "_origin": "ast",
       "id": "db_schema_insertaccountschema",
-      "community": 510,
+      "community": 23,
       "norm_label": "insertaccountschema"
     },
     {
@@ -13172,7 +13252,7 @@
       "source_location": "L107",
       "_origin": "ast",
       "id": "db_schema_insertcategoryschema",
-      "community": 510,
+      "community": 23,
       "norm_label": "insertcategoryschema"
     },
     {
@@ -13252,7 +13332,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_usebulkdeleteaccounts",
-      "community": 520,
+      "community": 518,
       "norm_label": "usebulkdeleteaccounts()"
     },
     {
@@ -13262,7 +13342,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account",
-      "community": 513,
+      "community": 518,
       "norm_label": "use-create-account.ts"
     },
     {
@@ -13272,7 +13352,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_responsetype",
-      "community": 513,
+      "community": 518,
       "norm_label": "responsetype"
     },
     {
@@ -13282,7 +13362,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_requesttype",
-      "community": 513,
+      "community": 518,
       "norm_label": "requesttype"
     },
     {
@@ -13372,7 +13452,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_account",
-      "community": 348,
+      "community": 432,
       "norm_label": "use-get-account.ts"
     },
     {
@@ -13452,7 +13532,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_accounts_components_account_form_accountform",
-      "community": 348,
+      "community": 23,
       "norm_label": "accountform()"
     },
     {
@@ -13492,7 +13572,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_components_new_account_sheet",
-      "community": 510,
+      "community": 518,
       "norm_label": "new-account-sheet.tsx"
     },
     {
@@ -13502,7 +13582,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "features_accounts_components_new_account_sheet_formvalues",
-      "community": 510,
+      "community": 518,
       "norm_label": "formvalues"
     },
     {
@@ -13522,7 +13602,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_new_account",
-      "community": 520,
+      "community": 518,
       "norm_label": "use-new-account.ts"
     },
     {
@@ -13532,7 +13612,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_new_account_newaccountstate",
-      "community": 520,
+      "community": 518,
       "norm_label": "newaccountstate"
     },
     {
@@ -13542,7 +13622,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_new_account_usenewaccount",
-      "community": 520,
+      "community": 518,
       "norm_label": "usenewaccount"
     },
     {
@@ -13582,7 +13662,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account",
-      "community": 13,
+      "community": 14,
       "norm_label": "use-select-account.tsx"
     },
     {
@@ -13632,7 +13712,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_categories_api_use_bulk_delete_categories_usebulkdeletecategories",
-      "community": 260,
+      "community": 518,
       "norm_label": "usebulkdeletecategories()"
     },
     {
@@ -13642,7 +13722,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category",
-      "community": 513,
+      "community": 518,
       "norm_label": "use-create-category.ts"
     },
     {
@@ -13652,7 +13732,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_responsetype",
-      "community": 513,
+      "community": 518,
       "norm_label": "responsetype"
     },
     {
@@ -13662,7 +13742,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_requesttype",
-      "community": 513,
+      "community": 518,
       "norm_label": "requesttype"
     },
     {
@@ -13682,7 +13762,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category",
-      "community": 432,
+      "community": 42,
       "norm_label": "use-delete-category.ts"
     },
     {
@@ -13692,7 +13772,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category_responsetype",
-      "community": 432,
+      "community": 42,
       "norm_label": "responsetype"
     },
     {
@@ -13702,7 +13782,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category_usedeletecategory",
-      "community": 432,
+      "community": 42,
       "norm_label": "usedeletecategory()"
     },
     {
@@ -13742,7 +13822,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category_useeditcategory",
-      "community": 432,
+      "community": 42,
       "norm_label": "useeditcategory()"
     },
     {
@@ -13772,7 +13852,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_get_category",
-      "community": 432,
+      "community": 42,
       "norm_label": "use-get-category.ts"
     },
     {
@@ -13782,7 +13862,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "features_categories_api_use_get_category_usegetcategory",
-      "community": 432,
+      "community": 42,
       "norm_label": "usegetcategory()"
     },
     {
@@ -13832,7 +13912,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_categories_components_category_form_categoryform",
-      "community": 510,
+      "community": 23,
       "norm_label": "categoryform()"
     },
     {
@@ -13842,7 +13922,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet",
-      "community": 510,
+      "community": 42,
       "norm_label": "edit-category-sheet.tsx"
     },
     {
@@ -13852,7 +13932,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet_formvalues",
-      "community": 510,
+      "community": 42,
       "norm_label": "formvalues"
     },
     {
@@ -13862,7 +13942,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet_editcategorysheet",
-      "community": 432,
+      "community": 42,
       "norm_label": "editcategorysheet()"
     },
     {
@@ -13872,7 +13952,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_components_new_category_sheet",
-      "community": 510,
+      "community": 518,
       "norm_label": "new-category-sheet.tsx"
     },
     {
@@ -13882,7 +13962,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "features_categories_components_new_category_sheet_formvalues",
-      "community": 510,
+      "community": 518,
       "norm_label": "formvalues"
     },
     {
@@ -13902,7 +13982,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_hooks_use_new_category",
-      "community": 260,
+      "community": 518,
       "norm_label": "use-new-category.ts"
     },
     {
@@ -13912,7 +13992,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_categories_hooks_use_new_category_newcategorystate",
-      "community": 260,
+      "community": 518,
       "norm_label": "newcategorystate"
     },
     {
@@ -13922,7 +14002,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_hooks_use_new_category_usenewcategory",
-      "community": 260,
+      "community": 518,
       "norm_label": "usenewcategory"
     },
     {
@@ -13972,7 +14052,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_summary_use_get_summary_usegetsummary",
-      "community": 432,
+      "community": 526,
       "norm_label": "usegetsummary()"
     },
     {
@@ -13982,7 +14062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_create_transactions",
-      "community": 379,
+      "community": 432,
       "norm_label": "use-bulk-create-transactions.ts"
     },
     {
@@ -13992,7 +14072,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_create_transactions_responsetype",
-      "community": 379,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -14002,7 +14082,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_create_transactions_requesttype",
-      "community": 379,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -14012,7 +14092,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_create_transactions_usebulkcreatetransactions",
-      "community": 379,
+      "community": 518,
       "norm_label": "usebulkcreatetransactions()"
     },
     {
@@ -14022,7 +14102,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_delete_transactions",
-      "community": 379,
+      "community": 432,
       "norm_label": "use-bulk-delete-transactions.ts"
     },
     {
@@ -14032,7 +14112,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_delete_transactions_responsetype",
-      "community": 379,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -14042,7 +14122,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_delete_transactions_requesttype",
-      "community": 379,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -14052,7 +14132,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_delete_transactions_usebulkdeletetransactions",
-      "community": 379,
+      "community": 518,
       "norm_label": "usebulkdeletetransactions()"
     },
     {
@@ -14102,7 +14182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_delete_transaction",
-      "community": 432,
+      "community": 518,
       "norm_label": "use-delete-transaction.ts"
     },
     {
@@ -14112,7 +14192,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_delete_transaction_responsetype",
-      "community": 432,
+      "community": 518,
       "norm_label": "responsetype"
     },
     {
@@ -14182,7 +14262,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transaction_usegettransaction",
-      "community": 432,
+      "community": 518,
       "norm_label": "usegettransaction()"
     },
     {
@@ -14322,7 +14402,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "features_transactions_components_transaction_form_transactionform",
-      "community": 518,
+      "community": 23,
       "norm_label": "transactionform()"
     },
     {
@@ -14392,7 +14472,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "hooks_use_confirm",
-      "community": 13,
+      "community": 14,
       "norm_label": "use-confirm.tsx"
     },
     {
@@ -14552,7 +14632,7 @@
       "source_location": "L112",
       "_origin": "ast",
       "id": "lib_api_error_createapierror",
-      "community": 432,
+      "community": 518,
       "norm_label": "createapierror()"
     },
     {
@@ -14692,7 +14772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options_test",
-      "community": 13,
+      "community": 45,
       "norm_label": "select-options.test.ts"
     },
     {
@@ -14702,7 +14782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options",
-      "community": 13,
+      "community": 45,
       "norm_label": "select-options.ts"
     },
     {
@@ -14712,7 +14792,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options_selectoption",
-      "community": 13,
+      "community": 45,
       "norm_label": "selectoption"
     },
     {
@@ -14722,7 +14802,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "lib_select_options_mergecreatedselectoption",
-      "community": 13,
+      "community": 45,
       "norm_label": "mergecreatedselectoption()"
     },
     {
@@ -14732,7 +14812,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_import_test",
-      "community": 40,
+      "community": 517,
       "norm_label": "transaction-import.test.ts"
     },
     {
@@ -14742,7 +14822,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_import",
-      "community": 40,
+      "community": 517,
       "norm_label": "transaction-import.ts"
     },
     {
@@ -14752,7 +14832,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "lib_transaction_import_importedtransactionrow",
-      "community": 40,
+      "community": 517,
       "norm_label": "importedtransactionrow"
     },
     {
@@ -14762,7 +14842,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "lib_transaction_import_rawimportedtransactionrow",
-      "community": 40,
+      "community": 517,
       "norm_label": "rawimportedtransactionrow"
     },
     {
@@ -14772,7 +14852,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "lib_transaction_import_importedtransactionrowerror",
-      "community": 40,
+      "community": 517,
       "norm_label": "importedtransactionrowerror"
     },
     {
@@ -14782,7 +14862,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "lib_transaction_import_parseimportedtransactionrows",
-      "community": 40,
+      "community": 517,
       "norm_label": "parseimportedtransactionrows()"
     },
     {
@@ -14912,7 +14992,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_utils",
-      "community": 9,
+      "community": 432,
       "norm_label": "utils.ts"
     },
     {
@@ -14922,7 +15002,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "lib_utils_cn",
-      "community": 42,
+      "community": 14,
       "norm_label": "cn()"
     },
     {
@@ -14942,7 +15022,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "lib_utils_convertamounttomiliunits",
-      "community": 40,
+      "community": 23,
       "norm_label": "convertamounttomiliunits()"
     },
     {
@@ -14982,7 +15062,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "lib_utils_period",
-      "community": 9,
+      "community": 432,
       "norm_label": "period"
     },
     {
@@ -14992,7 +15072,7 @@
       "source_location": "L76",
       "_origin": "ast",
       "id": "lib_utils_formatdaterange",
-      "community": 526,
+      "community": 14,
       "norm_label": "formatdaterange()"
     },
     {
@@ -30230,7 +30310,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/cmd/api/main.go",
-      "source_location": "L85",
+      "source_location": "L96",
       "weight": 1.0,
       "source": "backend_cmd_api_main",
       "target": "backend_cmd_api_main_databasehost",
@@ -30296,7 +30376,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/cmd/api/main.go",
-      "source_location": "L41",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "backend_cmd_api_main_main",
+      "target": "backend_internal_db_rls_verifyrlsactive"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/cmd/api/main.go",
+      "source_location": "L52",
       "weight": 1.0,
       "source": "backend_cmd_api_main_main",
       "target": "backend_internal_http_auth_newauthserver"
@@ -30307,7 +30398,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/cmd/api/main.go",
-      "source_location": "L45",
+      "source_location": "L56",
       "weight": 1.0,
       "source": "backend_cmd_api_main_main",
       "target": "backend_internal_http_router_newrouter"
@@ -30318,7 +30409,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/cmd/api/main.go",
-      "source_location": "L40",
+      "source_location": "L51",
       "weight": 1.0,
       "source": "backend_cmd_api_main_main",
       "target": "backend_internal_mail_smtp_newsmtpmailer"
@@ -32832,7 +32923,29 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L76",
+      "source_location": "L277",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
+      "target": "backend_internal_db_db_newpool"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L298",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
+      "target": "backend_internal_db_db_newpool"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L77",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
       "target": "backend_internal_db_db_newpool"
@@ -32843,7 +32956,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L130",
+      "source_location": "L131",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
       "target": "backend_internal_db_db_newpool"
@@ -32854,7 +32967,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L231",
+      "source_location": "L232",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
       "target": "backend_internal_db_db_newpool"
@@ -32865,9 +32978,20 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L193",
+      "source_location": "L194",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_db_newpool"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
       "target": "backend_internal_db_db_newpool"
     },
     {
@@ -33266,6 +33390,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "target": "backend_internal_db_finance_rls_test_inserttestuser"
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/finance_rls_test.go",
@@ -33387,6 +33522,39 @@
       "target": "backend_internal_db_finance_rls_test_setappuser"
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "target": "backend_internal_db_finance_rls_test_setappuser"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "target": "backend_internal_db_finance_rls_test_inserttestaccount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L63",
+      "weight": 1.0,
+      "source": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "target": "backend_internal_db_finance_rls_test_inserttestcategory"
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/finance_rls_test.go",
@@ -33396,6 +33564,28 @@
       "source": "backend_internal_db_finance_rls_test_inserttesttransaction",
       "target": "backend_internal_db_finance_rls_test_go_time",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L161",
+      "weight": 1.0,
+      "source": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "target": "backend_internal_db_finance_rls_test_assertrowcount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L110",
+      "weight": 1.0,
+      "source": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "target": "backend_internal_db_finance_rls_test_assertrlsviolation"
     },
     {
       "relation": "contains",
@@ -35004,7 +35194,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L241",
+      "source_location": "L242",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
       "target": "backend_internal_db_gen_db_new"
@@ -36526,6 +36716,16 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/livedb_test.go",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "backend_internal_db_livedb_test",
+      "target": "backend_internal_db_livedb_test_admindatabaseurl",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/livedb_test.go",
       "source_location": "L17",
       "weight": 1.0,
       "source": "backend_internal_db_livedb_test",
@@ -36571,7 +36771,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L73",
+      "source_location": "L274",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
+      "target": "backend_internal_db_livedb_test_livedatabaseurl"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L74",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
       "target": "backend_internal_db_livedb_test_livedatabaseurl"
@@ -36582,7 +36793,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L127",
+      "source_location": "L128",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
       "target": "backend_internal_db_livedb_test_livedatabaseurl"
@@ -36593,7 +36804,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L228",
+      "source_location": "L229",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
       "target": "backend_internal_db_livedb_test_livedatabaseurl"
@@ -36604,10 +36815,43 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L190",
+      "source_location": "L191",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
       "target": "backend_internal_db_livedb_test_livedatabaseurl"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "target": "backend_internal_db_livedb_test_livedatabaseurl"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/livedb_test.go",
+      "source_location": "L39",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_livedb_test_admindatabaseurl",
+      "target": "backend_internal_db_livedb_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L295",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
+      "target": "backend_internal_db_livedb_test_admindatabaseurl"
     },
     {
       "relation": "contains",
@@ -36730,6 +36974,26 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
+      "source_location": "L113",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls",
+      "target": "backend_internal_db_rls_connectionroleattributes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L92",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls",
+      "target": "backend_internal_db_rls_verifyrlsactive",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
       "source_location": "L37",
       "weight": 1.0,
       "source": "backend_internal_db_rls",
@@ -36742,7 +37006,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L50",
+      "source_location": "L51",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_createrlstestaccount",
       "target": "backend_internal_db_rls_withusertx"
@@ -36753,7 +37017,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L90",
+      "source_location": "L91",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
       "target": "backend_internal_db_rls_withusertx"
@@ -36764,7 +37028,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L243",
+      "source_location": "L244",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
       "target": "backend_internal_db_rls_withusertx"
@@ -36836,10 +37100,87 @@
       "target": "backend_internal_db_rls_withusertx"
     },
     {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L113",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_connectionroleattributes",
+      "target": "backend_internal_db_rls_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L92",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_verifyrlsactive",
+      "target": "backend_internal_db_rls_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L113",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_connectionroleattributes",
+      "target": "backend_internal_db_rls_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L92",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_verifyrlsactive",
+      "target": "backend_internal_db_rls_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L283",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
+      "target": "backend_internal_db_rls_verifyrlsactive"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L304",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
+      "target": "backend_internal_db_rls_verifyrlsactive"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_verifyrlsactive",
+      "target": "backend_internal_db_rls_connectionroleattributes",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L47",
+      "source_location": "L48",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_createrlstestaccount",
@@ -36849,7 +37190,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L19",
+      "source_location": "L20",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_createrlstestuser",
@@ -36859,7 +37200,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_deleterlstestusers",
@@ -36869,7 +37210,27 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L72",
+      "source_location": "L273",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L294",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L73",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
@@ -36879,7 +37240,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L126",
+      "source_location": "L127",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
@@ -36889,7 +37250,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L227",
+      "source_location": "L228",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
@@ -36899,7 +37260,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L189",
+      "source_location": "L190",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
@@ -36909,7 +37270,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L19",
+      "source_location": "L20",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_createrlstestuser",
@@ -36920,7 +37281,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L19",
+      "source_location": "L20",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_createrlstestuser",
@@ -36931,7 +37292,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L19",
+      "source_location": "L20",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_createrlstestuser",
@@ -36942,7 +37303,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L19",
+      "source_location": "L20",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_db_rls_test_createrlstestuser",
@@ -36954,7 +37315,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L82",
+      "source_location": "L83",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
       "target": "backend_internal_db_rls_test_createrlstestuser",
@@ -36965,7 +37326,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L136",
+      "source_location": "L137",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
       "target": "backend_internal_db_rls_test_createrlstestuser",
@@ -36976,7 +37337,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L237",
+      "source_location": "L238",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
       "target": "backend_internal_db_rls_test_createrlstestuser",
@@ -36987,7 +37348,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L199",
+      "source_location": "L200",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
       "target": "backend_internal_db_rls_test_createrlstestuser",
@@ -36997,7 +37358,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L47",
+      "source_location": "L48",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_createrlstestaccount",
@@ -37008,7 +37369,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_deleterlstestusers",
@@ -37019,7 +37380,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L47",
+      "source_location": "L48",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_createrlstestaccount",
@@ -37030,7 +37391,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_deleterlstestusers",
@@ -37041,7 +37402,29 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L72",
+      "source_location": "L273",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L294",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L73",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
@@ -37052,7 +37435,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L126",
+      "source_location": "L127",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
@@ -37063,7 +37446,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L227",
+      "source_location": "L228",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
@@ -37074,7 +37457,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L189",
+      "source_location": "L190",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
@@ -37085,7 +37468,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L47",
+      "source_location": "L48",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_createrlstestaccount",
@@ -37096,7 +37479,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_deleterlstestusers",
@@ -37107,7 +37490,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L47",
+      "source_location": "L48",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_createrlstestaccount",
@@ -37119,7 +37502,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L84",
+      "source_location": "L85",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
       "target": "backend_internal_db_rls_test_deleterlstestusers",
@@ -37130,7 +37513,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L138",
+      "source_location": "L139",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
       "target": "backend_internal_db_rls_test_deleterlstestusers",
@@ -37141,7 +37524,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L238",
+      "source_location": "L239",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_rollsbackonerror_livedatabase",
       "target": "backend_internal_db_rls_test_deleterlstestusers",
@@ -37152,7 +37535,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L200",
+      "source_location": "L201",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
       "target": "backend_internal_db_rls_test_deleterlstestusers",
@@ -37163,7 +37546,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L87",
+      "source_location": "L88",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_ownerroundtrip_livedatabase",
       "target": "backend_internal_db_rls_test_createrlstestaccount",
@@ -37174,7 +37557,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L141",
+      "source_location": "L142",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_policyblockscrossuseraccess_livedatabase",
       "target": "backend_internal_db_rls_test_createrlstestaccount",
@@ -37185,10 +37568,31 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L203",
+      "source_location": "L204",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
       "target": "backend_internal_db_rls_test_createrlstestaccount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L24",
+      "weight": 1.0,
+      "source": "backend_internal_db_transactions_category_rls_test",
+      "target": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/transactions_category_rls_test.go",
+      "source_location": "L24",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_transactions_category_rls_test_testtransactionscategoryownerrls_livedatabase",
+      "target": "backend_internal_db_transactions_category_rls_test_go_t",
       "confidence_score": 1.0
     },
     {
@@ -72513,5 +72917,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "65cfd0518c9506d142ecddf7b3e287291b707a60"
+  "built_at_commit": "3a9e429c7cc5d7b7bc6045573814ae8d651e94be"
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,1011 +1,1011 @@
 {
   ".vscode/extensions.json": {
-    "mtime": 1783698026.630728,
+    "mtime": 1784776716.4017534,
     "ast_hash": "36e6640c0f3f8502e74aa2519e650e2e",
     "semantic_hash": "36e6640c0f3f8502e74aa2519e650e2e"
   },
   ".vscode/mcp.json": {
-    "mtime": 1783698026.6317263,
+    "mtime": 1784776716.4027503,
     "ast_hash": "46382058c9547d789e39f5fece62198d",
     "semantic_hash": "46382058c9547d789e39f5fece62198d"
   },
   ".vscode/settings.json": {
-    "mtime": 1783698026.6317263,
+    "mtime": 1784776716.4047458,
     "ast_hash": "9e961d3a67aa59bbf1f99ac1c99aa470",
     "semantic_hash": "9e961d3a67aa59bbf1f99ac1c99aa470"
   },
   "app/(auth)/sign-in/[[...sign-in]]/page.tsx": {
-    "mtime": 1783698026.6407292,
+    "mtime": 1784776716.4147477,
     "ast_hash": "c68779d3caf55983d25cd75574d5a176",
     "semantic_hash": "c68779d3caf55983d25cd75574d5a176"
   },
   "app/(auth)/sign-up/[[...sign-up]]/page.tsx": {
-    "mtime": 1783698026.6427307,
+    "mtime": 1784776716.416752,
     "ast_hash": "15042e883d27c10bae944ec6afc2daae",
     "semantic_hash": "15042e883d27c10bae944ec6afc2daae"
   },
   "app/(dashboard)/accounts/actions.tsx": {
-    "mtime": 1783698026.6437268,
+    "mtime": 1784776716.4187505,
     "ast_hash": "315e74a734d2f6f4799f9f8d1ce71495",
     "semantic_hash": "315e74a734d2f6f4799f9f8d1ce71495"
   },
   "app/(dashboard)/accounts/columns.tsx": {
-    "mtime": 1783698026.644727,
+    "mtime": 1784776716.4197514,
     "ast_hash": "98d37b4022593adcc2565fe5c2c85a06",
     "semantic_hash": "98d37b4022593adcc2565fe5c2c85a06"
   },
   "app/(dashboard)/accounts/page.tsx": {
-    "mtime": 1783698026.645727,
+    "mtime": 1784776716.4207513,
     "ast_hash": "ad0e1c443c11d0de7b68f61e91a15fa5",
     "semantic_hash": "ad0e1c443c11d0de7b68f61e91a15fa5"
   },
   "app/(dashboard)/categories/actions.tsx": {
-    "mtime": 1783698026.6467257,
+    "mtime": 1784776716.421748,
     "ast_hash": "4f61a34a890d7c56f7c257dd598317f7",
     "semantic_hash": "4f61a34a890d7c56f7c257dd598317f7"
   },
   "app/(dashboard)/categories/columns.tsx": {
-    "mtime": 1783698026.6477234,
+    "mtime": 1784776716.4227448,
     "ast_hash": "4227909a5834e47ccc8ee94359f2324e",
     "semantic_hash": "4227909a5834e47ccc8ee94359f2324e"
   },
   "app/(dashboard)/categories/page.tsx": {
-    "mtime": 1783698026.6477234,
+    "mtime": 1784776716.4237468,
     "ast_hash": "136e925c29f9dc6e9f8c38d0e9f9f438",
     "semantic_hash": "136e925c29f9dc6e9f8c38d0e9f9f438"
   },
   "app/(dashboard)/layout.tsx": {
-    "mtime": 1783698026.6487267,
+    "mtime": 1784776716.4237468,
     "ast_hash": "63185be01318f280f5ebc9c035de9135",
     "semantic_hash": "63185be01318f280f5ebc9c035de9135"
   },
   "app/(dashboard)/page.tsx": {
-    "mtime": 1783698026.6497252,
+    "mtime": 1784776716.4247432,
     "ast_hash": "188c4550eb09cf168857ab186acfb957",
     "semantic_hash": "188c4550eb09cf168857ab186acfb957"
   },
   "app/(dashboard)/transactions/account-column.tsx": {
-    "mtime": 1783698026.6507232,
+    "mtime": 1784776716.4257438,
     "ast_hash": "e40922b1e8dc2d6bea4713b579426f4f",
     "semantic_hash": "e40922b1e8dc2d6bea4713b579426f4f"
   },
   "app/(dashboard)/transactions/actions.tsx": {
-    "mtime": 1783698026.6507232,
+    "mtime": 1784776716.4267435,
     "ast_hash": "e4e9879ebb0fbfa27c4707cc670bf44e",
     "semantic_hash": "e4e9879ebb0fbfa27c4707cc670bf44e"
   },
   "app/(dashboard)/transactions/category-column.tsx": {
-    "mtime": 1783698026.651726,
+    "mtime": 1784776716.4277496,
     "ast_hash": "eb23c51dff5efdc39b32575e4e3f1e8e",
     "semantic_hash": "eb23c51dff5efdc39b32575e4e3f1e8e"
   },
   "app/(dashboard)/transactions/columns.tsx": {
-    "mtime": 1783698026.6527295,
+    "mtime": 1784776716.4277496,
     "ast_hash": "0b8a1678cdf61fe69a3ed89160ac7e4c",
     "semantic_hash": "0b8a1678cdf61fe69a3ed89160ac7e4c"
   },
   "app/(dashboard)/transactions/import-card.tsx": {
-    "mtime": 1783698026.6537251,
+    "mtime": 1784776716.428746,
     "ast_hash": "ebaad9a52017562b95b4149b7982adcc",
     "semantic_hash": "ebaad9a52017562b95b4149b7982adcc"
   },
   "app/(dashboard)/transactions/import-table.tsx": {
-    "mtime": 1783698026.6537251,
+    "mtime": 1784776716.429746,
     "ast_hash": "b79716f109add1c0e70637507fe18464",
     "semantic_hash": "b79716f109add1c0e70637507fe18464"
   },
   "app/(dashboard)/transactions/page.tsx": {
-    "mtime": 1783698026.654728,
+    "mtime": 1784776716.429746,
     "ast_hash": "f2ca714712848388fb77c24390c04d35",
     "semantic_hash": "f2ca714712848388fb77c24390c04d35"
   },
   "app/(dashboard)/transactions/table-head-select.tsx": {
-    "mtime": 1783698026.654728,
+    "mtime": 1784776716.4307508,
     "ast_hash": "99f36d8c45e1cffb94510d1241aa3e83",
     "semantic_hash": "99f36d8c45e1cffb94510d1241aa3e83"
   },
   "app/(dashboard)/transactions/upload-button.tsx": {
-    "mtime": 1783698026.655726,
+    "mtime": 1784776716.4317484,
     "ast_hash": "5e7894f75af604d220a426d1f0a8d0c8",
     "semantic_hash": "5e7894f75af604d220a426d1f0a8d0c8"
   },
   "app/api/[[...route]]/accounts.ts": {
-    "mtime": 1783698026.6577241,
+    "mtime": 1784776716.4337497,
     "ast_hash": "2afcc4966311b4727d4bf9bbd7dfb8e5",
     "semantic_hash": "2afcc4966311b4727d4bf9bbd7dfb8e5"
   },
   "app/api/[[...route]]/categories.ts": {
-    "mtime": 1783698026.6577241,
+    "mtime": 1784776716.4347537,
     "ast_hash": "f3f3cfd4da3d4a2e03041ffe3a024cb0",
     "semantic_hash": "f3f3cfd4da3d4a2e03041ffe3a024cb0"
   },
   "app/api/[[...route]]/route.ts": {
-    "mtime": 1783698026.6587255,
+    "mtime": 1784776716.4357526,
     "ast_hash": "2b8fd8e03b9195350f20f8e36c22a236",
     "semantic_hash": "2b8fd8e03b9195350f20f8e36c22a236"
   },
   "app/api/[[...route]]/summary.ts": {
-    "mtime": 1783698026.6597254,
+    "mtime": 1784776716.4367483,
     "ast_hash": "52c363ad2d7c4b5079404d1b1964c998",
     "semantic_hash": "52c363ad2d7c4b5079404d1b1964c998"
   },
   "app/api/[[...route]]/transactions.ts": {
-    "mtime": 1783698026.6607246,
+    "mtime": 1784776716.4377496,
     "ast_hash": "9a4bdd8c6c8f3a5f1909dcf1c0b8c198",
     "semantic_hash": "9a4bdd8c6c8f3a5f1909dcf1c0b8c198"
   },
   "app/layout.tsx": {
-    "mtime": 1783698026.6637259,
+    "mtime": 1784776716.4407494,
     "ast_hash": "a974b84f869ed5e86967fc377f86a12a",
     "semantic_hash": "a974b84f869ed5e86967fc377f86a12a"
   },
   "backend/cmd/api/main.go": {
-    "mtime": 1784664178.1065233,
+    "mtime": 1784776716.4437468,
     "ast_hash": "b58790eed295c0a01b8a72c61e492ece",
     "semantic_hash": ""
   },
   "backend/internal/config/config.go": {
-    "mtime": 1784664178.1085217,
+    "mtime": 1784776716.4557443,
     "ast_hash": "8203cf0cfcc9b075241d7119822d6dc8",
     "semantic_hash": ""
   },
   "backend/internal/http/health.go": {
-    "mtime": 1783698026.6697252,
+    "mtime": 1784776716.486752,
     "ast_hash": "892e87794a60999e03ab630f9a141593",
     "semantic_hash": "892e87794a60999e03ab630f9a141593"
   },
   "backend/internal/http/health_test.go": {
-    "mtime": 1784296925.9319763,
+    "mtime": 1784776716.4877467,
     "ast_hash": "b637bd3212f02488845cfc4d77410cd9",
     "semantic_hash": ""
   },
   "backend/internal/http/router.go": {
-    "mtime": 1784664178.1305218,
-    "ast_hash": "f8d0810b5ddd1d441d8f6abef2d6e091",
+    "mtime": 1784777166.5883553,
+    "ast_hash": "5df169cb71838294662d3e1c1b2b1070",
     "semantic_hash": ""
   },
   "components.json": {
-    "mtime": 1783698026.67873,
+    "mtime": 1784776716.5057528,
     "ast_hash": "6d9018deb951297f49f351aac49c68a6",
     "semantic_hash": "6d9018deb951297f49f351aac49c68a6"
   },
   "components/account-filter.tsx": {
-    "mtime": 1783698026.679726,
+    "mtime": 1784776716.5067532,
     "ast_hash": "c59551b47fd3183b6d8ff63f3188463b",
     "semantic_hash": "c59551b47fd3183b6d8ff63f3188463b"
   },
   "components/amount-input.tsx": {
-    "mtime": 1783698026.679726,
+    "mtime": 1784776716.5077472,
     "ast_hash": "adcce293adc9b9056aed727a8ffd4e8b",
     "semantic_hash": "adcce293adc9b9056aed727a8ffd4e8b"
   },
   "components/area-variant.tsx": {
-    "mtime": 1783698026.680729,
+    "mtime": 1784776716.508747,
     "ast_hash": "17d74c83f1b3d6f23b97bfbb20e08932",
     "semantic_hash": "17d74c83f1b3d6f23b97bfbb20e08932"
   },
   "components/bar-variant.tsx": {
-    "mtime": 1783698026.681727,
+    "mtime": 1784776716.5097463,
     "ast_hash": "0eefeafb7c7739d167a65a14f5a8065d",
     "semantic_hash": "0eefeafb7c7739d167a65a14f5a8065d"
   },
   "components/category-tooltip.tsx": {
-    "mtime": 1783698026.682728,
+    "mtime": 1784776716.510749,
     "ast_hash": "78c4faf727e238549c68f52115b5e113",
     "semantic_hash": "78c4faf727e238549c68f52115b5e113"
   },
   "components/chart.tsx": {
-    "mtime": 1783698026.682728,
+    "mtime": 1784776716.510749,
     "ast_hash": "74d6516a8d4331be3c1de2f5546f02c8",
     "semantic_hash": "74d6516a8d4331be3c1de2f5546f02c8"
   },
   "components/count-up.tsx": {
-    "mtime": 1783698026.683727,
+    "mtime": 1784776716.5117466,
     "ast_hash": "2a5e30686c2508ea1297d07290e8ab0a",
     "semantic_hash": "2a5e30686c2508ea1297d07290e8ab0a"
   },
   "components/custom-tooltip.tsx": {
-    "mtime": 1783698026.683727,
+    "mtime": 1784776716.5127459,
     "ast_hash": "6ff4eadd897894c15b30eb3cf1814af6",
     "semantic_hash": "6ff4eadd897894c15b30eb3cf1814af6"
   },
   "components/data-card.tsx": {
-    "mtime": 1783698026.6847284,
+    "mtime": 1784776716.5137484,
     "ast_hash": "2321ab5ad86822aa6ab8f2e187b7a03b",
     "semantic_hash": "2321ab5ad86822aa6ab8f2e187b7a03b"
   },
   "components/data-charts.tsx": {
-    "mtime": 1783698026.6847284,
+    "mtime": 1784776716.5137484,
     "ast_hash": "9d25bd8d4050d3a5852454fdd29d8075",
     "semantic_hash": "9d25bd8d4050d3a5852454fdd29d8075"
   },
   "components/data-grid.tsx": {
-    "mtime": 1783698026.6857238,
+    "mtime": 1784776716.5147445,
     "ast_hash": "60a5989035455640e62801b3f63338d5",
     "semantic_hash": "60a5989035455640e62801b3f63338d5"
   },
   "components/data-table.tsx": {
-    "mtime": 1783698026.6867247,
+    "mtime": 1784776716.5167472,
     "ast_hash": "0036603ad3c39c45593f5023a22e28e6",
     "semantic_hash": "0036603ad3c39c45593f5023a22e28e6"
   },
   "components/date-filter.tsx": {
-    "mtime": 1783698026.6867247,
+    "mtime": 1784776716.5187492,
     "ast_hash": "a9244f433aa9208513f183234d3f3520",
     "semantic_hash": "a9244f433aa9208513f183234d3f3520"
   },
   "components/date-picker.tsx": {
-    "mtime": 1783698026.6877248,
+    "mtime": 1784776716.519747,
     "ast_hash": "ed84ded8b671ffd9ad60272f9d11c00d",
     "semantic_hash": "ed84ded8b671ffd9ad60272f9d11c00d"
   },
   "components/filters.tsx": {
-    "mtime": 1783698026.6877248,
+    "mtime": 1784776716.5207486,
     "ast_hash": "e75b50e83846dba53c1898763595d123",
     "semantic_hash": "e75b50e83846dba53c1898763595d123"
   },
   "components/header-logo.tsx": {
-    "mtime": 1783698026.688725,
+    "mtime": 1784776716.521747,
     "ast_hash": "c46ab98f0bacb4de80cf4edb4c615abd",
     "semantic_hash": "c46ab98f0bacb4de80cf4edb4c615abd"
   },
   "components/header.tsx": {
-    "mtime": 1783698026.6897311,
+    "mtime": 1784776716.5227535,
     "ast_hash": "7802b7fd1726fea6aa089a9250fdffde",
     "semantic_hash": "7802b7fd1726fea6aa089a9250fdffde"
   },
   "components/line-variant.tsx": {
-    "mtime": 1783698026.6897311,
+    "mtime": 1784776716.5227535,
     "ast_hash": "8dc9ece9d612703a75f566706708ba2b",
     "semantic_hash": "8dc9ece9d612703a75f566706708ba2b"
   },
   "components/nav-button.tsx": {
-    "mtime": 1783698026.6907363,
+    "mtime": 1784776716.5237534,
     "ast_hash": "b2c4d52348074882daa31c134d88b2d8",
     "semantic_hash": "b2c4d52348074882daa31c134d88b2d8"
   },
   "components/navigation.tsx": {
-    "mtime": 1783698026.6918538,
+    "mtime": 1784776716.524751,
     "ast_hash": "997f8a982058f5412d757a788d9516d9",
     "semantic_hash": "997f8a982058f5412d757a788d9516d9"
   },
   "components/pie-variant.tsx": {
-    "mtime": 1783698026.6927245,
+    "mtime": 1784776716.525749,
     "ast_hash": "7569854c8d21bf9c912c37ffee6e7b2c",
     "semantic_hash": "7569854c8d21bf9c912c37ffee6e7b2c"
   },
   "components/radar-variant.tsx": {
-    "mtime": 1783698026.6937232,
+    "mtime": 1784776716.526752,
     "ast_hash": "f88facb25684dc4cb57a53d88d2f2b2d",
     "semantic_hash": "f88facb25684dc4cb57a53d88d2f2b2d"
   },
   "components/radial-variant.tsx": {
-    "mtime": 1783698026.6937232,
+    "mtime": 1784776716.526752,
     "ast_hash": "b7ae0721877e097af9c60f51ee8c5d53",
     "semantic_hash": "b7ae0721877e097af9c60f51ee8c5d53"
   },
   "components/select.tsx": {
-    "mtime": 1783698026.6947315,
+    "mtime": 1784776716.52775,
     "ast_hash": "ec40de40d9c2ebac1f51fc91cc26482a",
     "semantic_hash": "ec40de40d9c2ebac1f51fc91cc26482a"
   },
   "components/spending-pie.tsx": {
-    "mtime": 1783698026.6957326,
+    "mtime": 1784776716.528751,
     "ast_hash": "d84612a66f0575ca30483841e3f1ace0",
     "semantic_hash": "d84612a66f0575ca30483841e3f1ace0"
   },
   "components/ui/badge.tsx": {
-    "mtime": 1783698026.6967292,
+    "mtime": 1784776716.5297523,
     "ast_hash": "4dbaeb29689b069d2b5c29e4403c22ed",
     "semantic_hash": "4dbaeb29689b069d2b5c29e4403c22ed"
   },
   "components/ui/button.tsx": {
-    "mtime": 1783698026.6967292,
+    "mtime": 1784776716.530749,
     "ast_hash": "c146cd1d6f1e0d54e4a7bb5f15a0834b",
     "semantic_hash": "c146cd1d6f1e0d54e4a7bb5f15a0834b"
   },
   "components/ui/calendar.tsx": {
-    "mtime": 1783698026.6977258,
+    "mtime": 1784776716.531748,
     "ast_hash": "5d3fb01c5e7002fb7d8a3a9b7eb490da",
     "semantic_hash": "5d3fb01c5e7002fb7d8a3a9b7eb490da"
   },
   "components/ui/card.tsx": {
-    "mtime": 1783698026.6987243,
+    "mtime": 1784776716.5327506,
     "ast_hash": "a6752f4d1da504c7f03196d90cde4b2c",
     "semantic_hash": "a6752f4d1da504c7f03196d90cde4b2c"
   },
   "components/ui/checkbox.tsx": {
-    "mtime": 1783698026.6987243,
+    "mtime": 1784776716.5337517,
     "ast_hash": "a6f8a3a1887026cb83a784484e17fea5",
     "semantic_hash": "a6f8a3a1887026cb83a784484e17fea5"
   },
   "components/ui/dialog.tsx": {
-    "mtime": 1783698026.699728,
+    "mtime": 1784776716.5337517,
     "ast_hash": "f1a1f40caa86d72f9863b966b4f61c54",
     "semantic_hash": "f1a1f40caa86d72f9863b966b4f61c54"
   },
   "components/ui/dropdown-menu.tsx": {
-    "mtime": 1783698026.7007246,
+    "mtime": 1784776716.5357494,
     "ast_hash": "4d34f2b82c3880388c0eda72d38365dc",
     "semantic_hash": "4d34f2b82c3880388c0eda72d38365dc"
   },
   "components/ui/form.tsx": {
-    "mtime": 1783698026.7017264,
+    "mtime": 1784776716.5367458,
     "ast_hash": "cc761fa32f15b47f7cacf623f48b115f",
     "semantic_hash": "cc761fa32f15b47f7cacf623f48b115f"
   },
   "components/ui/input.tsx": {
-    "mtime": 1783698026.7017264,
+    "mtime": 1784776716.5377452,
     "ast_hash": "6666f8369b53c79d39be8060dc6c4ce5",
     "semantic_hash": "6666f8369b53c79d39be8060dc6c4ce5"
   },
   "components/ui/label.tsx": {
-    "mtime": 1783698026.7027252,
+    "mtime": 1784776716.5387473,
     "ast_hash": "14f124762142b39a666ce10d3b42d28c",
     "semantic_hash": "14f124762142b39a666ce10d3b42d28c"
   },
   "components/ui/popover.tsx": {
-    "mtime": 1783698026.7037253,
+    "mtime": 1784776716.539749,
     "ast_hash": "ccb677b4322e7cde381fd479f6b6ec3d",
     "semantic_hash": "ccb677b4322e7cde381fd479f6b6ec3d"
   },
   "components/ui/select.tsx": {
-    "mtime": 1783698026.7037253,
+    "mtime": 1784776716.5407498,
     "ast_hash": "57eeee9dc97be258532e1a2242f6052a",
     "semantic_hash": "57eeee9dc97be258532e1a2242f6052a"
   },
   "components/ui/separator.tsx": {
-    "mtime": 1783698026.7047248,
+    "mtime": 1784776716.5407498,
     "ast_hash": "a27e39c797c6856cf5843b7b84d81cff",
     "semantic_hash": "a27e39c797c6856cf5843b7b84d81cff"
   },
   "components/ui/sheet.tsx": {
-    "mtime": 1783698026.7057245,
+    "mtime": 1784776716.5417466,
     "ast_hash": "0fe0e7acf5cf19ddc3b138c1ed249ca3",
     "semantic_hash": "0fe0e7acf5cf19ddc3b138c1ed249ca3"
   },
   "components/ui/skeleton.tsx": {
-    "mtime": 1783698026.7077246,
+    "mtime": 1784776716.5427468,
     "ast_hash": "ee5017bac14efeda715feaceb488382a",
     "semantic_hash": "ee5017bac14efeda715feaceb488382a"
   },
   "components/ui/sonner.tsx": {
-    "mtime": 1783698026.7087278,
+    "mtime": 1784776716.5437474,
     "ast_hash": "5dde0d04f3ecf6b5e812104aca12c546",
     "semantic_hash": "5dde0d04f3ecf6b5e812104aca12c546"
   },
   "components/ui/table.tsx": {
-    "mtime": 1783698026.7097285,
+    "mtime": 1784776716.5437474,
     "ast_hash": "294d03324937ba75b77ad45ca31a0770",
     "semantic_hash": "294d03324937ba75b77ad45ca31a0770"
   },
   "components/ui/textarea.tsx": {
-    "mtime": 1783698026.7097285,
+    "mtime": 1784776716.5447464,
     "ast_hash": "04f9af2a78672f7018b16db2bcec5036",
     "semantic_hash": "04f9af2a78672f7018b16db2bcec5036"
   },
   "components/ui/tooltip.tsx": {
-    "mtime": 1783698026.7107282,
+    "mtime": 1784776716.5457454,
     "ast_hash": "17aeef2e263039ea21914a51d71e290f",
     "semantic_hash": "17aeef2e263039ea21914a51d71e290f"
   },
   "components/ui/visually-hidden.tsx": {
-    "mtime": 1783698026.7117264,
+    "mtime": 1784776716.5457454,
     "ast_hash": "fccdf5ff7ac1a80fa0092ebbeccae487",
     "semantic_hash": "fccdf5ff7ac1a80fa0092ebbeccae487"
   },
   "components/welcome-msg.tsx": {
-    "mtime": 1783698026.712728,
+    "mtime": 1784776716.546744,
     "ast_hash": "eae01daa519d10611ce285e97ec0b88c",
     "semantic_hash": "eae01daa519d10611ce285e97ec0b88c"
   },
   "db/connection.test.ts": {
-    "mtime": 1783698026.713726,
+    "mtime": 1784776716.5477502,
     "ast_hash": "795511b3f6d89d418a6c83cae9f00436",
     "semantic_hash": "795511b3f6d89d418a6c83cae9f00436"
   },
   "db/connection.ts": {
-    "mtime": 1783698026.713726,
+    "mtime": 1784776716.5487466,
     "ast_hash": "0a76c321e21b4cd0e497be9a4927574f",
     "semantic_hash": "0a76c321e21b4cd0e497be9a4927574f"
   },
   "db/drizzle.ts": {
-    "mtime": 1783698026.7147307,
+    "mtime": 1784776716.5497594,
     "ast_hash": "231c8d06860dc3b91a8736ed7018f6be",
     "semantic_hash": "231c8d06860dc3b91a8736ed7018f6be"
   },
   "db/schema.ts": {
-    "mtime": 1783698026.7147307,
+    "mtime": 1784776716.550753,
     "ast_hash": "7b894991c744333c2537b2814fd7c491",
     "semantic_hash": "7b894991c744333c2537b2814fd7c491"
   },
   "drizzle.config.ts": {
-    "mtime": 1783698026.7217247,
+    "mtime": 1784776716.567755,
     "ast_hash": "e943f9e498a9323436e5e17709e05fed",
     "semantic_hash": "e943f9e498a9323436e5e17709e05fed"
   },
   "drizzle/0000_optimal_luckman.sql": {
-    "mtime": 1783698026.7227278,
+    "mtime": 1784776716.5687542,
     "ast_hash": "bd2145027d2bbbc98d26731f1226a1c7",
     "semantic_hash": "bd2145027d2bbbc98d26731f1226a1c7"
   },
   "drizzle/0001_swift_arclight.sql": {
-    "mtime": 1783698026.7237337,
+    "mtime": 1784776716.56975,
     "ast_hash": "967fb21d10f6e12a1f6fc3dcbc877c60",
     "semantic_hash": "967fb21d10f6e12a1f6fc3dcbc877c60"
   },
   "drizzle/0002_fantastic_puff_adder.sql": {
-    "mtime": 1783698026.724724,
+    "mtime": 1784776716.570749,
     "ast_hash": "cd4b63737426b98becafe6ff3a6d75ef",
     "semantic_hash": "cd4b63737426b98becafe6ff3a6d75ef"
   },
   "drizzle/0003_rich_clea.sql": {
-    "mtime": 1783698026.72573,
+    "mtime": 1784776716.571749,
     "ast_hash": "d7bc04fb4b92ff8699c9825a20f4a06e",
     "semantic_hash": "d7bc04fb4b92ff8699c9825a20f4a06e"
   },
   "drizzle/0004_dazzling_changeling.sql": {
-    "mtime": 1783698026.7267325,
+    "mtime": 1784776716.5727477,
     "ast_hash": "5bfc6634def7305187ce73ca331e6ee9",
     "semantic_hash": "5bfc6634def7305187ce73ca331e6ee9"
   },
   "drizzle/0005_square_grey_gargoyle.sql": {
-    "mtime": 1783698026.7267325,
+    "mtime": 1784776716.5737512,
     "ast_hash": "b89b8036526aa7ac1e176b4eb5e94daa",
     "semantic_hash": "b89b8036526aa7ac1e176b4eb5e94daa"
   },
   "drizzle/0006_melted_supernaut.sql": {
-    "mtime": 1783698026.7277303,
+    "mtime": 1784776716.5737512,
     "ast_hash": "42c949a692333a0e9a172a1b6806a951",
     "semantic_hash": "42c949a692333a0e9a172a1b6806a951"
   },
   "drizzle/0007_modern_virginia_dare.sql": {
-    "mtime": 1783698026.7277303,
+    "mtime": 1784776716.574749,
     "ast_hash": "2c346ad11dcffe8d5df1960242faf954",
     "semantic_hash": "2c346ad11dcffe8d5df1960242faf954"
   },
   "drizzle/meta/0000_snapshot.json": {
-    "mtime": 1783698026.7297313,
+    "mtime": 1784776716.5757494,
     "ast_hash": "758d52119d2e618c6f6a94e5b67dc2e3",
     "semantic_hash": "758d52119d2e618c6f6a94e5b67dc2e3"
   },
   "drizzle/meta/0001_snapshot.json": {
-    "mtime": 1783698026.7297313,
+    "mtime": 1784776716.5767477,
     "ast_hash": "bc4b3d07d564bb41f9cc45d4f0dad487",
     "semantic_hash": "bc4b3d07d564bb41f9cc45d4f0dad487"
   },
   "drizzle/meta/0002_snapshot.json": {
-    "mtime": 1783698026.7317283,
+    "mtime": 1784776716.5777502,
     "ast_hash": "36372ab5b284c91ff60fd2f28d0292e3",
     "semantic_hash": "36372ab5b284c91ff60fd2f28d0292e3"
   },
   "drizzle/meta/0003_snapshot.json": {
-    "mtime": 1783698026.732726,
+    "mtime": 1784776716.5787485,
     "ast_hash": "cf0a270eed48ec3418d3da247b953162",
     "semantic_hash": "cf0a270eed48ec3418d3da247b953162"
   },
   "drizzle/meta/0004_snapshot.json": {
-    "mtime": 1783698026.732726,
+    "mtime": 1784776716.5797472,
     "ast_hash": "97ffb3bda68144cf4192026240f80d8d",
     "semantic_hash": "97ffb3bda68144cf4192026240f80d8d"
   },
   "drizzle/meta/0005_snapshot.json": {
-    "mtime": 1783698026.733726,
+    "mtime": 1784776716.5797472,
     "ast_hash": "84f8238dc35bc960c5a48b909e4dad08",
     "semantic_hash": "84f8238dc35bc960c5a48b909e4dad08"
   },
   "drizzle/meta/0006_snapshot.json": {
-    "mtime": 1783698026.7347307,
+    "mtime": 1784776716.5807471,
     "ast_hash": "a4db910e41810f476ded9eb06dc6d37f",
     "semantic_hash": "a4db910e41810f476ded9eb06dc6d37f"
   },
   "drizzle/meta/0007_snapshot.json": {
-    "mtime": 1783698026.7347307,
+    "mtime": 1784776716.5817482,
     "ast_hash": "b6a5ba0ed99498dc0f661aa193e023a2",
     "semantic_hash": "b6a5ba0ed99498dc0f661aa193e023a2"
   },
   "drizzle/meta/_journal.json": {
-    "mtime": 1783698026.7357252,
+    "mtime": 1784776716.5827508,
     "ast_hash": "637181a5a2a3b22a9bedbc518f5da57b",
     "semantic_hash": "637181a5a2a3b22a9bedbc518f5da57b"
   },
   "eslint.config.mjs": {
-    "mtime": 1783698026.7367315,
+    "mtime": 1784776716.5837479,
     "ast_hash": "340888b6e27069429228a613a145a858",
     "semantic_hash": "340888b6e27069429228a613a145a858"
   },
   "features/accounts/api/use-bulk-delete-accounts.ts": {
-    "mtime": 1783698026.738732,
+    "mtime": 1784776716.5867498,
     "ast_hash": "9f506b412d13313aea175b88fbebf566",
     "semantic_hash": "9f506b412d13313aea175b88fbebf566"
   },
   "features/accounts/api/use-create-account.ts": {
-    "mtime": 1783698026.73973,
+    "mtime": 1784776716.587748,
     "ast_hash": "19a27cff878cdfe1049ec38490522315",
     "semantic_hash": "19a27cff878cdfe1049ec38490522315"
   },
   "features/accounts/api/use-delete-account.ts": {
-    "mtime": 1783698026.7427294,
+    "mtime": 1784776716.5897548,
     "ast_hash": "012dc8f6db0a1d1f1e27bfe5fe82d72f",
     "semantic_hash": "012dc8f6db0a1d1f1e27bfe5fe82d72f"
   },
   "features/accounts/api/use-edit-account.ts": {
-    "mtime": 1783698026.7427294,
+    "mtime": 1784776716.5917492,
     "ast_hash": "5d30fa3abf5adae66613a0c5ec66466a",
     "semantic_hash": "5d30fa3abf5adae66613a0c5ec66466a"
   },
   "features/accounts/api/use-get-account.ts": {
-    "mtime": 1783698026.7437315,
+    "mtime": 1784776716.5917492,
     "ast_hash": "6958e1f2e321f36e7016177e4cc3832a",
     "semantic_hash": "6958e1f2e321f36e7016177e4cc3832a"
   },
   "features/accounts/api/use-get-accounts.ts": {
-    "mtime": 1783698026.7447295,
+    "mtime": 1784776716.5927472,
     "ast_hash": "45579b5c52f7712b855b0c7cff89e5f8",
     "semantic_hash": "45579b5c52f7712b855b0c7cff89e5f8"
   },
   "features/accounts/components/account-form.tsx": {
-    "mtime": 1783698026.7457252,
+    "mtime": 1784776716.594746,
     "ast_hash": "9fe855c98f49152c7fd3602a4727445f",
     "semantic_hash": "9fe855c98f49152c7fd3602a4727445f"
   },
   "features/accounts/components/edit-account-sheet.tsx": {
-    "mtime": 1783698026.7467346,
+    "mtime": 1784776716.5957515,
     "ast_hash": "903cbf5c453ad80f619e815d47f05528",
     "semantic_hash": "903cbf5c453ad80f619e815d47f05528"
   },
   "features/accounts/components/new-account-sheet.tsx": {
-    "mtime": 1783698026.7467346,
+    "mtime": 1784776716.5977457,
     "ast_hash": "f5a1d9a155604c8b8d58153f47a71624",
     "semantic_hash": "f5a1d9a155604c8b8d58153f47a71624"
   },
   "features/accounts/hooks/use-new-account.ts": {
-    "mtime": 1783698026.7487342,
+    "mtime": 1784776716.5987453,
     "ast_hash": "fb1670915c9440350ceb21ae6cca2cc0",
     "semantic_hash": "fb1670915c9440350ceb21ae6cca2cc0"
   },
   "features/accounts/hooks/use-open-account.ts": {
-    "mtime": 1783698026.7487342,
+    "mtime": 1784776716.6007502,
     "ast_hash": "98bee9f77378a9ec8e38647c9e32ebb5",
     "semantic_hash": "98bee9f77378a9ec8e38647c9e32ebb5"
   },
   "features/accounts/hooks/use-select-account.tsx": {
-    "mtime": 1783698026.749732,
+    "mtime": 1784776716.6017466,
     "ast_hash": "c055cdf0090e8ea14e5c17f3d8d64ac5",
     "semantic_hash": "c055cdf0090e8ea14e5c17f3d8d64ac5"
   },
   "features/categories/api/use-bulk-delete-categories.ts": {
-    "mtime": 1783698026.75173,
+    "mtime": 1784776716.6037498,
     "ast_hash": "6c35e3f92077b6b90e9f81c107ee1106",
     "semantic_hash": "6c35e3f92077b6b90e9f81c107ee1106"
   },
   "features/categories/api/use-create-category.ts": {
-    "mtime": 1783698026.75173,
+    "mtime": 1784776716.604745,
     "ast_hash": "934a542997766c5f9d92ad50e0949f11",
     "semantic_hash": "934a542997766c5f9d92ad50e0949f11"
   },
   "features/categories/api/use-delete-category.ts": {
-    "mtime": 1783698026.7537296,
+    "mtime": 1784776716.6067555,
     "ast_hash": "8fb473fe2293d8426d5170978daef45f",
     "semantic_hash": "8fb473fe2293d8426d5170978daef45f"
   },
   "features/categories/api/use-edit-category.ts": {
-    "mtime": 1783698026.754728,
+    "mtime": 1784776716.6077547,
     "ast_hash": "acd026b34c1bc7d7699a62938631d000",
     "semantic_hash": "acd026b34c1bc7d7699a62938631d000"
   },
   "features/categories/api/use-get-categories.ts": {
-    "mtime": 1783698026.754728,
+    "mtime": 1784776716.6087523,
     "ast_hash": "a754c910faddd7056fd7d0aae8580296",
     "semantic_hash": "a754c910faddd7056fd7d0aae8580296"
   },
   "features/categories/api/use-get-category.ts": {
-    "mtime": 1783698026.75573,
+    "mtime": 1784776716.6087523,
     "ast_hash": "e487a09f03820a988f1fba7af46efd9b",
     "semantic_hash": "e487a09f03820a988f1fba7af46efd9b"
   },
   "features/categories/components/category-form.tsx": {
-    "mtime": 1783698026.7579055,
+    "mtime": 1784776716.6107504,
     "ast_hash": "fab3b1ee581c6a7a3bc11777fbfa44cb",
     "semantic_hash": "fab3b1ee581c6a7a3bc11777fbfa44cb"
   },
   "features/categories/components/edit-category-sheet.tsx": {
-    "mtime": 1783698026.7579055,
+    "mtime": 1784776716.6117501,
     "ast_hash": "eac9c84208ac474bfa500ebb2078f6fc",
     "semantic_hash": "eac9c84208ac474bfa500ebb2078f6fc"
   },
   "features/categories/components/new-category-sheet.tsx": {
-    "mtime": 1783698026.7587247,
+    "mtime": 1784776716.6127486,
     "ast_hash": "44c4510df4d98642cbde5f163048e2b2",
     "semantic_hash": "44c4510df4d98642cbde5f163048e2b2"
   },
   "features/categories/hooks/use-new-category.ts": {
-    "mtime": 1783698026.759732,
+    "mtime": 1784776716.6147463,
     "ast_hash": "62c621c2b5c510b0c69a874325da21d9",
     "semantic_hash": "62c621c2b5c510b0c69a874325da21d9"
   },
   "features/categories/hooks/use-open-category.ts": {
-    "mtime": 1783698026.7607288,
+    "mtime": 1784776716.6147463,
     "ast_hash": "cf1b909f1cc666056c826133f28ff687",
     "semantic_hash": "cf1b909f1cc666056c826133f28ff687"
   },
   "features/summary/use-get-summary.ts": {
-    "mtime": 1783698026.7617302,
+    "mtime": 1784776716.6177526,
     "ast_hash": "11733b2a81f054a67a7fe0b4e4395241",
     "semantic_hash": "11733b2a81f054a67a7fe0b4e4395241"
   },
   "features/transactions/api/use-bulk-create-transactions.ts": {
-    "mtime": 1783698026.7637303,
+    "mtime": 1784776716.620748,
     "ast_hash": "53337c2baddf08b70e20ea2744fc15c4",
     "semantic_hash": "53337c2baddf08b70e20ea2744fc15c4"
   },
   "features/transactions/api/use-bulk-delete-transactions.ts": {
-    "mtime": 1783698026.7637303,
+    "mtime": 1784776716.6217494,
     "ast_hash": "23716d6abac7b5a9e69fc2e3685490c1",
     "semantic_hash": "23716d6abac7b5a9e69fc2e3685490c1"
   },
   "features/transactions/api/use-create-transaction.ts": {
-    "mtime": 1783698026.7647276,
+    "mtime": 1784776716.6227462,
     "ast_hash": "044508d87a96ebcccdadfccc576b11f8",
     "semantic_hash": "044508d87a96ebcccdadfccc576b11f8"
   },
   "features/transactions/api/use-delete-transaction.ts": {
-    "mtime": 1783698026.765733,
+    "mtime": 1784776716.6237476,
     "ast_hash": "4b0a01e8b9a8077331d54e352ed9344a",
     "semantic_hash": "4b0a01e8b9a8077331d54e352ed9344a"
   },
   "features/transactions/api/use-edit-transaction.ts": {
-    "mtime": 1783698026.765733,
+    "mtime": 1784776716.6247468,
     "ast_hash": "21fda0694c1345ba54cc76df9b2e15aa",
     "semantic_hash": "21fda0694c1345ba54cc76df9b2e15aa"
   },
   "features/transactions/api/use-get-transaction.ts": {
-    "mtime": 1783698026.7667286,
+    "mtime": 1784776716.625748,
     "ast_hash": "f1acd3c01aa08aef4154b85beaee7777",
     "semantic_hash": "f1acd3c01aa08aef4154b85beaee7777"
   },
   "features/transactions/api/use-get-transactions.ts": {
-    "mtime": 1783698026.7667286,
+    "mtime": 1784776716.6267476,
     "ast_hash": "0b3c01ed924bca03d9b4eecb6091d37e",
     "semantic_hash": "0b3c01ed924bca03d9b4eecb6091d37e"
   },
   "features/transactions/components/edit-transaction-sheet.tsx": {
-    "mtime": 1783698026.767732,
+    "mtime": 1784776716.6287453,
     "ast_hash": "48bb9fbbe7f41d8ea67950bd86b6a079",
     "semantic_hash": "48bb9fbbe7f41d8ea67950bd86b6a079"
   },
   "features/transactions/components/new-transaction-sheet.tsx": {
-    "mtime": 1783698026.7687278,
+    "mtime": 1784776716.629747,
     "ast_hash": "687a00a2104d398ea3644aaadda4f56e",
     "semantic_hash": "687a00a2104d398ea3644aaadda4f56e"
   },
   "features/transactions/components/transaction-form.tsx": {
-    "mtime": 1783698026.7697315,
+    "mtime": 1784776716.630745,
     "ast_hash": "d2cad1fe2acc4fb3d9ea2825067441be",
     "semantic_hash": "d2cad1fe2acc4fb3d9ea2825067441be"
   },
   "features/transactions/hooks/use-new-transaction.ts": {
-    "mtime": 1783698026.7707274,
+    "mtime": 1784776716.6327474,
     "ast_hash": "406300d4fe753393fb2511fd580dc237",
     "semantic_hash": "406300d4fe753393fb2511fd580dc237"
   },
   "features/transactions/hooks/use-open-transaction.ts": {
-    "mtime": 1783698026.7717302,
+    "mtime": 1784776716.6337483,
     "ast_hash": "b5fb68ce3ee90e730a0ff90ceb053bf2",
     "semantic_hash": "b5fb68ce3ee90e730a0ff90ceb053bf2"
   },
   "hooks/use-confirm.tsx": {
-    "mtime": 1783698026.7857275,
+    "mtime": 1784776716.658755,
     "ast_hash": "b997aa85b43ca41d936c526373c1a690",
     "semantic_hash": "b997aa85b43ca41d936c526373c1a690"
   },
   "lib/api-base-url.test.ts": {
-    "mtime": 1783698026.7867272,
+    "mtime": 1784776716.659752,
     "ast_hash": "26dca4a2e42cc3b2b5715f8138cf6380",
     "semantic_hash": "26dca4a2e42cc3b2b5715f8138cf6380"
   },
   "lib/api-base-url.ts": {
-    "mtime": 1783698026.7867272,
+    "mtime": 1784776716.6607523,
     "ast_hash": "0466af5fa2a369989955fcfa20b9fbb2",
     "semantic_hash": "0466af5fa2a369989955fcfa20b9fbb2"
   },
   "lib/api-error.ts": {
-    "mtime": 1783698026.7877283,
+    "mtime": 1784776716.6617453,
     "ast_hash": "2872eb16f0b1bde6a0f2846d3f0f08ba",
     "semantic_hash": "2872eb16f0b1bde6a0f2846d3f0f08ba"
   },
   "lib/chunk-items.test.ts": {
-    "mtime": 1783698026.7917266,
+    "mtime": 1784776716.6677508,
     "ast_hash": "085fa5724c2d7a4d69f089ea2085de5b",
     "semantic_hash": "085fa5724c2d7a4d69f089ea2085de5b"
   },
   "lib/chunk-items.ts": {
-    "mtime": 1783698026.7927282,
+    "mtime": 1784776716.66875,
     "ast_hash": "189dbe829e294fa23f8911b96b2058a2",
     "semantic_hash": "189dbe829e294fa23f8911b96b2058a2"
   },
   "lib/hono.ts": {
-    "mtime": 1783698026.793728,
+    "mtime": 1784776716.66875,
     "ast_hash": "9d52fd96018b274dc387f48e607105c2",
     "semantic_hash": "9d52fd96018b274dc387f48e607105c2"
   },
   "lib/select-options.test.ts": {
-    "mtime": 1783698026.793728,
+    "mtime": 1784776716.6697483,
     "ast_hash": "76beb3bfa1e41d1469b1cbec4e312e24",
     "semantic_hash": "76beb3bfa1e41d1469b1cbec4e312e24"
   },
   "lib/select-options.ts": {
-    "mtime": 1783698026.7947247,
+    "mtime": 1784776716.6707473,
     "ast_hash": "33346a4dd0d8b9f14f60e6de1327e85a",
     "semantic_hash": "33346a4dd0d8b9f14f60e6de1327e85a"
   },
   "lib/transaction-import.test.ts": {
-    "mtime": 1783698026.7957249,
+    "mtime": 1784776716.6717496,
     "ast_hash": "4d374a452c5574fdd81560c9b7701baf",
     "semantic_hash": "4d374a452c5574fdd81560c9b7701baf"
   },
   "lib/transaction-import.ts": {
-    "mtime": 1783698026.7957249,
+    "mtime": 1784776716.6717496,
     "ast_hash": "343a027eed9ca2d9ac57963fa5035472",
     "semantic_hash": "343a027eed9ca2d9ac57963fa5035472"
   },
   "lib/transaction-limits.ts": {
-    "mtime": 1783698026.7967248,
+    "mtime": 1784776716.6727493,
     "ast_hash": "fff8d0679f824e17df45c3128f5453fc",
     "semantic_hash": "fff8d0679f824e17df45c3128f5453fc"
   },
   "lib/transaction-route-utils.test.ts": {
-    "mtime": 1783698026.7977252,
+    "mtime": 1784776716.6737452,
     "ast_hash": "a2cbbfa132acbd51958ee1d3a7b759de",
     "semantic_hash": "a2cbbfa132acbd51958ee1d3a7b759de"
   },
   "lib/transaction-route-utils.ts": {
-    "mtime": 1783698026.7977252,
+    "mtime": 1784776716.6747525,
     "ast_hash": "d5b31a484ab4348ed3b91ca1243b88c3",
     "semantic_hash": "d5b31a484ab4348ed3b91ca1243b88c3"
   },
   "lib/utils.ts": {
-    "mtime": 1783698026.7987258,
+    "mtime": 1784776716.675749,
     "ast_hash": "7f31f0445ffd29bbd4d58ed86e1ae568",
     "semantic_hash": "7f31f0445ffd29bbd4d58ed86e1ae568"
   },
   "next.config.ts": {
-    "mtime": 1783698026.7987258,
+    "mtime": 1784776716.675749,
     "ast_hash": "1bb2f779f0a75d33af448649d3793ff9",
     "semantic_hash": "1bb2f779f0a75d33af448649d3793ff9"
   },
   "package.json": {
-    "mtime": 1784742043.7327802,
+    "mtime": 1784776716.6807482,
     "ast_hash": "b12ce8a02f9c31286cdd3a4ba807424a",
     "semantic_hash": ""
   },
   "postcss.config.mjs": {
-    "mtime": 1783698026.8057396,
+    "mtime": 1784776716.7117498,
     "ast_hash": "e9d66e1263ec6f84f9c7f4b88b00e4f9",
     "semantic_hash": "e9d66e1263ec6f84f9c7f4b88b00e4f9"
   },
   "providers/query-provider.tsx": {
-    "mtime": 1783698026.812728,
+    "mtime": 1784776716.713745,
     "ast_hash": "9ecd69a2c447c1b35a6ed3d5decae60b",
     "semantic_hash": "9ecd69a2c447c1b35a6ed3d5decae60b"
   },
   "providers/sheet-provider.tsx": {
-    "mtime": 1783698026.8137352,
+    "mtime": 1784776716.7147443,
     "ast_hash": "04d761cf7b5e877bb9de17d75822de28",
     "semantic_hash": "04d761cf7b5e877bb9de17d75822de28"
   },
   "proxy.ts": {
-    "mtime": 1783698026.815732,
+    "mtime": 1784776716.7147443,
     "ast_hash": "48745f85b81daa2435b98d7b30bdfe9d",
     "semantic_hash": "48745f85b81daa2435b98d7b30bdfe9d"
   },
   "scripts/dev-local.ts": {
-    "mtime": 1783698026.825726,
+    "mtime": 1784776716.727744,
     "ast_hash": "7bffc8a9f0abd5f4e89dbc4f797005a2",
     "semantic_hash": "7bffc8a9f0abd5f4e89dbc4f797005a2"
   },
   "scripts/migrate.ts": {
-    "mtime": 1783698026.8267236,
+    "mtime": 1784776716.727744,
     "ast_hash": "c3978e78f7441fd5ea4f8f0821bed4a3",
     "semantic_hash": "c3978e78f7441fd5ea4f8f0821bed4a3"
   },
   "scripts/seed.ts": {
-    "mtime": 1783698026.8267236,
+    "mtime": 1784776716.7287543,
     "ast_hash": "5c2eda2cd604e35c10e716ee32143c89",
     "semantic_hash": "5c2eda2cd604e35c10e716ee32143c89"
   },
   "tsconfig.json": {
-    "mtime": 1783698026.827724,
+    "mtime": 1784776716.7307527,
     "ast_hash": "02fc19ad21338c2ab820a70136310db4",
     "semantic_hash": "02fc19ad21338c2ab820a70136310db4"
   },
   "AGENTS.md": {
-    "mtime": 1783698026.6327255,
+    "mtime": 1784776716.4057496,
     "ast_hash": "84b181fae5bdfc5707f0fba5ac5e8c3c",
     "semantic_hash": ""
   },
   "PR-Reviews/13.Upload-Transactions-Import.md": {
-    "mtime": 1783698026.6347277,
+    "mtime": 1784776716.407749,
     "ast_hash": "bc9c10e9559c4fbc0e22c11e0493f8fa",
     "semantic_hash": "bc9c10e9559c4fbc0e22c11e0493f8fa"
   },
   "PR-Reviews/Agents instructions/copilot_review_prompt.md": {
-    "mtime": 1783698026.6357257,
+    "mtime": 1784776716.4097507,
     "ast_hash": "02820e48e71bf49720d4beba6168839c",
     "semantic_hash": "02820e48e71bf49720d4beba6168839c"
   },
   "PR-Reviews/Agents instructions/tech_debt_instructions.md": {
-    "mtime": 1783698026.636725,
+    "mtime": 1784776716.4097507,
     "ast_hash": "4bc40013bd1a94835f993cb2b0c94093",
     "semantic_hash": "4bc40013bd1a94835f993cb2b0c94093"
   },
   "PR_REVIEW_TECH_DEBT_CONSOLIDATED.md": {
-    "mtime": 1783698026.636725,
+    "mtime": 1784776716.4107468,
     "ast_hash": "63554a20789b246c658cfbd38898b199",
     "semantic_hash": "63554a20789b246c658cfbd38898b199"
   },
   "README.md": {
-    "mtime": 1784664178.1015217,
+    "mtime": 1784776716.4117498,
     "ast_hash": "600ed002df03e363026bdc5a4020f273",
     "semantic_hash": ""
   },
   "backend/README.md": {
-    "mtime": 1784664178.1035283,
+    "mtime": 1784776716.4417453,
     "ast_hash": "c0d59faef1f81423a9fd6cb63d986c97",
     "semantic_hash": ""
   },
   "docker-compose.dev.yml": {
-    "mtime": 1783698026.7157264,
+    "mtime": 1784776716.5517504,
     "ast_hash": "641a0abbc4bcd1e6636d89aab283628b",
     "semantic_hash": "641a0abbc4bcd1e6636d89aab283628b"
   },
   "docker-compose.yml": {
-    "mtime": 1784664178.137525,
+    "mtime": 1784776716.5537467,
     "ast_hash": "6ea49b72ecc0efcd9f97d6a194fe3bcd",
     "semantic_hash": ""
   },
   "docs/CODEX_CONTEXT.md": {
-    "mtime": 1783698026.7177246,
+    "mtime": 1784776716.5577457,
     "ast_hash": "9afd74a76dd596e56746c4685a6cdb40",
     "semantic_hash": "9afd74a76dd596e56746c4685a6cdb40"
   },
   "docs/features-roadmap/roadmap_features_list.md": {
-    "mtime": 1783698026.718733,
+    "mtime": 1784776716.5597472,
     "ast_hash": "614d3f13c04f409e3c36559b38c8a5db",
     "semantic_hash": "614d3f13c04f409e3c36559b38c8a5db"
   },
   "docs/specs/18-go-backend-replacement/spec.md": {
-    "mtime": 1784748314.222078,
+    "mtime": 1784776716.5667548,
     "ast_hash": "cb85d7c923228886aa883c052365e242",
     "semantic_hash": ""
   },
   "refreshApp/CODEX_CONTEXT.md": {
-    "mtime": 1783698026.8237402,
+    "mtime": 1784776716.724749,
     "ast_hash": "84d15e20cddd4de32b421607e3b8df58",
     "semantic_hash": "84d15e20cddd4de32b421607e3b8df58"
   },
   "refreshApp/pr summaries/project-polish-pr-summary.md": {
-    "mtime": 1783698026.8247252,
+    "mtime": 1784776716.7257445,
     "ast_hash": "b3239a8197aa94eaa5cd1f627941b33f",
     "semantic_hash": "b3239a8197aa94eaa5cd1f627941b33f"
   },
   "public/file.svg": {
-    "mtime": 1783698026.816731,
+    "mtime": 1784776716.7177517,
     "ast_hash": "d09f95206c3fa0bb9bd9fefabfd0ea71",
     "semantic_hash": "d09f95206c3fa0bb9bd9fefabfd0ea71"
   },
   "public/globe.svg": {
-    "mtime": 1783698026.8177302,
+    "mtime": 1784776716.7187507,
     "ast_hash": "2aaafa6a49b6563925fe440891e32717",
     "semantic_hash": "2aaafa6a49b6563925fe440891e32717"
   },
   "public/logo.svg": {
-    "mtime": 1783698026.8187287,
+    "mtime": 1784776716.719753,
     "ast_hash": "7b5e20dc584002f6561ef811f3e1464d",
     "semantic_hash": "7b5e20dc584002f6561ef811f3e1464d"
   },
   "public/next.svg": {
-    "mtime": 1783698026.8207247,
+    "mtime": 1784776716.721749,
     "ast_hash": "8e061864f388b47f33a1c3780831193e",
     "semantic_hash": "8e061864f388b47f33a1c3780831193e"
   },
   "public/vercel.svg": {
-    "mtime": 1783698026.8217244,
+    "mtime": 1784776716.7227478,
     "ast_hash": "c0af2f507b369b085b35ef4bbe3bcf1e",
     "semantic_hash": "c0af2f507b369b085b35ef4bbe3bcf1e"
   },
   "public/window.svg": {
-    "mtime": 1783698026.8217244,
+    "mtime": 1784776716.723744,
     "ast_hash": "a2760511c65806022ad20adf74370ff3",
     "semantic_hash": "a2760511c65806022ad20adf74370ff3"
   },
   "openapi/nuchi.openapi.json": {
-    "mtime": 1783698026.801723,
+    "mtime": 1784776716.6787488,
     "ast_hash": "aaaf6fff33095e2859910a5a51868241",
     "semantic_hash": ""
   },
   "scripts/validate-openapi.ts": {
-    "mtime": 1783698026.827724,
+    "mtime": 1784776716.7297528,
     "ast_hash": "d3b95441be9cc70c68755656681ace75",
     "semantic_hash": "d3b95441be9cc70c68755656681ace75"
   },
   "backend/internal/openapi/README.md": {
-    "mtime": 1783698026.671726,
+    "mtime": 1784776716.4947488,
     "ast_hash": "e797f9a57d120da32ba7b8ebee253ae6",
     "semantic_hash": "e797f9a57d120da32ba7b8ebee253ae6"
   },
   "docs/specs/18-go-backend-replacement/api-parity-fixtures.md": {
-    "mtime": 1783698026.7207258,
+    "mtime": 1784776716.564744,
     "ast_hash": "98c0c0219dd7f1c5dccc6896bce89bba",
     "semantic_hash": "98c0c0219dd7f1c5dccc6896bce89bba"
   },
   "lib/api/generated/README.md": {
-    "mtime": 1783698026.7897284,
+    "mtime": 1784776716.66475,
     "ast_hash": "58840bd101db026d04637a1cf07bb8cf",
     "semantic_hash": "58840bd101db026d04637a1cf07bb8cf"
   },
   "openapi/README.md": {
-    "mtime": 1783698026.800723,
+    "mtime": 1784776716.676747,
     "ast_hash": "744ff7b621c032eba306b350d636ff93",
     "semantic_hash": ""
   },
   "openapi/oapi-codegen.yaml": {
-    "mtime": 1783698026.801723,
+    "mtime": 1784776716.6787488,
     "ast_hash": "81d1787ebd0ac01e2bb85021ec353b8b",
     "semantic_hash": ""
   },
   ".codex/hooks.json": {
-    "mtime": 1784315916.7934,
+    "mtime": 1784776716.3817468,
     "ast_hash": "efead0799c3e7316bae44143fdd0c63a",
     "semantic_hash": ""
   },
   "backend/go.mod": {
-    "mtime": 1784296925.9112468,
+    "mtime": 1784776716.4447453,
     "ast_hash": "9c492f412148cd9969d630216864f84c",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/SKILL.md": {
-    "mtime": 1784315916.7971697,
+    "mtime": 1784776716.3857486,
     "ast_hash": "21f78a7f96e2f9aecc0f7afc053bd3cc",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/add-watch.md": {
-    "mtime": 1784315916.7982788,
+    "mtime": 1784776716.386747,
     "ast_hash": "d59d027fe449f06aa03905a01184e779",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/exports.md": {
-    "mtime": 1784315916.7992885,
+    "mtime": 1784776716.3877492,
     "ast_hash": "9da2a2152e60a22f07f05fed5158f287",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/extraction-spec.md": {
-    "mtime": 1784315916.799798,
+    "mtime": 1784776716.3887482,
     "ast_hash": "bf895ec4d4e40f5f66f7d31c2a9bd4a7",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/github-and-merge.md": {
-    "mtime": 1784315916.8013117,
+    "mtime": 1784776716.389751,
     "ast_hash": "cde13df085e4c492aeb7ba298a996d0d",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/hooks.md": {
-    "mtime": 1784315916.801818,
+    "mtime": 1784776716.3907468,
     "ast_hash": "3f545db6ce646650bb9de588f5512a27",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/query.md": {
-    "mtime": 1784315916.802325,
+    "mtime": 1784776716.391746,
     "ast_hash": "3c46f8ad006874260614ed8657d02307",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/transcribe.md": {
-    "mtime": 1784315916.8033352,
+    "mtime": 1784776716.3927488,
     "ast_hash": "67b6a5fa6c0974e18f60db9f8932fbd8",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/update.md": {
-    "mtime": 1784315916.8043368,
+    "mtime": 1784776716.3927488,
     "ast_hash": "c698309979460d0f02ba616417844399",
     "semantic_hash": ""
   },
@@ -1015,433 +1015,458 @@
     "semantic_hash": ""
   },
   ".claude/settings.json": {
-    "mtime": 1783698026.6117263,
+    "mtime": 1784776716.378748,
     "ast_hash": "e2078912071ec3800daf5e38e480c97e",
     "semantic_hash": ""
   },
   ".claude/agents/go-migrator.md": {
-    "mtime": 1783698026.6097245,
+    "mtime": 1784776716.3767471,
     "ast_hash": "e2a0d1530cfd5594e4575fb71794f92f",
     "semantic_hash": ""
   },
   ".claude/agents/parity-reviewer.md": {
-    "mtime": 1783698026.6097245,
+    "mtime": 1784776716.3777473,
     "ast_hash": "600cdce7e43ec1386cda547db80d4cdd",
     "semantic_hash": ""
   },
   ".claude/agents/researcher.md": {
-    "mtime": 1783698026.6107347,
+    "mtime": 1784776716.3777473,
     "ast_hash": "734052bd3b657c0db31df9e9827a7e8b",
     "semantic_hash": ""
   },
   ".claude/skills/pr-review-cycle/SKILL.md": {
-    "mtime": 1783698026.6127312,
+    "mtime": 1784776716.3807461,
     "ast_hash": "1a5460a3ea945aa8d875f8781840776b",
     "semantic_hash": ""
   },
   ".github/copilot-instructions.md": {
-    "mtime": 1783698026.626726,
+    "mtime": 1784776716.3957481,
     "ast_hash": "9538cefd640d4ba4dc1298b8f39a7296",
     "semantic_hash": ""
   },
   ".github/workflows/ci.yml": {
-    "mtime": 1784748314.222078,
+    "mtime": 1784776716.3977487,
     "ast_hash": "2d4aa10d182684983fb4909f4aece8f5",
     "semantic_hash": ""
   },
   "CLAUDE.md": {
-    "mtime": 1783887237.1592243,
-    "ast_hash": "82d60683c2197ba2f70d348cdac8f69f",
+    "mtime": 1784776716.406746,
+    "ast_hash": "e00415072c5cc93dd907b12aae164551",
     "semantic_hash": ""
   },
   "backend/tools.go": {
-    "mtime": 1783698026.6757264,
+    "mtime": 1784776716.5017524,
     "ast_hash": "23cf25294ceccdbda20370b02cb84e60",
     "semantic_hash": ""
   },
   "lib/api/generated/schema.d.ts": {
-    "mtime": 1783698026.7917266,
+    "mtime": 1784776716.6667564,
     "ast_hash": "74d8afeedee4554b2ea3668aa5ce804e",
     "semantic_hash": ""
   },
   "backend/internal/openapi/generated.gen.go": {
-    "mtime": 1783698026.6757264,
+    "mtime": 1784776716.4957502,
     "ast_hash": "08cd9ebcbd805f53ad4cf86929cf52e7",
     "semantic_hash": ""
   },
   "backend/internal/config/config_test.go": {
-    "mtime": 1784664178.110524,
+    "mtime": 1784776716.4567502,
     "ast_hash": "d4989f1882f4c30be77d4ba609358360",
     "semantic_hash": ""
   },
   "backend/internal/db/db.go": {
-    "mtime": 1783701470.0356092,
+    "mtime": 1784776716.4597447,
     "ast_hash": "703aa2ff939c3ef2b02afcd332a05456",
     "semantic_hash": ""
   },
   "backend/internal/db/db_test.go": {
-    "mtime": 1784664178.1135266,
+    "mtime": 1784776716.460747,
     "ast_hash": "11881577635a7488b07bb7e93bb0747c",
     "semantic_hash": ""
   },
   "backend/sqlc.yaml": {
-    "mtime": 1783887559.0670724,
+    "mtime": 1784776716.5017524,
     "ast_hash": "5afb93ae3e86332b4b2628259f4f2da4",
     "semantic_hash": ""
   },
   "backend/internal/db/auth_schema_test.go": {
-    "mtime": 1784664178.1115255,
+    "mtime": 1784776716.4587464,
     "ast_hash": "3840960a3a8fe1ad99c5813546c3c7d4",
     "semantic_hash": ""
   },
   "backend/migrations/00001_auth_base.sql": {
-    "mtime": 1783712765.761052,
+    "mtime": 1784776716.4977455,
     "ast_hash": "2864776619a3cd615f7e6cca5c49ca99",
     "semantic_hash": ""
   },
   "backend/internal/db/finance_rls_test.go": {
-    "mtime": 1784664178.1145236,
+    "mtime": 1784776716.4617488,
     "ast_hash": "193db5b30c5be881cc4632c19b861739",
     "semantic_hash": ""
   },
   "backend/internal/db/finance_schema_test.go": {
-    "mtime": 1784664178.116521,
+    "mtime": 1784776716.4627466,
     "ast_hash": "b1f212b072e882200ba0ca980d6c0321",
     "semantic_hash": ""
   },
   "backend/migrations/00002_finance_base.sql": {
-    "mtime": 1783737060.975606,
+    "mtime": 1784776716.4987495,
     "ast_hash": "4c11467f09bb1f26c06ba0d89685ce4d",
     "semantic_hash": ""
   },
   "backend/migrations/00003_finance_rls.sql": {
-    "mtime": 1783737060.975606,
+    "mtime": 1784776716.4997492,
     "ast_hash": "35da157d2e9249449f9777bd62d8a12c",
     "semantic_hash": ""
   },
   "docs/investigation/Argentina_Openbanking/README.md": {
-    "mtime": 1783737060.975606,
+    "mtime": 1784776716.5607483,
     "ast_hash": "e77c5b72d96913778bf0182ffbd54ef2",
     "semantic_hash": ""
   },
   "docs/investigation/Argentina_Openbanking/briefing.md": {
-    "mtime": 1783737060.975606,
+    "mtime": 1784776716.5617452,
     "ast_hash": "4beed5fee8ba44e01a97c39ca01f3cee",
     "semantic_hash": ""
   },
   "docs/investigation/Argentina_Openbanking/findings.md": {
-    "mtime": 1783737060.975606,
+    "mtime": 1784776716.5627482,
     "ast_hash": "d726752ccb7a768a0edc9d241ce3895a",
     "semantic_hash": ""
   },
   "docs/investigation/Argentina_Openbanking/summary.md": {
-    "mtime": 1783737060.975606,
+    "mtime": 1784776716.5627482,
     "ast_hash": "c589199ac4a3041110ca967bef2d686e",
     "semantic_hash": ""
   },
   "post-migration-improvements/README.md": {
-    "mtime": 1784315821.4807198,
+    "mtime": 1784776716.682749,
     "ast_hash": "9eae0432a8a8b0d295bbe09c3aec543b",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/accounts.sql.go": {
-    "mtime": 1783887559.0466275,
+    "mtime": 1784776716.4637456,
     "ast_hash": "af1dc6dd7cb96a277729363d132b2b07",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/auth_tokens.sql.go": {
-    "mtime": 1783887559.04918,
+    "mtime": 1784776716.4647489,
     "ast_hash": "42e6f12daa50c1456b94131a8c1e2e7e",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/categories.sql.go": {
-    "mtime": 1783887559.0496902,
+    "mtime": 1784776716.4657452,
     "ast_hash": "5d1b7fc9c52c60275f499b56be493f72",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/db.go": {
-    "mtime": 1783887559.0512123,
+    "mtime": 1784776716.467755,
     "ast_hash": "2cbddc42f0f37817a76d68976a4de47e",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/models.go": {
-    "mtime": 1783887559.0517206,
+    "mtime": 1784776716.4687514,
     "ast_hash": "d0cfef4d937f49dc3fdab9a12c584cd6",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/summary.sql.go": {
-    "mtime": 1783887559.0527315,
+    "mtime": 1784776716.4697547,
     "ast_hash": "e85b9f8abe428d8d4fb9d174f9d6d26e",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/transactions.sql.go": {
-    "mtime": 1783887559.0537689,
+    "mtime": 1784776716.4707546,
     "ast_hash": "a59d638fbd799924efa2bc6c979a22bb",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/users.sql.go": {
-    "mtime": 1784664178.1185212,
+    "mtime": 1784776716.4717531,
     "ast_hash": "04e56c6a60df24019975998c499b029f",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/accounts.sql": {
-    "mtime": 1783887559.0563467,
+    "mtime": 1784776716.4737487,
     "ast_hash": "c19a70b6deabac81626755660d96cd97",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/auth_tokens.sql": {
-    "mtime": 1783887559.058889,
+    "mtime": 1784776716.4757447,
     "ast_hash": "1de03d1bde5c37b2d819e8a220acdedd",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/categories.sql": {
-    "mtime": 1783887559.0599024,
+    "mtime": 1784776716.4767458,
     "ast_hash": "471aeeadf00bc1eefd38a982a708f6c2",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/summary.sql": {
-    "mtime": 1783887559.0609229,
+    "mtime": 1784776716.4777489,
     "ast_hash": "d5d0817b00911263f72cea337607a775",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/transactions.sql": {
-    "mtime": 1783887559.0634835,
+    "mtime": 1784776716.4787478,
     "ast_hash": "02a072d89078bb63502c772d6c82e8cc",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/users.sql": {
-    "mtime": 1784664178.1205192,
+    "mtime": 1784776716.4787478,
     "ast_hash": "44ea3644e18d081175d20d4cd3fb756a",
     "semantic_hash": ""
   },
   "backend/internal/db/queries_live_test.go": {
-    "mtime": 1784664178.1225293,
+    "mtime": 1784776716.4807465,
     "ast_hash": "7731f5f10e10f56cb1b8274892715813",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0001-transactions-date-timestamp.md": {
-    "mtime": 1783742949.6068866,
+    "mtime": 1784776716.68375,
     "ast_hash": "bdb237aff47235dbcfd6f545799bf218",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0002-finance-ids-and-uuidv7-default.md": {
-    "mtime": 1783742958.4917693,
+    "mtime": 1784776716.6847506,
     "ast_hash": "3821814262de62bc4748b757732d7487",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0003-in-memory-rate-limiting.md": {
-    "mtime": 1783742966.9757066,
+    "mtime": 1784776716.686748,
     "ast_hash": "f8a432d1eac12d3c0305088e6209b047",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0004-bulk-delete-silent-ignore.md": {
-    "mtime": 1783742975.4338036,
+    "mtime": 1784776716.6877482,
     "ast_hash": "2b31a879438178d4fe50712087d2b062",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0005-category-duplicate-update-500.md": {
-    "mtime": 1783742985.0225415,
+    "mtime": 1784776716.688745,
     "ast_hash": "7189807e1baa9d12447a80f759612924",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0006-amount-int32-milliunit-cap.md": {
-    "mtime": 1783887559.0825,
+    "mtime": 1784776716.6897523,
     "ast_hash": "751e99677def5208b91e516742bc981e",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/00-current-state.md": {
-    "mtime": 1783886259.7899237,
+    "mtime": 1784776716.6967468,
     "ast_hash": "24215e20cd45ee75c52d5835d8f4a597",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/01-target-architecture.md": {
-    "mtime": 1783886259.7909331,
+    "mtime": 1784776716.6977496,
     "ast_hash": "c1d09ee4f014e24aad97a18c65d7b795",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/02-security.md": {
-    "mtime": 1783886259.7929242,
+    "mtime": 1784776716.698748,
     "ast_hash": "4a1821f45c74c6bc0d1f76dd1d6aecc4",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/03-performance-and-queries.md": {
-    "mtime": 1783886369.2243311,
+    "mtime": 1784776716.700749,
     "ast_hash": "d9c3e87abb1e1f9635599a02ea971a5d",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/04-robustness-and-transactions.md": {
-    "mtime": 1783886369.22533,
+    "mtime": 1784776716.7017534,
     "ast_hash": "18487368076de09133109d8497b7a14c",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/05-api-documentation.md": {
-    "mtime": 1783886369.2263217,
+    "mtime": 1784776716.702749,
     "ast_hash": "dd065cb03d1572ad43c0642a12102122",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/06-observability-readiness.md": {
-    "mtime": 1783886369.2273376,
+    "mtime": 1784776716.703751,
     "ast_hash": "8cea1acfcda440ba4857f0022d15e36e",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/07-module-improvement-map.md": {
-    "mtime": 1783886441.7495658,
+    "mtime": 1784776716.703751,
     "ast_hash": "9523b6bedd5d7f26c387f7647e06d6f2",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/08-delivery-roadmap.md": {
-    "mtime": 1783886441.7505753,
+    "mtime": 1784776716.7047453,
     "ast_hash": "ef6276032dfba882145ac3c2e4fe7b32",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/README.md": {
-    "mtime": 1783886259.7889216,
+    "mtime": 1784776716.7077432,
     "ast_hash": "dd880b25040ad1b40166d3dbb0275649",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/templates/endpoint-review.md": {
-    "mtime": 1783886441.7525747,
+    "mtime": 1784776716.7097454,
     "ast_hash": "7191eb90724b140e153f0f308d010206",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/templates/improvement-proposal.md": {
-    "mtime": 1783886441.753572,
+    "mtime": 1784776716.71075,
     "ast_hash": "00bd4fa4acf9f6ff0c5291c2520d8e9d",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0008-no-midlife-access-token-revocation.md": {
-    "mtime": 1783998225.9647148,
+    "mtime": 1784776716.6907473,
     "ast_hash": "52fd1695466063418820cb36d926f223",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0009-refresh-reuse-detection-session-listing.md": {
-    "mtime": 1783998235.2082634,
+    "mtime": 1784776716.6917462,
     "ast_hash": "909c538cdeb7a782ec8c80070d852533",
     "semantic_hash": ""
   },
   "backend/internal/auth/jwt.go": {
-    "mtime": 1784296925.91784,
-    "ast_hash": "3f179de38e9410836933c396d6c2d9e8",
+    "mtime": 1784777074.2704048,
+    "ast_hash": "6d9277432d896f349a116430df14f23a",
     "semantic_hash": ""
   },
   "backend/internal/auth/jwt_test.go": {
-    "mtime": 1784296925.91784,
-    "ast_hash": "a661f20cdbaff57c1aed7302816c0a57",
+    "mtime": 1784777085.9962285,
+    "ast_hash": "b0710242431507a04035b72e5bb08911",
     "semantic_hash": ""
   },
   "backend/internal/auth/password.go": {
-    "mtime": 1784296925.91784,
+    "mtime": 1784776716.4507496,
     "ast_hash": "185dd2946e9d45e53af209091acbc69a",
     "semantic_hash": ""
   },
   "backend/internal/auth/password_test.go": {
-    "mtime": 1784296925.9227943,
+    "mtime": 1784776716.4517493,
     "ast_hash": "11f7c3d603351c5e925beb96a345bd99",
     "semantic_hash": ""
   },
   "backend/internal/auth/token.go": {
-    "mtime": 1784296925.9227943,
+    "mtime": 1784776716.4517493,
     "ast_hash": "cc2d1d3c8987927c3ce120c9cc440c27",
     "semantic_hash": ""
   },
   "backend/internal/auth/token_test.go": {
-    "mtime": 1784296925.9248064,
+    "mtime": 1784776716.4527504,
     "ast_hash": "e651536884cee427ba4e8a435d039dcc",
     "semantic_hash": ""
   },
   "backend/internal/http/auth.go": {
-    "mtime": 1784664178.1245248,
-    "ast_hash": "894de8e5fe2a88f3b8ad48b386dcf543",
+    "mtime": 1784777155.3752546,
+    "ast_hash": "18babaa827ddf92710ffa2eba7304f36",
     "semantic_hash": ""
   },
   "backend/internal/http/auth_live_test.go": {
-    "mtime": 1784664178.1265302,
+    "mtime": 1784776716.483748,
     "ast_hash": "d97547dfc3a163e51519bba64f106c43",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260714_131130_got_ticket__41_done_by_claude__please_review_the_p.md": {
-    "mtime": 1784034690.381011,
-    "ast_hash": "a9e36397da37905470e4315d54019dab",
+    "mtime": 1784776716.6487455,
+    "ast_hash": "6ca8770a1f7138a550049a55a5ca822b",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260714_162453_recheck_the_fixes_and_give_another_pass_for_review.md": {
-    "mtime": 1784046293.3942628,
-    "ast_hash": "e2ceb19665e5c766b6ae3c18e156608a",
+    "mtime": 1784776716.6507542,
+    "ast_hash": "edee4902544d478254e36558268a7786",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260715_022121_give_it_a_last_review_of_all_the_files_changend_in.md": {
-    "mtime": 1784082081.5438933,
-    "ast_hash": "6d977fb265dae34a94fda15fc0adf635",
+    "mtime": 1784776716.651752,
+    "ast_hash": "32739c926d5d93bcf8ab5c93ead1839a",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0010-auth-contract-omits-500.md": {
-    "mtime": 1784296925.9444642,
+    "mtime": 1784776716.692751,
     "ast_hash": "0f5ccef73b4e6343bbf4303cff08ea95",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260717_150834_review_pr__64_against_post_merge_pr__62_comment_an.md": {
-    "mtime": 1784300914.0623503,
-    "ast_hash": "b86c85d7b31c9bbc03aadb2678d9f8be",
+    "mtime": 1784776716.652747,
+    "ast_hash": "da65100a0778e79ca39eb827c06f8c16",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0011-no-resend-endpoint-fire-and-forget-mail.md": {
-    "mtime": 1784315785.0611346,
+    "mtime": 1784776716.6937497,
     "ast_hash": "496c201389dbe529abd4e3869d7ded9d",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0012-reset-request-timing-oracle.md": {
-    "mtime": 1784315795.5497026,
+    "mtime": 1784776716.6947556,
     "ast_hash": "a90d642eee349d26e0a64a9afd7ca614",
     "semantic_hash": ""
   },
   "backend/internal/http/email_flows_live_test.go": {
-    "mtime": 1784664178.1275241,
+    "mtime": 1784776716.485748,
     "ast_hash": "632d19fbb6225b0571157d5a431a9b1c",
     "semantic_hash": ""
   },
   "backend/internal/mail/fake.go": {
-    "mtime": 1784664178.1325233,
+    "mtime": 1784776716.4907498,
     "ast_hash": "7c3b36862e7d13c9af86569cd0122932",
     "semantic_hash": ""
   },
   "backend/internal/mail/mail.go": {
-    "mtime": 1784664178.1335218,
+    "mtime": 1784776716.4917476,
     "ast_hash": "25cc3dfb79130623a1915455e626dfe7",
     "semantic_hash": ""
   },
   "backend/internal/mail/mail_test.go": {
-    "mtime": 1784664178.1345239,
+    "mtime": 1784776716.4927487,
     "ast_hash": "2ebd12b7fd8317f2cbee48c255877cd8",
     "semantic_hash": ""
   },
   "backend/internal/mail/smtp.go": {
-    "mtime": 1784664178.1355252,
+    "mtime": 1784776716.493749,
     "ast_hash": "57fa574c964177409d06097d36b6d835",
     "semantic_hash": ""
   },
   "backend/internal/db/livedb_test.go": {
-    "mtime": 1784664178.119526,
+    "mtime": 1784776716.4727507,
     "ast_hash": "1dd93e919c07f404f9dabe67787fe81e",
     "semantic_hash": ""
   },
   "backend/internal/http/livedb_test.go": {
-    "mtime": 1784664178.1295264,
+    "mtime": 1784776716.488749,
     "ast_hash": "ec6da0358ebdfb4ffa84cd26798a1107",
     "semantic_hash": ""
   },
   "docker/postgres/init/01-app-role.sql": {
-    "mtime": 1784664178.1415224,
+    "mtime": 1784776716.5567453,
     "ast_hash": "bf2ab260c5b03d5432d4f4d0670584a1",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260721_182422_review_pr_65_email_verification_and_password_reset.md": {
-    "mtime": 1784658262.6666281,
-    "ast_hash": "a615d7d66ca013b1bf4f200a7ef84502",
+    "mtime": 1784776716.6547444,
+    "ast_hash": "1d0d3ad556b5520396ff0728a21ae495",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260721_192433_recheck_latest_pr_65_changes_and_comments_for_merg.md": {
-    "mtime": 1784661873.344869,
-    "ast_hash": "fe8c2399fff5f53327746ca88dd2c5db",
+    "mtime": 1784776716.6557436,
+    "ast_hash": "6e07e9638589f4dc8304c8ea4ba39666",
+    "semantic_hash": ""
+  },
+  "backend/internal/db/rls.go": {
+    "mtime": 1784777097.3664489,
+    "ast_hash": "664918ce324583512aefef914a851235",
+    "semantic_hash": ""
+  },
+  "backend/internal/db/rls_test.go": {
+    "mtime": 1784777355.5667634,
+    "ast_hash": "b6a6a90b006b1fc9a7d231cb14b3d3e0",
+    "semantic_hash": ""
+  },
+  "backend/internal/http/middleware.go": {
+    "mtime": 1784777148.8688881,
+    "ast_hash": "15e71d733007418b2dedd157ad99f588",
+    "semantic_hash": ""
+  },
+  "backend/internal/http/middleware_live_test.go": {
+    "mtime": 1784777229.9078643,
+    "ast_hash": "fadb0f78c23feb90acd86867afd5648b",
+    "semantic_hash": ""
+  },
+  "backend/internal/http/middleware_test.go": {
+    "mtime": 1784777200.0791092,
+    "ast_hash": "6547f1cd81048be755c64376cd8cafc4",
     "semantic_hash": ""
   }
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -140,8 +140,8 @@
     "semantic_hash": "a974b84f869ed5e86967fc377f86a12a"
   },
   "backend/cmd/api/main.go": {
-    "mtime": 1784776716.4437468,
-    "ast_hash": "b58790eed295c0a01b8a72c61e492ece",
+    "mtime": 1785176539.8831787,
+    "ast_hash": "af0614cf83f7548b851e581cc3b0ee21",
     "semantic_hash": ""
   },
   "backend/internal/config/config.go": {
@@ -1420,8 +1420,8 @@
     "semantic_hash": ""
   },
   "backend/internal/db/livedb_test.go": {
-    "mtime": 1784776716.4727507,
-    "ast_hash": "1dd93e919c07f404f9dabe67787fe81e",
+    "mtime": 1785176549.3732822,
+    "ast_hash": "8c4ad41d29cc74b7077c2556cd08100e",
     "semantic_hash": ""
   },
   "backend/internal/http/livedb_test.go": {
@@ -1445,13 +1445,13 @@
     "semantic_hash": ""
   },
   "backend/internal/db/rls.go": {
-    "mtime": 1784777097.3664489,
-    "ast_hash": "664918ce324583512aefef914a851235",
+    "mtime": 1785176527.8663676,
+    "ast_hash": "d23f4412ed3a5808c61deb9c75bd3ab4",
     "semantic_hash": ""
   },
   "backend/internal/db/rls_test.go": {
-    "mtime": 1784777355.5667634,
-    "ast_hash": "b6a6a90b006b1fc9a7d231cb14b3d3e0",
+    "mtime": 1785176674.5818398,
+    "ast_hash": "5fcce1f05bfcb7c444ed73765f063cd7",
     "semantic_hash": ""
   },
   "backend/internal/http/middleware.go": {
@@ -1467,6 +1467,16 @@
   "backend/internal/http/middleware_test.go": {
     "mtime": 1784777200.0791092,
     "ast_hash": "6547f1cd81048be755c64376cd8cafc4",
+    "semantic_hash": ""
+  },
+  "backend/internal/db/transactions_category_rls_test.go": {
+    "mtime": 1785176648.7030272,
+    "ast_hash": "097e6feb916ddea6d38c68ae24a91b39",
+    "semantic_hash": ""
+  },
+  "backend/migrations/00004_transactions_category_owner_rls.sql": {
+    "mtime": 1785176505.2620988,
+    "ast_hash": "ee62b56867b1d412ec7520666b9a7be4",
     "semantic_hash": ""
   }
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1475,8 +1475,13 @@
     "semantic_hash": ""
   },
   "backend/migrations/00004_transactions_category_owner_rls.sql": {
-    "mtime": 1785176505.2620988,
-    "ast_hash": "ee62b56867b1d412ec7520666b9a7be4",
+    "mtime": 1785178905.617622,
+    "ast_hash": "a74c516d8f1d8cf6e6271aac9f5c704f",
+    "semantic_hash": ""
+  },
+  "backend/internal/db/migration_upgrade_test.go": {
+    "mtime": 1785178861.3308668,
+    "ast_hash": "e25e1bd9742ec43d32853120da665a53",
     "semantic_hash": ""
   }
 }


### PR DESCRIPTION
Closes #43.

## What

Wires authenticated requests to the Go route layer and the PostgreSQL RLS
model. This is the ticket where **RLS stops being theoretical**: the #39
policies have existed since that ticket, but nothing set `app.user_id` at
request time, so no policy had ever engaged on a real request.

## Pieces

**`RequireAuth` middleware** (`internal/http/middleware.go`) — validates a
Bearer HS256 access token via the existing `auth.VerifyAccessToken`, puts the
verified UUID on the request context under an unexported key type, and exposes
it through `UserIDFromContext(ctx) (uuid.UUID, bool)`. The boolean makes "no
user in context" unmistakable, so a handler can't silently act as the
all-zeros user. Identity comes **only** from the `Authorization` header —
never a body field, query param, or `X-User-Id`. Applied once at a
router-level group instead of the legacy per-route `clerkMiddleware()`
repetition (a structural change that keeps observable behavior identical).

**`WithUserTx` helper** (`internal/db/rls.go`) — the single sanctioned path to
owned tables. Begins a transaction, runs `set_config('app.user_id', $1, true)`
(transaction-local, parameterized) as the first statement, runs `fn` against a
tx-bound `*dbgen.Queries`, commits on success, rolls back on error/panic.
Transaction-local is deliberate: `pgxpool` reuses connections, so a
session-level bind would leak one user's identity into the next request on that
connection. `dbgen.New(pool)` against owned tables is now forbidden — with no
transaction, the tx-local bind has nothing to attach to and the policy silently
returns zero rows. #44–#48 route through this helper.

**Expiry carve-out** (`internal/auth/jwt.go`) — `VerifyAccessToken` returns the
new `ErrAccessTokenExpired` sentinel for the expired case only (via
`errors.Is(err, jwt.ErrTokenExpired)`, checked before the generic collapse), so
the middleware can surface the contract's distinct `ACCESS_TOKEN_EXPIRED` code;
the client needs it to know when to hit `/api/auth/refresh`. Every other
failure (bad signature, wrong secret, disallowed alg, missing exp, non-UUID
subject) stays collapsed into the opaque `ErrInvalidAccessToken`.

## 401 shape — contract, not fixture

The legacy Hono handlers return flat `{"error":"Unauthorized"}`. This uses the
structured `ApiErrorResponse` envelope `{"error":{"code","message"}}` instead —
the divergence is **documented on the contract's `UnauthorizedError`
response**, so this is parity with the contract, which is the source of truth.
Only the two contract-documented codes are emitted: `UNAUTHORIZED` and
`ACCESS_TOKEN_EXPIRED`.

## Scope

Resource handlers (accounts/categories/transactions/summary) are #44–#48. The
`RequireAuth` group is mounted but intentionally empty here.

## Tests

Live DB (against Postgres 17), all green:
- Cross-user isolation proven **at the RLS policy itself** — predicate-free
  `SELECT`/`UPDATE`/`DELETE` under another user's binding, all 0 rows, so the
  policy (not a `WHERE` clause) is demonstrably doing the work.
- Fail-closed: an unbound transaction sees 0 rows, not an error and not every
  row.
- Rollback-on-error leaves no row behind.
- Missing / malformed / expired / wrong-secret / `alg:none` / HS512 → 401 with
  the right code; valid token exposes the correct UUID; body identity ignored.

Unit (no DB): the full middleware rejection matrix and the JWT expiry-vs-other
carve-out (expired satisfies `ErrAccessTokenExpired` and not
`ErrInvalidAccessToken`, and vice versa).

## Verification

Local against WSL Postgres 17 (non-superuser `nuchi` role, so the RLS proof is
real, not a superuser bypass):

```
ok  internal/auth    2.141s
ok  internal/config  0.590s
ok  internal/db      2.326s
ok  internal/http    6.630s
ok  internal/mail    1.119s
```

`go vet ./...` clean. `parity-reviewer` reviewed the diff against the contract
and fixtures — no findings; confirmed the test role is non-superuser and all
nine required scenarios are present and green. CI (with its own Postgres
service and the `-race` step from #67) is the authoritative check on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)