### PR TITLE
[Issue - #45] Implement categories API parity

### DIFF
--- a/backend/internal/http/accounts.go
+++ b/backend/internal/http/accounts.go
@@ -2,9 +2,7 @@ package httpapi
 
 import (
 	"errors"
-	"log/slog"
 	"net/http"
-	"unicode/utf8"
 
 	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
 	// Aliased: the bare package name `id` would read as shadowed inside the
@@ -52,7 +50,7 @@ func (s *ResourceServer) ListAccounts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		logAccountsError(r, "list accounts", err)
+		logResourceError(r, "list accounts", err)
 		resp := openapi.ListAccounts500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to fetch accounts")}
 		_ = resp.VisitListAccountsResponse(w)
 		return
@@ -95,7 +93,7 @@ func (s *ResourceServer) GetAccount(w http.ResponseWriter, r *http.Request, id o
 		resp := openapi.GetAccount404JSONResponse{AccountNotFoundErrorJSONResponse: accountNotFoundError()}
 		_ = resp.VisitGetAccountResponse(w)
 	default:
-		logAccountsError(r, "fetch account", err)
+		logResourceError(r, "fetch account", err)
 		resp := openapi.GetAccount500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to fetch account")}
 		_ = resp.VisitGetAccountResponse(w)
 	}
@@ -152,7 +150,7 @@ func (s *ResourceServer) CreateAccount(w http.ResponseWriter, r *http.Request) {
 		resp := openapi.CreateAccount409JSONResponse{DuplicateAccountNameErrorJSONResponse: duplicateAccountNameError(txErr)}
 		_ = resp.VisitCreateAccountResponse(w)
 	default:
-		logAccountsError(r, "create account", txErr)
+		logResourceError(r, "create account", txErr)
 		resp := openapi.CreateAccount500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to create account")}
 		_ = resp.VisitCreateAccountResponse(w)
 	}
@@ -209,7 +207,7 @@ func (s *ResourceServer) UpdateAccount(w http.ResponseWriter, r *http.Request, i
 		resp := openapi.UpdateAccount409JSONResponse{DuplicateAccountNameErrorJSONResponse: duplicateAccountNameError(err)}
 		_ = resp.VisitUpdateAccountResponse(w)
 	default:
-		logAccountsError(r, "update account", err)
+		logResourceError(r, "update account", err)
 		resp := openapi.UpdateAccount500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to update account")}
 		_ = resp.VisitUpdateAccountResponse(w)
 	}
@@ -243,7 +241,7 @@ func (s *ResourceServer) DeleteAccount(w http.ResponseWriter, r *http.Request, i
 		resp := openapi.DeleteAccount404JSONResponse{AccountNotFoundErrorJSONResponse: accountNotFoundError()}
 		_ = resp.VisitDeleteAccountResponse(w)
 	default:
-		logAccountsError(r, "delete account", err)
+		logResourceError(r, "delete account", err)
 		resp := openapi.DeleteAccount500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to delete account")}
 		_ = resp.VisitDeleteAccountResponse(w)
 	}
@@ -279,7 +277,7 @@ func (s *ResourceServer) BulkDeleteAccounts(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err != nil {
-		logAccountsError(r, "delete accounts", err)
+		logResourceError(r, "delete accounts", err)
 		resp := openapi.BulkDeleteAccounts500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to delete accounts")}
 		_ = resp.VisitBulkDeleteAccountsResponse(w)
 		return
@@ -296,14 +294,11 @@ func (s *ResourceServer) BulkDeleteAccounts(w http.ResponseWriter, r *http.Reque
 
 // --- validation -----------------------------------------------------------
 
-// validateAccountName enforces the contract's AccountInput.name: minLength
-// 1, counted in runes (not bytes) to match #41's convention. No trimming —
-// trimming would change stored values relative to legacy.
+// validateAccountName enforces the contract's AccountInput.name. Shares
+// validateResourceName with categories: both schemas declare the same
+// minLength 1 on an identically named field.
 func validateAccountName(name string) []apiFieldError {
-	if utf8.RuneCountInString(name) < 1 {
-		return []apiFieldError{{Path: "name", Message: "Name is required."}}
-	}
-	return nil
+	return validateResourceName(name)
 }
 
 // validateBulkDeleteIds enforces the contract's BulkDeleteRequest.ids:
@@ -390,12 +385,4 @@ func constraintName(err error) string {
 		return pgErr.ConstraintName
 	}
 	return ""
-}
-
-// logAccountsError logs a database failure on an accounts operation.
-// Follows auth.go's convention (see writeInternalError / sendAsync): the
-// raw driver error is logged server-side only, never placed in the
-// response body.
-func logAccountsError(r *http.Request, operation string, err error) {
-	slog.Default().ErrorContext(r.Context(), "accounts operation failed", "operation", operation, "error", err)
 }

--- a/backend/internal/http/categories.go
+++ b/backend/internal/http/categories.go
@@ -1,0 +1,346 @@
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+
+	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
+	idgen "github.com/GonzaloSecades/nuchi/backend/internal/id"
+	"github.com/GonzaloSecades/nuchi/backend/internal/openapi"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// errCategoryNotFound is the sentinel withUser's fn returns when a by-id
+// category query (get/update/delete) matches no row. Every such query
+// carries a WHERE id = $ AND user_id = $ predicate, so a foreign category
+// and a genuinely missing one are indistinguishable to the caller — both
+// roll the transaction back and map to 404, mirroring accounts.
+var errCategoryNotFound = errors.New("httpapi: category not found")
+
+// categoryInputBody is the lenient decode target for CategoryInput
+// ({name}), used by both CreateCategory and UpdateCategory.
+type categoryInputBody struct {
+	Name string `json:"name"`
+}
+
+// ListCategories implements GET /api/categories. Returns the summary shape
+// ({id, name}), the same list/get-vs-create/update asymmetry accounts has.
+func (s *ResourceServer) ListCategories(w http.ResponseWriter, r *http.Request) {
+	var rows []dbgen.Category
+	err, ok := s.withUser(w, r, func(userID uuid.UUID, q *dbgen.Queries) error {
+		var err error
+		rows, err = q.ListCategories(r.Context(), pgUserID(userID))
+		return err
+	})
+	if !ok {
+		return
+	}
+	if err != nil {
+		logResourceError(r, "list categories", err)
+		resp := openapi.ListCategories500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to fetch categories")}
+		_ = resp.VisitListCategoriesResponse(w)
+		return
+	}
+
+	// Nil slice from zero rows would serialize as JSON null; the contract
+	// (and the frontend's .map) requires [].
+	summaries := make([]openapi.CategorySummary, 0, len(rows))
+	for _, row := range rows {
+		summaries = append(summaries, toCategorySummary(row))
+	}
+	resp := openapi.ListCategories200JSONResponse{Data: summaries}
+	_ = resp.VisitListCategoriesResponse(w)
+}
+
+// GetCategory implements GET /api/categories/{id}. Returns the summary
+// shape; 404 for a missing or foreign id.
+func (s *ResourceServer) GetCategory(w http.ResponseWriter, r *http.Request, id openapi.ResourceId) {
+	var category dbgen.Category
+	err, ok := s.withUser(w, r, func(userID uuid.UUID, q *dbgen.Queries) error {
+		row, err := q.GetCategory(r.Context(), dbgen.GetCategoryParams{ID: id, UserID: pgUserID(userID)})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return errCategoryNotFound
+		}
+		if err != nil {
+			return err
+		}
+		category = row
+		return nil
+	})
+	if !ok {
+		return
+	}
+
+	switch {
+	case err == nil:
+		resp := openapi.GetCategory200JSONResponse{Data: toCategorySummary(category)}
+		_ = resp.VisitGetCategoryResponse(w)
+	case errors.Is(err, errCategoryNotFound):
+		resp := openapi.GetCategory404JSONResponse{CategoryNotFoundErrorJSONResponse: categoryNotFoundError()}
+		_ = resp.VisitGetCategoryResponse(w)
+	default:
+		logResourceError(r, "fetch category", err)
+		resp := openapi.GetCategory500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to fetch category")}
+		_ = resp.VisitGetCategoryResponse(w)
+	}
+}
+
+// CreateCategory implements POST /api/categories. Returns the full row
+// (plaidId always null, since legacy never sets it on create); 409 on a
+// duplicate (user_id, name).
+func (s *ResourceServer) CreateCategory(w http.ResponseWriter, r *http.Request) {
+	var body categoryInputBody
+	if !decodeResourceBody(w, r, &body) {
+		resp := openapi.CreateCategory400JSONResponse{ValidationErrorJSONResponse: validationError()}
+		_ = resp.VisitCreateCategoryResponse(w)
+		return
+	}
+
+	if fields := validateCategoryName(body.Name); len(fields) > 0 {
+		resp := openapi.CreateCategory400JSONResponse{ValidationErrorJSONResponse: validationError(fields...)}
+		_ = resp.VisitCreateCategoryResponse(w)
+		return
+	}
+
+	// cuid2-shaped id, matching legacy categories.ts's createId(); UUIDv7
+	// convergence for finance tables is deferred by post-migration
+	// improvement 0002.
+	categoryID := idgen.New()
+
+	var category dbgen.Category
+	txErr, ok := s.withUser(w, r, func(userID uuid.UUID, q *dbgen.Queries) error {
+		row, err := q.CreateCategory(r.Context(), dbgen.CreateCategoryParams{
+			ID:     categoryID,
+			Name:   body.Name,
+			UserID: pgUserID(userID),
+			// PlaidID stays NULL: legacy categories.ts never sets it on
+			// create.
+		})
+		if err != nil {
+			return err
+		}
+		category = row
+		return nil
+	})
+	if !ok {
+		return
+	}
+
+	switch {
+	case txErr == nil:
+		resp := openapi.CreateCategory200JSONResponse{Data: toCategory(category)}
+		_ = resp.VisitCreateCategoryResponse(w)
+	case isUniqueViolation(txErr):
+		resp := openapi.CreateCategory409JSONResponse{DuplicateCategoryNameErrorJSONResponse: duplicateCategoryNameError(txErr)}
+		_ = resp.VisitCreateCategoryResponse(w)
+	default:
+		logResourceError(r, "create category", txErr)
+		resp := openapi.CreateCategory500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to create category")}
+		_ = resp.VisitCreateCategoryResponse(w)
+	}
+}
+
+// UpdateCategory implements PATCH /api/categories/{id}.
+//
+// Duplicate names return 409, NOT the 500 the legacy handler produces. This
+// is the one deliberate behavior divergence in this ticket: legacy
+// categories.ts wraps its UPDATE in a bare catch with no 23505 branch, so
+// renaming a category onto an existing name surfaces as a server error
+// (fixtures line 321). spec.md line 104 requires that mismatch to be decided
+// explicitly in the contract rather than inherited accidentally, and the
+// contract decided 409 — updateCategory declares it, with the same
+// DuplicateCategoryNameError shape as create. Post-migration improvement
+// 0005 tracks the history.
+//
+// Otherwise identical to UpdateAccount: the single UPDATE statement is both
+// the ownership check and the race-free update, so a foreign or missing row
+// yields pgx.ErrNoRows -> 404 with no existence pre-check.
+func (s *ResourceServer) UpdateCategory(w http.ResponseWriter, r *http.Request, id openapi.ResourceId) {
+	var body categoryInputBody
+	if !decodeResourceBody(w, r, &body) {
+		resp := openapi.UpdateCategory400JSONResponse{ValidationErrorJSONResponse: validationError()}
+		_ = resp.VisitUpdateCategoryResponse(w)
+		return
+	}
+
+	if fields := validateCategoryName(body.Name); len(fields) > 0 {
+		resp := openapi.UpdateCategory400JSONResponse{ValidationErrorJSONResponse: validationError(fields...)}
+		_ = resp.VisitUpdateCategoryResponse(w)
+		return
+	}
+
+	var category dbgen.Category
+	err, ok := s.withUser(w, r, func(userID uuid.UUID, q *dbgen.Queries) error {
+		row, err := q.UpdateCategoryName(r.Context(), dbgen.UpdateCategoryNameParams{
+			Name:   body.Name,
+			ID:     id,
+			UserID: pgUserID(userID),
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return errCategoryNotFound
+		}
+		if err != nil {
+			return err
+		}
+		category = row
+		return nil
+	})
+	if !ok {
+		return
+	}
+
+	switch {
+	case err == nil:
+		resp := openapi.UpdateCategory200JSONResponse{Data: toCategory(category)}
+		_ = resp.VisitUpdateCategoryResponse(w)
+	case errors.Is(err, errCategoryNotFound):
+		resp := openapi.UpdateCategory404JSONResponse{CategoryNotFoundErrorJSONResponse: categoryNotFoundError()}
+		_ = resp.VisitUpdateCategoryResponse(w)
+	case isUniqueViolation(err):
+		resp := openapi.UpdateCategory409JSONResponse{DuplicateCategoryNameErrorJSONResponse: duplicateCategoryNameError(err)}
+		_ = resp.VisitUpdateCategoryResponse(w)
+	default:
+		logResourceError(r, "update category", err)
+		resp := openapi.UpdateCategory500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to update category")}
+		_ = resp.VisitUpdateCategoryResponse(w)
+	}
+}
+
+// DeleteCategory implements DELETE /api/categories/{id}. 404 for a missing
+// or foreign id. Deleting a category does NOT delete the transactions that
+// reference it: transactions.category_id is ON DELETE SET NULL (migration
+// 00002), so those transactions survive with a null category. This is the
+// opposite of accounts, where deletion cascades the transactions away.
+func (s *ResourceServer) DeleteCategory(w http.ResponseWriter, r *http.Request, id openapi.ResourceId) {
+	var deletedID string
+	err, ok := s.withUser(w, r, func(userID uuid.UUID, q *dbgen.Queries) error {
+		row, err := q.DeleteCategory(r.Context(), dbgen.DeleteCategoryParams{ID: id, UserID: pgUserID(userID)})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return errCategoryNotFound
+		}
+		if err != nil {
+			return err
+		}
+		deletedID = row
+		return nil
+	})
+	if !ok {
+		return
+	}
+
+	switch {
+	case err == nil:
+		resp := openapi.DeleteCategory200JSONResponse{Data: openapi.DeletedResource{Id: deletedID}}
+		_ = resp.VisitDeleteCategoryResponse(w)
+	case errors.Is(err, errCategoryNotFound):
+		resp := openapi.DeleteCategory404JSONResponse{CategoryNotFoundErrorJSONResponse: categoryNotFoundError()}
+		_ = resp.VisitDeleteCategoryResponse(w)
+	default:
+		logResourceError(r, "delete category", err)
+		resp := openapi.DeleteCategory500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to delete category")}
+		_ = resp.VisitDeleteCategoryResponse(w)
+	}
+}
+
+// BulkDeleteCategories implements POST /api/categories/bulk-delete. Missing
+// or unowned ids are silently ignored by the query; this operation never
+// 404s. Referencing transactions have their category_id set to null, same
+// as the single delete.
+func (s *ResourceServer) BulkDeleteCategories(w http.ResponseWriter, r *http.Request) {
+	var body bulkDeleteBody
+	if !decodeResourceBody(w, r, &body) {
+		resp := openapi.BulkDeleteCategories400JSONResponse{ValidationErrorJSONResponse: validationError()}
+		_ = resp.VisitBulkDeleteCategoriesResponse(w)
+		return
+	}
+
+	if fields := validateBulkDeleteIds(body.Ids); len(fields) > 0 {
+		resp := openapi.BulkDeleteCategories400JSONResponse{ValidationErrorJSONResponse: validationError(fields...)}
+		_ = resp.VisitBulkDeleteCategoriesResponse(w)
+		return
+	}
+
+	var deletedIDs []string
+	err, ok := s.withUser(w, r, func(userID uuid.UUID, q *dbgen.Queries) error {
+		var err error
+		deletedIDs, err = q.BulkDeleteCategories(r.Context(), dbgen.BulkDeleteCategoriesParams{
+			Ids:    body.Ids,
+			UserID: pgUserID(userID),
+		})
+		return err
+	})
+	if !ok {
+		return
+	}
+	if err != nil {
+		logResourceError(r, "delete categories", err)
+		resp := openapi.BulkDeleteCategories500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to delete categories")}
+		_ = resp.VisitBulkDeleteCategoriesResponse(w)
+		return
+	}
+
+	deleted := make([]openapi.DeletedResource, 0, len(deletedIDs))
+	for _, id := range deletedIDs {
+		deleted = append(deleted, openapi.DeletedResource{Id: id})
+	}
+	resp := openapi.BulkDeleteCategories200JSONResponse{Data: deleted}
+	_ = resp.VisitBulkDeleteCategoriesResponse(w)
+}
+
+// --- validation -----------------------------------------------------------
+
+// validateCategoryName enforces the contract's CategoryInput.name:
+// minLength 1, counted in runes rather than bytes. No trimming — trimming
+// would change stored values relative to legacy.
+func validateCategoryName(name string) []apiFieldError {
+	return validateResourceName(name)
+}
+
+// --- projections ----------------------------------------------------------
+
+// toCategorySummary projects a row into the contract's CategorySummary
+// shape ({id, name}) used by list/get.
+func toCategorySummary(c dbgen.Category) openapi.CategorySummary {
+	return openapi.CategorySummary{Id: c.ID, Name: c.Name}
+}
+
+// toCategory projects a row into the contract's full Category shape used by
+// create/update. plaidId is always serialized, never omitted (nil renders
+// as JSON null, satisfying the schema's required plaidId).
+func toCategory(c dbgen.Category) openapi.Category {
+	var plaidID *string
+	if c.PlaidID.Valid {
+		plaidID = &c.PlaidID.String
+	}
+	return openapi.Category{
+		Id:      c.ID,
+		Name:    c.Name,
+		PlaidId: plaidID,
+		UserId:  uuid.UUID(c.UserID.Bytes).String(),
+	}
+}
+
+// --- errors ---------------------------------------------------------------
+
+// categoryNotFoundError mirrors the CategoryNotFoundError response example.
+func categoryNotFoundError() openapi.CategoryNotFoundErrorJSONResponse {
+	return openapi.CategoryNotFoundErrorJSONResponse{
+		Error: openapi.ApiError{Code: "CATEGORY_NOT_FOUND", Message: "Category not found."},
+	}
+}
+
+// duplicateCategoryNameError mirrors the DuplicateCategoryNameError
+// response example, carrying the violated constraint under
+// details.constraint (the contract's ApiError is additionalProperties:
+// false, so unlike the legacy flat shape the constraint goes in details).
+func duplicateCategoryNameError(err error) openapi.DuplicateCategoryNameErrorJSONResponse {
+	details := map[string]any{"constraint": constraintName(err)}
+	return openapi.DuplicateCategoryNameErrorJSONResponse{
+		Error: openapi.ApiError{
+			Code:    "DUPLICATE_CATEGORY_NAME",
+			Message: "You already have a category with this name.",
+			Details: &details,
+		},
+	}
+}

--- a/backend/internal/http/categories_live_test.go
+++ b/backend/internal/http/categories_live_test.go
@@ -1,0 +1,538 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GonzaloSecades/nuchi/backend/internal/auth"
+	"github.com/GonzaloSecades/nuchi/backend/internal/db"
+	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
+	"github.com/GonzaloSecades/nuchi/backend/internal/openapi"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Categories reuse accountsTestEnv: it already wires a live pool, the real
+// AuthServer + ResourceServer, and the same TEST_DATABASE_URL skip
+// convention. Only the routes exercised differ.
+
+func assertCategoryNotFound(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	body := decodeAccountsAPIError(t, rec)
+	if body.Error.Code != "CATEGORY_NOT_FOUND" {
+		t.Errorf("expected code CATEGORY_NOT_FOUND, got %q", body.Error.Code)
+	}
+}
+
+func assertDuplicateCategoryName(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	body := decodeAccountsAPIError(t, rec)
+	if body.Error.Code != "DUPLICATE_CATEGORY_NAME" {
+		t.Errorf("expected code DUPLICATE_CATEGORY_NAME, got %q", body.Error.Code)
+	}
+	if body.Error.Details == nil {
+		t.Fatalf("expected details.constraint, got no details (body: %s)", rec.Body.String())
+	}
+	constraint, ok := (*body.Error.Details)["constraint"]
+	if !ok || constraint != "categories_user_id_name_uniq" {
+		t.Errorf("expected details.constraint %q, got %v", "categories_user_id_name_uniq", constraint)
+	}
+}
+
+func createTestCategory(t *testing.T, env accountsTestEnv, token, name string) string {
+	t.Helper()
+	rec := env.do(t, http.MethodPost, "/api/categories", token, categoryInputBody{Name: name})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create category %q: expected 200, got %d (body: %s)", name, rec.Code, rec.Body.String())
+	}
+	var created openapi.CategoryResponse
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create category: %v", err)
+	}
+	return created.Data.Id
+}
+
+// --- happy path -----------------------------------------------------------
+
+func TestCategoriesLive_HappyPath_AllOperations(t *testing.T) {
+	env := newAccountsTestEnv(t)
+	userID, token := env.createAccountsTestUser(t, "cat-happy")
+
+	// Create (full row shape).
+	createRec := env.do(t, http.MethodPost, "/api/categories", token, categoryInputBody{Name: "Groceries"})
+	if createRec.Code != http.StatusOK {
+		t.Fatalf("create: expected 200, got %d (body: %s)", createRec.Code, createRec.Body.String())
+	}
+	createRawBody := createRec.Body.String()
+	var created openapi.CategoryResponse
+	if err := json.NewDecoder(strings.NewReader(createRawBody)).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Data.Name != "Groceries" {
+		t.Errorf("create: expected name %q, got %q", "Groceries", created.Data.Name)
+	}
+	if created.Data.PlaidId != nil {
+		t.Errorf("create: expected plaidId nil, got %v", *created.Data.PlaidId)
+	}
+	if created.Data.UserId != userID.String() {
+		t.Errorf("create: expected userId %q, got %q", userID.String(), created.Data.UserId)
+	}
+	// Ids keep the legacy cuid2 format (post-migration improvement 0002
+	// defers UUIDv7 convergence); a UUID here fails this pattern.
+	if !legacyResourceIDPattern.MatchString(created.Data.Id) {
+		t.Errorf("create: expected a cuid2-format id matching %s, got %q", legacyResourceIDPattern, created.Data.Id)
+	}
+	if !strings.Contains(createRawBody, `"plaidId":null`) {
+		t.Errorf("create: expected raw body to contain \"plaidId\":null, got %s", createRawBody)
+	}
+	categoryID := created.Data.Id
+
+	// List (summary shape).
+	listRec := env.do(t, http.MethodGet, "/api/categories", token, nil)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d (body: %s)", listRec.Code, listRec.Body.String())
+	}
+	if strings.Contains(listRec.Body.String(), "userId") || strings.Contains(listRec.Body.String(), "plaidId") {
+		t.Errorf("list: expected summary shape ({id,name} only), got %s", listRec.Body.String())
+	}
+	var listed openapi.CategoryListResponse
+	if err := json.NewDecoder(listRec.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed.Data) != 1 || listed.Data[0].Id != categoryID || listed.Data[0].Name != "Groceries" {
+		t.Errorf("list: expected [{%q,Groceries}], got %+v", categoryID, listed.Data)
+	}
+
+	// Get (summary shape).
+	getRec := env.do(t, http.MethodGet, "/api/categories/"+categoryID, token, nil)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d (body: %s)", getRec.Code, getRec.Body.String())
+	}
+	if strings.Contains(getRec.Body.String(), "userId") || strings.Contains(getRec.Body.String(), "plaidId") {
+		t.Errorf("get: expected summary shape, got %s", getRec.Body.String())
+	}
+	var got openapi.CategorySummaryResponse
+	if err := json.NewDecoder(getRec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if got.Data.Id != categoryID || got.Data.Name != "Groceries" {
+		t.Errorf("get: expected {%q,Groceries}, got %+v", categoryID, got.Data)
+	}
+
+	// Update (full row shape).
+	updateRec := env.do(t, http.MethodPatch, "/api/categories/"+categoryID, token, categoryInputBody{Name: "Food"})
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d (body: %s)", updateRec.Code, updateRec.Body.String())
+	}
+	var updated openapi.CategoryResponse
+	if err := json.NewDecoder(updateRec.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode update response: %v", err)
+	}
+	if updated.Data.Id != categoryID || updated.Data.Name != "Food" || updated.Data.UserId != userID.String() {
+		t.Errorf("update: expected {%q,Food,%q}, got %+v", categoryID, userID.String(), updated.Data)
+	}
+	if updated.Data.PlaidId != nil {
+		t.Errorf("update: expected plaidId nil, got %v", *updated.Data.PlaidId)
+	}
+
+	// Delete.
+	deleteRec := env.do(t, http.MethodDelete, "/api/categories/"+categoryID, token, nil)
+	if deleteRec.Code != http.StatusOK {
+		t.Fatalf("delete: expected 200, got %d (body: %s)", deleteRec.Code, deleteRec.Body.String())
+	}
+	var deleted openapi.DeletedResourceResponse
+	if err := json.NewDecoder(deleteRec.Body).Decode(&deleted); err != nil {
+		t.Fatalf("decode delete response: %v", err)
+	}
+	if deleted.Data.Id != categoryID {
+		t.Errorf("delete: expected id %q, got %q", categoryID, deleted.Data.Id)
+	}
+
+	// Bulk-delete (on a freshly created category).
+	bulkID := createTestCategory(t, env, token, "Transport")
+	bulkRec := env.do(t, http.MethodPost, "/api/categories/bulk-delete", token, bulkDeleteBody{Ids: []string{bulkID}})
+	if bulkRec.Code != http.StatusOK {
+		t.Fatalf("bulk-delete: expected 200, got %d (body: %s)", bulkRec.Code, bulkRec.Body.String())
+	}
+	var bulked openapi.DeletedResourceListResponse
+	if err := json.NewDecoder(bulkRec.Body).Decode(&bulked); err != nil {
+		t.Fatalf("decode bulk-delete response: %v", err)
+	}
+	if len(bulked.Data) != 1 || bulked.Data[0].Id != bulkID {
+		t.Errorf("bulk-delete: expected [{%q}], got %+v", bulkID, bulked.Data)
+	}
+}
+
+func TestCategoriesLive_ListEmpty_ReturnsEmptyArrayNotNull(t *testing.T) {
+	env := newAccountsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "cat-empty")
+
+	rec := env.do(t, http.MethodGet, "/api/categories", token, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	// Asserted on the raw body: a decoded []T hides the null-vs-[] difference
+	// that breaks the frontend's .map.
+	if body := strings.TrimSpace(rec.Body.String()); body != `{"data":[]}` {
+		t.Errorf("expected {\"data\":[]}, got %s", body)
+	}
+}
+
+// --- duplicates -----------------------------------------------------------
+
+func TestCategoriesLive_DuplicateName_OnCreate(t *testing.T) {
+	env := newAccountsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "cat-dup-create")
+
+	createTestCategory(t, env, token, "Groceries")
+
+	t.Run("exact duplicate", func(t *testing.T) {
+		rec := env.do(t, http.MethodPost, "/api/categories", token, categoryInputBody{Name: "Groceries"})
+		assertDuplicateCategoryName(t, rec)
+	})
+
+	// name is citext, so duplicate detection is case-insensitive per user
+	// without any Go-side normalization.
+	t.Run("case-differing duplicate", func(t *testing.T) {
+		rec := env.do(t, http.MethodPost, "/api/categories", token, categoryInputBody{Name: "groceries"})
+		assertDuplicateCategoryName(t, rec)
+	})
+}
+
+// TestCategoriesLive_DuplicateName_OnUpdate covers the one deliberate
+// divergence from legacy in this ticket. Legacy categories.ts wraps its
+// UPDATE in a bare catch with no 23505 branch, so renaming a category onto
+// an existing name returns 500 (fixtures line 321). spec.md line 104
+// requires that mismatch to be decided in the contract instead of inherited,
+// and the contract declares 409 on updateCategory. A regression to 500 fails
+// here.
+func TestCategoriesLive_DuplicateName_OnUpdate(t *testing.T) {
+	env := newAccountsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "cat-dup-update")
+
+	createTestCategory(t, env, token, "Groceries")
+	otherID := createTestCategory(t, env, token, "Transport")
+
+	t.Run("exact duplicate", func(t *testing.T) {
+		rec := env.do(t, http.MethodPatch, "/api/categories/"+otherID, token, categoryInputBody{Name: "Groceries"})
+		assertDuplicateCategoryName(t, rec)
+	})
+
+	t.Run("case-differing duplicate", func(t *testing.T) {
+		rec := env.do(t, http.MethodPatch, "/api/categories/"+otherID, token, categoryInputBody{Name: "GROCERIES"})
+		assertDuplicateCategoryName(t, rec)
+	})
+}
+
+// --- not found ------------------------------------------------------------
+
+func TestCategoriesLive_NotFound_Nonexistent(t *testing.T) {
+	env := newAccountsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "cat-404")
+
+	missingID := "does-not-exist-" + uuid.NewString()
+
+	t.Run("GET", func(t *testing.T) {
+		assertCategoryNotFound(t, env.do(t, http.MethodGet, "/api/categories/"+missingID, token, nil))
+	})
+	t.Run("PATCH", func(t *testing.T) {
+		assertCategoryNotFound(t, env.do(t, http.MethodPatch, "/api/categories/"+missingID, token, categoryInputBody{Name: "Nope"}))
+	})
+	t.Run("DELETE", func(t *testing.T) {
+		assertCategoryNotFound(t, env.do(t, http.MethodDelete, "/api/categories/"+missingID, token, nil))
+	})
+}
+
+// --- cross-user isolation -------------------------------------------------
+
+func TestCategoriesLive_CrossUserIsolation(t *testing.T) {
+	env := newAccountsTestEnv(t)
+	_, tokenA := env.createAccountsTestUser(t, "cat-isolation-a")
+	_, tokenB := env.createAccountsTestUser(t, "cat-isolation-b")
+
+	catA := createTestCategory(t, env, tokenA, "A's Groceries")
+	catB := createTestCategory(t, env, tokenB, "B's Groceries")
+
+	// A cannot GET/PATCH/DELETE B's category.
+	assertCategoryNotFound(t, env.do(t, http.MethodGet, "/api/categories/"+catB, tokenA, nil))
+	assertCategoryNotFound(t, env.do(t, http.MethodPatch, "/api/categories/"+catB, tokenA, categoryInputBody{Name: "Hijacked"}))
+	assertCategoryNotFound(t, env.do(t, http.MethodDelete, "/api/categories/"+catB, tokenA, nil))
+
+	// B's row survives A's failed attempts, unmodified.
+	bCheckRec := env.do(t, http.MethodGet, "/api/categories/"+catB, tokenB, nil)
+	if bCheckRec.Code != http.StatusOK {
+		t.Fatalf("B re-fetch after A's failed attempts: expected 200, got %d (body: %s)", bCheckRec.Code, bCheckRec.Body.String())
+	}
+	var bCheck openapi.CategorySummaryResponse
+	if err := json.NewDecoder(bCheckRec.Body).Decode(&bCheck); err != nil {
+		t.Fatalf("decode B re-fetch: %v", err)
+	}
+	if bCheck.Data.Name != "B's Groceries" {
+		t.Errorf("B's category name changed by A's failed patch: expected %q, got %q", "B's Groceries", bCheck.Data.Name)
+	}
+
+	// A's list never contains B's category.
+	listRec := env.do(t, http.MethodGet, "/api/categories", tokenA, nil)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("A list: expected 200, got %d", listRec.Code)
+	}
+	var listed openapi.CategoryListResponse
+	if err := json.NewDecoder(listRec.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode A list: %v", err)
+	}
+	for _, item := range listed.Data {
+		if item.Id == catB {
+			t.Fatalf("A's list contains B's category id %q", catB)
+		}
+	}
+
+	// Bulk-delete mixing A's id, B's id and garbage deletes only A's.
+	garbageID := "garbage-" + uuid.NewString()
+	bulkRec := env.do(t, http.MethodPost, "/api/categories/bulk-delete", tokenA,
+		bulkDeleteBody{Ids: []string{catA, catB, garbageID}})
+	if bulkRec.Code != http.StatusOK {
+		t.Fatalf("bulk-delete: expected 200, got %d (body: %s)", bulkRec.Code, bulkRec.Body.String())
+	}
+	var bulked openapi.DeletedResourceListResponse
+	if err := json.NewDecoder(bulkRec.Body).Decode(&bulked); err != nil {
+		t.Fatalf("decode bulk-delete: %v", err)
+	}
+	if len(bulked.Data) != 1 || bulked.Data[0].Id != catA {
+		t.Errorf("bulk-delete: expected only A's id [{%q}], got %+v", catA, bulked.Data)
+	}
+
+	// B's category still exists after A's bulk-delete named it.
+	if rec := env.do(t, http.MethodGet, "/api/categories/"+catB, tokenB, nil); rec.Code != http.StatusOK {
+		t.Errorf("B's category was deleted by A's bulk-delete: expected 200, got %d", rec.Code)
+	}
+}
+
+// --- unauthorized ---------------------------------------------------------
+
+func TestCategoriesLive_Unauthorized(t *testing.T) {
+	env := newAccountsTestEnv(t)
+	_, validToken := env.createAccountsTestUser(t, "cat-unauth-seed")
+
+	// A real category id, so the by-id routes' 401-before-404 ordering is
+	// exercised against something that would otherwise be visible.
+	categoryID := createTestCategory(t, env, validToken, "Seed")
+
+	wrongSecretToken, _, err := auth.IssueAccessToken([]byte("a-totally-different-secret-32-bytes!!"), uuid.New(), 30*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken wrong secret: %v", err)
+	}
+	expiredToken, _, err := auth.IssueAccessToken(env.secret, uuid.New(), -1*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken expired: %v", err)
+	}
+
+	routes := []struct {
+		method string
+		path   string
+		body   any
+	}{
+		{http.MethodGet, "/api/categories", nil},
+		{http.MethodPost, "/api/categories", categoryInputBody{Name: "X"}},
+		{http.MethodGet, "/api/categories/" + categoryID, nil},
+		{http.MethodPatch, "/api/categories/" + categoryID, categoryInputBody{Name: "X"}},
+		{http.MethodDelete, "/api/categories/" + categoryID, nil},
+		{http.MethodPost, "/api/categories/bulk-delete", bulkDeleteBody{Ids: []string{categoryID}}},
+	}
+
+	tokenCases := []struct {
+		name     string
+		token    string
+		wantCode string
+	}{
+		{"no-header", "", "UNAUTHORIZED"},
+		{"malformed-header", "not-a-jwt", "UNAUTHORIZED"},
+		{"bad-signature", wrongSecretToken, "UNAUTHORIZED"},
+		{"expired", expiredToken, "ACCESS_TOKEN_EXPIRED"},
+	}
+
+	for _, rt := range routes {
+		for _, tc := range tokenCases {
+			t.Run(fmt.Sprintf("%s %s/%s", rt.method, rt.path, tc.name), func(t *testing.T) {
+				rec := env.do(t, rt.method, rt.path, tc.token, rt.body)
+				if rec.Code != http.StatusUnauthorized {
+					t.Fatalf("expected 401, got %d (body: %s)", rec.Code, rec.Body.String())
+				}
+				apiErr := decodeAccountsAPIError(t, rec)
+				if apiErr.Error.Code != tc.wantCode {
+					t.Errorf("expected code %q, got %q", tc.wantCode, apiErr.Error.Code)
+				}
+			})
+		}
+	}
+}
+
+// --- validation -----------------------------------------------------------
+
+func TestCategoriesLive_Validation(t *testing.T) {
+	env := newAccountsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "cat-validation")
+
+	t.Run("create: unknown field", func(t *testing.T) {
+		rec := env.do(t, http.MethodPost, "/api/categories", token, map[string]string{"name": "X", "extra": "nope"})
+		assertValidationError(t, rec)
+	})
+	t.Run("create: empty name", func(t *testing.T) {
+		rec := env.do(t, http.MethodPost, "/api/categories", token, categoryInputBody{Name: ""})
+		assertValidationError(t, rec)
+	})
+	t.Run("create: missing name", func(t *testing.T) {
+		rec := env.do(t, http.MethodPost, "/api/categories", token, map[string]string{})
+		assertValidationError(t, rec)
+	})
+	t.Run("update: unknown field", func(t *testing.T) {
+		catID := createTestCategory(t, env, token, "update-unknown")
+		rec := env.do(t, http.MethodPatch, "/api/categories/"+catID, token, map[string]string{"name": "New", "extra": "nope"})
+		assertValidationError(t, rec)
+	})
+	t.Run("update: empty name", func(t *testing.T) {
+		catID := createTestCategory(t, env, token, "update-empty")
+		rec := env.do(t, http.MethodPatch, "/api/categories/"+catID, token, categoryInputBody{Name: ""})
+		assertValidationError(t, rec)
+	})
+	t.Run("bulk-delete: missing ids", func(t *testing.T) {
+		rec := env.do(t, http.MethodPost, "/api/categories/bulk-delete", token, map[string]string{})
+		assertValidationError(t, rec)
+	})
+	t.Run("bulk-delete: empty ids array", func(t *testing.T) {
+		rec := env.do(t, http.MethodPost, "/api/categories/bulk-delete", token, bulkDeleteBody{Ids: []string{}})
+		assertValidationError(t, rec)
+	})
+	t.Run("bulk-delete: empty string id", func(t *testing.T) {
+		rec := env.do(t, http.MethodPost, "/api/categories/bulk-delete", token, bulkDeleteBody{Ids: []string{"ok", ""}})
+		assertValidationError(t, rec)
+	})
+	// No byte cap on resource bodies (post-migration improvement 0013): a
+	// large contract-valid body must be accepted, matching Hono.
+	t.Run("create: large body is accepted, not capped", func(t *testing.T) {
+		largeName := strings.Repeat("y", 128*1024)
+		rec := env.do(t, http.MethodPost, "/api/categories", token, categoryInputBody{Name: largeName})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200 for a large contract-valid name, got %d (body: %s)", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// --- FK behavior ----------------------------------------------------------
+
+// TestCategoriesLive_DeleteSetsTransactionCategoryNull covers the acceptance
+// criterion "Category deletion clears category_id on transactions", on BOTH
+// delete paths.
+//
+// This is the inverse of accounts, where deleting cascades the transaction
+// away entirely (transactions.account_id is ON DELETE CASCADE, category_id
+// is ON DELETE SET NULL — migration 00002). A test that only asserted "the
+// transaction is gone" would pass for the wrong reason here, so it asserts
+// the transaction SURVIVES with a null category.
+func TestCategoriesLive_DeleteSetsTransactionCategoryNull(t *testing.T) {
+	env := newAccountsTestEnv(t)
+	userID, token := env.createAccountsTestUser(t, "cat-fk")
+
+	t.Run("single delete", func(t *testing.T) {
+		categoryID := createTestCategory(t, env, token, "FK Single")
+		accountID := createTestAccount(t, env, token, "FK Single Account")
+		transactionID := seedTransaction(t, env.pool, userID, accountID, categoryID)
+
+		rec := env.do(t, http.MethodDelete, "/api/categories/"+categoryID, token, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("delete category: expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+		}
+
+		assertTransactionSurvivesWithNullCategory(t, env.pool, userID, transactionID)
+	})
+
+	t.Run("bulk delete", func(t *testing.T) {
+		categoryID := createTestCategory(t, env, token, "FK Bulk")
+		accountID := createTestAccount(t, env, token, "FK Bulk Account")
+		transactionID := seedTransaction(t, env.pool, userID, accountID, categoryID)
+
+		rec := env.do(t, http.MethodPost, "/api/categories/bulk-delete", token, bulkDeleteBody{Ids: []string{categoryID}})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("bulk-delete category: expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+		}
+
+		assertTransactionSurvivesWithNullCategory(t, env.pool, userID, transactionID)
+	})
+}
+
+// seedTransaction inserts a transaction referencing accountID and
+// categoryID, bypassing the (not yet migrated) transactions API.
+//
+// It must go through db.WithUserTx: transactions_owner's WITH CHECK
+// requires a bound app.user_id, so a bare pool insert is rejected with
+// SQLSTATE 42501 rather than silently succeeding.
+func seedTransaction(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, accountID, categoryID string) string {
+	t.Helper()
+
+	ctx := context.Background()
+	transactionID := "txn-" + uuid.NewString()
+	err := db.WithUserTx(ctx, pool, userID, func(q *dbgen.Queries) error {
+		_, err := q.CreateTransaction(ctx, dbgen.CreateTransactionParams{
+			ID:         transactionID,
+			Amount:     1000,
+			Payee:      "FK payee",
+			Date:       pgtype.Timestamp{Time: time.Now(), Valid: true},
+			AccountID:  accountID,
+			CategoryID: pgtype.Text{String: categoryID, Valid: true},
+			Currency:   "ARS",
+		})
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seed transaction: %v", err)
+	}
+	return transactionID
+}
+
+// assertTransactionSurvivesWithNullCategory verifies ON DELETE SET NULL:
+// the transaction row still exists and its category_id is NULL. Read
+// through db.WithUserTx so the RLS policies apply exactly as they do in the
+// request path (a bare pool read would see zero rows regardless).
+func assertTransactionSurvivesWithNullCategory(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID, transactionID string) {
+	t.Helper()
+
+	ctx := context.Background()
+	var transaction dbgen.Transaction
+	var found bool
+	err := db.WithUserTx(ctx, pool, userID, func(q *dbgen.Queries) error {
+		row, err := q.GetTransaction(ctx, dbgen.GetTransactionParams{ID: transactionID, UserID: pgUserID(userID)})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		transaction = row
+		found = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("read transaction after category delete: %v", err)
+	}
+
+	if !found {
+		t.Fatalf("transaction %q was deleted; category_id is ON DELETE SET NULL, so the transaction must survive", transactionID)
+	}
+	if transaction.CategoryID.Valid {
+		t.Errorf("expected category_id NULL after category delete, got %q", transaction.CategoryID.String)
+	}
+}

--- a/backend/internal/http/resources.go
+++ b/backend/internal/http/resources.go
@@ -1,7 +1,9 @@
 package httpapi
 
 import (
+	"log/slog"
 	"net/http"
+	"unicode/utf8"
 
 	"github.com/GonzaloSecades/nuchi/backend/internal/db"
 	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
@@ -48,21 +50,28 @@ func NewResourceServer(pool *pgxpool.Pool) *ResourceServer {
 	return &ResourceServer{pool: pool}
 }
 
-// accountsServerMethods documents that ResourceServer's account methods
+// resourceServerMethods documents that ResourceServer's handler methods
 // have the exact signatures openapi.ServerInterface declares for the same
 // operation names. It is not used for dispatch (chi routing stays
-// hand-wired, same as auth), only as a compile-time signature check so
-// #45-#48 adding categories/transactions/summary methods stay additive.
-type accountsServerMethods interface {
+// hand-wired, same as auth), only as a compile-time signature check, and it
+// grows as #46-#48 add transactions and summary.
+type resourceServerMethods interface {
 	ListAccounts(w http.ResponseWriter, r *http.Request)
 	CreateAccount(w http.ResponseWriter, r *http.Request)
 	BulkDeleteAccounts(w http.ResponseWriter, r *http.Request)
 	GetAccount(w http.ResponseWriter, r *http.Request, id openapi.ResourceId)
 	UpdateAccount(w http.ResponseWriter, r *http.Request, id openapi.ResourceId)
 	DeleteAccount(w http.ResponseWriter, r *http.Request, id openapi.ResourceId)
+
+	ListCategories(w http.ResponseWriter, r *http.Request)
+	CreateCategory(w http.ResponseWriter, r *http.Request)
+	BulkDeleteCategories(w http.ResponseWriter, r *http.Request)
+	GetCategory(w http.ResponseWriter, r *http.Request, id openapi.ResourceId)
+	UpdateCategory(w http.ResponseWriter, r *http.Request, id openapi.ResourceId)
+	DeleteCategory(w http.ResponseWriter, r *http.Request, id openapi.ResourceId)
 }
 
-var _ accountsServerMethods = (*ResourceServer)(nil)
+var _ resourceServerMethods = (*ResourceServer)(nil)
 
 // withResourceID adapts a handler with the generated (w, r, id) signature
 // into a plain chi handler that reads the {id} URL parameter. Shared by
@@ -103,6 +112,26 @@ func (s *ResourceServer) withUser(w http.ResponseWriter, r *http.Request, fn fun
 // sqlc-generated query params expect.
 func pgUserID(userID uuid.UUID) pgtype.UUID {
 	return pgtype.UUID{Bytes: [16]byte(userID), Valid: true}
+}
+
+// validateResourceName enforces the minLength 1 that every owned-resource
+// name field declares (AccountInput.name, CategoryInput.name). Counted in
+// runes rather than bytes, matching #41's convention, so a multi-byte
+// single-character name is not rejected. No trimming — trimming would
+// change stored values relative to legacy.
+func validateResourceName(name string) []apiFieldError {
+	if utf8.RuneCountInString(name) < 1 {
+		return []apiFieldError{{Path: "name", Message: "Name is required."}}
+	}
+	return nil
+}
+
+// logResourceError logs a database failure on an owned-resource operation.
+// Follows auth.go's convention (see writeInternalError / sendAsync): the
+// raw driver error is logged server-side only, never placed in the
+// response body.
+func logResourceError(r *http.Request, operation string, err error) {
+	slog.Default().ErrorContext(r.Context(), "resource operation failed", "operation", operation, "error", err)
 }
 
 // dbError builds the contract's DatabaseErrorJSONResponse embedding message,

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -49,6 +49,15 @@ func NewRouter(authServer *AuthServer, resources *ResourceServer) http.Handler {
 					r.Patch("/{id}", withResourceID(resources.UpdateAccount))
 					r.Delete("/{id}", withResourceID(resources.DeleteAccount))
 				})
+
+				r.Route("/api/categories", func(r chi.Router) {
+					r.Get("/", resources.ListCategories)
+					r.Post("/", resources.CreateCategory)
+					r.Post("/bulk-delete", resources.BulkDeleteCategories)
+					r.Get("/{id}", withResourceID(resources.GetCategory))
+					r.Patch("/{id}", withResourceID(resources.UpdateCategory))
+					r.Delete("/{id}", withResourceID(resources.DeleteCategory))
+				})
 			}
 		})
 	}

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -377,6 +377,7 @@
   "375": "compositePrimaryKeys",
   "376": ".GetCategory",
   "377": "BulkCreateTransactionsRequestObject",
+  "378": "api-base-url.ts",
   "379": "name",
   "380": "account_id",
   "381": "amount",

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - nuchi  (2026-07-29)
 
 ## Corpus Check
-- 282 files · ~134,424 words
+- 284 files · ~138,257 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2695 nodes · 4582 edges · 541 communities (141 shown, 400 thin omitted)
-- Extraction: 95% EXTRACTED · 5% INFERRED · 0% AMBIGUOUS · INFERRED: 234 edges (avg confidence: 0.8)
+- 2733 nodes · 4724 edges · 542 communities (141 shown, 401 thin omitted)
+- Extraction: 94% EXTRACTED · 6% INFERRED · 0% AMBIGUOUS · INFERRED: 288 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `dbb52bcc`
+- Built from commit: `552a6b33`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -379,6 +379,7 @@
 - [[_COMMUNITY_compositePrimaryKeys|compositePrimaryKeys]]
 - [[_COMMUNITY_.GetCategory|.GetCategory]]
 - [[_COMMUNITY_BulkCreateTransactionsRequestObject|BulkCreateTransactionsRequestObject]]
+- [[_COMMUNITY_api-base-url.ts|api-base-url.ts]]
 - [[_COMMUNITY_name|name]]
 - [[_COMMUNITY_account_id|account_id]]
 - [[_COMMUNITY_amount|amount]]
@@ -545,27 +546,27 @@
 4. `ServerInterfaceWrapper` - 33 edges
 5. `strictHandler` - 32 edges
 6. `Unimplemented` - 29 edges
-7. `Button()` - 26 edges
-8. `Load()` - 24 edges
-9. `client` - 24 edges
-10. `NewPool()` - 23 edges
+7. `newAccountsTestEnv()` - 27 edges
+8. `Button()` - 26 edges
+9. `Load()` - 24 edges
+10. `client` - 24 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `Generated Go Output` --semantically_similar_to--> `generated.gen.go`  [INFERRED] [semantically similar]
   openapi/oapi-codegen.yaml → backend/internal/openapi/README.md
+- `DialogOverlay()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/dialog.tsx → lib/utils.ts
 - `PopoverHeader()` --calls--> `cn()`  [EXTRACTED]
   components/ui/popover.tsx → lib/utils.ts
 - `PopoverTitle()` --calls--> `cn()`  [EXTRACTED]
   components/ui/popover.tsx → lib/utils.ts
 - `PopoverDescription()` --calls--> `cn()`  [EXTRACTED]
   components/ui/popover.tsx → lib/utils.ts
-- `Actions()` --calls--> `useDeleteAccount()`  [EXTRACTED]
-  app/(dashboard)/accounts/actions.tsx → features/accounts/api/use-delete-account.ts
 
 ## Import Cycles
 - None detected.
 
-## Communities (541 total, 400 thin omitted)
+## Communities (542 total, 401 thin omitted)
 
 ### Community 0 - "Transaction Form Tsx"
 Cohesion: 0.12
@@ -593,7 +594,7 @@ Nodes (31): 1. Frontend - Data/State (Next.js, React hooks, mutation hooks), 2. 
 
 ### Community 9 - "0004 Snapshot Json"
 Cohesion: 0.08
-Nodes (32): AreaVariant(), Props, BarVariant(), Props, CategoryTooltip(), CategoryTooltipPayload, CategoryTooltipProps, CustomTooltip() (+24 more)
+Nodes (27): AreaVariant(), Props, BarVariant(), Props, CategoryTooltip(), CategoryTooltipPayload, CategoryTooltipProps, CustomTooltip() (+19 more)
 
 ### Community 10 - "Data Card Tsx"
 Cohesion: 0.33
@@ -604,12 +605,12 @@ Cohesion: 0.33
 Nodes (5): 0001 — transactions.date is timestamp without time zone, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 13 - "PR Overview Descriptive Title"
-Cohesion: 0.09
-Nodes (30): Props, isImportableTransactionField(), TableHeadSelect(), DataTableProps, NavButton(), CardAction(), CardFooter(), DialogOverlay() (+22 more)
+Cohesion: 0.10
+Nodes (24): AmountInput(), Props, CardAction(), CardFooter(), DropdownMenuCheckboxItem(), DropdownMenuContent(), DropdownMenuItem(), DropdownMenuLabel() (+16 more)
 
 ### Community 14 - "0002 Snapshot Json"
-Cohesion: 0.12
-Nodes (22): Preset, PresetKey, PRESETS, DatePicker(), Props, Props, Button(), buttonVariants (+14 more)
+Cohesion: 0.10
+Nodes (23): CSVReaderRenderProps, CSVUploadResults, Props, UploadButton(), AccountFilter(), DateFilter(), Preset, PresetKey (+15 more)
 
 ### Community 16 - "Project Polish Pr Summary"
 Cohesion: 0.20
@@ -620,20 +621,20 @@ Cohesion: 0.02
 Nodes (130): ResourceId, Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody (+122 more)
 
 ### Community 18 - "0001 Snapshot Json"
-Cohesion: 0.19
-Nodes (8): Props, AccountFilter(), DateFilter(), Filters(), Header(), HeaderLogo(), Navigation(), WelcomeMsg()
+Cohesion: 0.27
+Nodes (5): Props, Header(), HeaderLogo(), Navigation(), WelcomeMsg()
 
 ### Community 19 - "Json Editor Code Actions"
 Cohesion: 0.15
 Nodes (13): app, enforceJsonBodyLimit(), OwnedReferencesResult, transactions, checkTransactionMutationRateLimit(), cleanupMutationRateLimit(), DateRangeQueryOptions, DateRangeQueryResult (+5 more)
 
 ### Community 20 - "0000 Snapshot Json"
-Cohesion: 0.13
-Nodes (17): app, app, app, AppType, DELETE, GET, OPTIONS, PATCH (+9 more)
+Cohesion: 0.14
+Nodes (13): app, app, app, AppType, DELETE, GET, OPTIONS, PATCH (+5 more)
 
 ### Community 23 - "Nuchi Project Context"
 Cohesion: 0.11
-Nodes (26): FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem(), FormItemContext, FormItemContextValue (+18 more)
+Nodes (27): DatePicker(), FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem(), FormItemContext (+19 more)
 
 ### Community 24 - "Transactions API"
 Cohesion: 0.08
@@ -668,8 +669,8 @@ Cohesion: 0.05
 Nodes (39): devDependencies, dotenv, drizzle-kit, eslint, eslint-config-next, eslint-config-prettier, openapi-typescript, postcss (+31 more)
 
 ### Community 35 - "Seed Ts"
-Cohesion: 0.48
-Nodes (4): Props, Select(), mergeCreatedSelectOption(), SelectOption
+Cohesion: 0.19
+Nodes (11): Props, Select(), Dialog(), DialogContent(), DialogDescription(), DialogFooter(), DialogHeader(), DialogOverlay() (+3 more)
 
 ### Community 37 - "Nuchi Application"
 Cohesion: 0.10
@@ -688,20 +689,20 @@ Cohesion: 0.41
 Nodes (13): connect(), execUpgrade(), Context, T, gooseBinary(), insertUpgradeUser(), pgIdent(), runGoose() (+5 more)
 
 ### Community 41 - "New Router"
-Cohesion: 0.27
-Nodes (23): assertAccountNotFound(), assertValidationError(), createTestAccount(), decodeAccountsAPIError(), Handler, Pool, ResponseRecorder, T (+15 more)
+Cohesion: 0.15
+Nodes (41): assertAccountNotFound(), assertValidationError(), createTestAccount(), decodeAccountsAPIError(), Handler, Pool, ResponseRecorder, T (+33 more)
 
 ### Community 42 - "Api Error"
 Cohesion: 0.11
-Nodes (22): Actions(), Props, columns, ResponseType, AccountColumn(), Props, Actions(), Props (+14 more)
+Nodes (21): columns, ResponseType, Actions(), Props, columns, ResponseType, Actions(), Props (+13 more)
 
 ### Community 43 - "Edit Account Sheet Tsx"
 Cohesion: 0.18
 Nodes (10): Commands, Current Risk Areas, Env, graphify, Nuchi Codex Guide, Pull Requests Hard Rules, Reference, Repo Rules (+2 more)
 
 ### Community 45 - "Indexes Columns"
-Cohesion: 0.39
-Nodes (6): AmountInput(), Props, Tooltip(), TooltipContent(), TooltipProvider(), TooltipTrigger()
+Cohesion: 0.19
+Nodes (12): boxVariant, BoxVariants, DataCard(), DataCardLoading(), DataCardProps, iconVariant, IconVariants, DataCharts() (+4 more)
 
 ### Community 47 - "Plaid Id"
 Cohesion: 0.15
@@ -712,8 +713,8 @@ Cohesion: 0.09
 Nodes (26): Context, Queries, Timestamptz, UUID, Text, Timestamp, Timestamptz, UUID (+18 more)
 
 ### Community 49 - "Clerk Auth"
-Cohesion: 0.17
-Nodes (14): getDatabaseUrl(), assertSeedAllowed(), databaseUrl, db, defaultFrom, defaultTo, generateRandomAmount(), generateTransactions() (+6 more)
+Cohesion: 0.19
+Nodes (13): assertSeedAllowed(), databaseUrl, db, defaultFrom, defaultTo, generateRandomAmount(), generateTransactions(), generateTransactionsForDay() (+5 more)
 
 ### Community 50 - "Columns Plaid Id"
 Cohesion: 0.33
@@ -737,7 +738,7 @@ Nodes (22): BulkCreateTransactions401JSONResponse, BulkDeleteAccounts401JSONResp
 
 ### Community 58 - "Context"
 Cohesion: 0.24
-Nodes (10): Context, Queries, Text, UUID, Category, BulkDeleteCategoriesParams, CreateCategoryParams, DeleteCategoryParams (+2 more)
+Nodes (10): Category, Context, Queries, Text, UUID, BulkDeleteCategoriesParams, CreateCategoryParams, DeleteCategoryParams (+2 more)
 
 ### Community 60 - "Accounts Categories"
 Cohesion: 0.61
@@ -793,7 +794,7 @@ Nodes (5): 0011 — No resend endpoint; email delivery is fire-and-forget, How i
 
 ### Community 260 - "name"
 Cohesion: 0.11
-Nodes (19): columns, ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), INITIAL_IMPORT_RESULTS, VARIANTS (+11 more)
+Nodes (25): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), Props, ImportableTransactionField, isImportableTransactionField() (+17 more)
 
 ### Community 293 - "name"
 Cohesion: 0.08
@@ -821,7 +822,7 @@ Nodes (19): BulkCreateTransactions500JSONResponse, BulkDeleteCategories500JSONRe
 
 ### Community 317 - "notNull"
 Cohesion: 0.13
-Nodes (24): options, Props, Chart(), ChartEnum, ChartLoading(), Props, DataCharts(), DataTable() (+16 more)
+Nodes (24): INITIAL_IMPORT_RESULTS, VARIANTS, Chart(), ChartEnum, ChartLoading(), Props, DataTable(), Props (+16 more)
 
 ### Community 320 - "name"
 Cohesion: 0.25
@@ -844,16 +845,16 @@ Cohesion: 0.33
 Nodes (5): 0005 — Category duplicate update returns 500, create returns 409, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 348 - "type"
-Cohesion: 0.22
-Nodes (7): ResponseType, useDeleteAccount(), RequestType, ResponseType, useEditAccount(), useGetAccount(), EditAccountSheet()
+Cohesion: 0.24
+Nodes (10): Actions(), Props, AccountColumn(), Props, ResponseType, useDeleteAccount(), EditAccountSheet(), OpenAccountState (+2 more)
 
 ### Community 353 - "0006 — transactions.amount is 32-bit, capping a single transaction near ±2.1M ARS"
 Cohesion: 0.33
 Nodes (5): 0006 — transactions.amount is 32-bit, capping a single transaction near ±2.1M ARS, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 354 - "connection.ts"
-Cohesion: 0.20
-Nodes (11): buildPoolConfig(), createPool(), DatabasePoolCache, getOrCreateCachedPool(), isLocalDatabaseUrl(), LOCAL_HOSTS, shouldAllowInsecureTls(), shouldUseSsl() (+3 more)
+Cohesion: 0.21
+Nodes (11): buildPoolConfig(), createPool(), DatabasePoolCache, getDatabaseUrl(), getOrCreateCachedPool(), isLocalDatabaseUrl(), LOCAL_HOSTS, shouldAllowInsecureTls() (+3 more)
 
 ### Community 355 - "type"
 Cohesion: 0.29
@@ -885,19 +886,19 @@ Nodes (7): Categories, `DELETE /api/categories/:id`, `GET /api/categories`, `GET
 
 ### Community 376 - ".GetCategory"
 Cohesion: 0.50
-Nodes (3): routes, SheetTrigger(), VisuallyHidden()
+Nodes (3): CategoriesPage(), NewCategoryState, useNewCategory
 
 ### Community 377 - "BulkCreateTransactionsRequestObject"
 Cohesion: 0.33
 Nodes (5): 0010 — Auth operations do not declare 500 responses in the contract, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 379 - "name"
-Cohesion: 0.21
-Nodes (13): Actions(), Props, ResponseType, useDeleteCategory(), RequestType, ResponseType, useEditCategory(), useGetCategory() (+5 more)
+Cohesion: 0.29
+Nodes (6): useDeleteCategory(), RequestType, ResponseType, useEditCategory(), useGetCategory(), EditCategorySheet()
 
 ### Community 388 - ".UpdateCategory"
-Cohesion: 0.12
-Nodes (32): accountNotFoundError(), constraintName(), duplicateAccountNameError(), Account, ResourceServer, Request, ResourceId, ResponseWriter (+24 more)
+Cohesion: 0.09
+Nodes (44): accountNotFoundError(), constraintName(), duplicateAccountNameError(), Account, ResourceServer, Request, ResourceId, ResponseWriter (+36 more)
 
 ### Community 395 - "PR Review Cycle"
 Cohesion: 0.29
@@ -928,8 +929,8 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: give it a last review of all the files changend in the pr the comments and all that is in place right now in the pr leave comments for medim-high and high issues mid-low and low forget it we mande 3 iterations so far. if something is too big then addres it consitently here so it so i can anlyze it, Source Nodes
 
 ### Community 432 - "GetSummary200JSONResponse"
-Cohesion: 0.09
-Nodes (27): columns, ResponseType, TransactionsPage(), RequestType, ResponseType, RequestType, ResponseType, useBulkDeleteCategories() (+19 more)
+Cohesion: 0.10
+Nodes (26): TransactionsPage(), RequestType, ResponseType, useBulkDeleteAccounts(), RequestType, ResponseType, useEditAccount(), useGetAccount() (+18 more)
 
 ### Community 435 - "name"
 Cohesion: 0.38
@@ -968,8 +969,8 @@ Cohesion: 0.40
 Nodes (3): GetSummary400JSONResponse, InvalidDateQueryErrorJSONResponse, ListTransactions400JSONResponse
 
 ### Community 510 - "data-card.tsx"
-Cohesion: 0.25
-Nodes (6): AccountsPage(), RequestType, ResponseType, useBulkDeleteAccounts(), NewAccountState, useNewAccount
+Cohesion: 0.14
+Nodes (20): AccountsPage(), RequestType, ResponseType, useCreateAccount(), useGetAccounts(), FormValues, NewAccountSheet(), NewAccountState (+12 more)
 
 ### Community 511 - "BulkDeleteTransactions200JSONResponse"
 Cohesion: 0.33
@@ -980,8 +981,8 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: Review PR #64 against post-merge PR #62 comment and issue #63, Source Nodes
 
 ### Community 513 - ".CreateCategory"
-Cohesion: 0.12
-Nodes (7): RequestType, ResponseType, useCreateTransaction(), RequestType, ResponseType, useEditTransaction(), ApiError
+Cohesion: 0.11
+Nodes (8): RequestType, ResponseType, RequestType, ResponseType, RequestType, ResponseType, useEditTransaction(), ApiError
 
 ### Community 514 - "columns.tsx"
 Cohesion: 0.33
@@ -1000,8 +1001,8 @@ Cohesion: 0.14
 Nodes (9): ApiError, ApiErrorResponse, BulkCreateTransactions429JSONResponse, BulkDeleteTransactions429JSONResponse, CreateTransaction429JSONResponse, DeleteTransaction429JSONResponse, TransactionMutationRateLimitErrorJSONResponse, TransactionMutationRateLimitErrorResponseHeaders (+1 more)
 
 ### Community 518 - "graphify reference: query, path, explain"
-Cohesion: 0.11
-Nodes (33): CategoriesPage(), Sheet(), SheetContent(), SheetDescription(), SheetHeader(), SheetTitle(), accountsRelations, categoriesRelations (+25 more)
+Cohesion: 0.14
+Nodes (20): routes, Sheet(), SheetContent(), SheetDescription(), SheetHeader(), SheetTitle(), SheetTrigger(), VisuallyHidden() (+12 more)
 
 ### Community 519 - "README.md"
 Cohesion: 0.22
@@ -1056,9 +1057,9 @@ Cohesion: 0.50
 Nodes (3): InvalidRefreshTokenErrorJSONResponse, LogoutUser401JSONResponse, RefreshSession401JSONResponse
 
 ## Knowledge Gaps
-- **1046 isolated node(s):** `Props`, `ResponseType`, `Props`, `ResponseType`, `Props` (+1041 more)
+- **1047 isolated node(s):** `Props`, `ResponseType`, `Props`, `ResponseType`, `Props` (+1042 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **400 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **401 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Work-memory lessons
 
@@ -1073,15 +1074,15 @@ Nodes (3): InvalidRefreshTokenErrorJSONResponse, LogoutUser401JSONResponse, Refr
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `ApiErrorResponse` connect `RegisterUser201JSONResponse` to `New Router`, `Page Tsx`, `Components Json`, `Transactions Ts`?**
-  _High betweenness centrality (0.043) - this node is a cross-community bridge._
+  _High betweenness centrality (0.044) - this node is a cross-community bridge._
 - **Why does `toAuthUser()` connect `name` to `notNull`, `Route Ts`?**
-  _High betweenness centrality (0.028) - this node is a cross-community bridge._
+  _High betweenness centrality (0.027) - this node is a cross-community bridge._
 - **Why does `decodeAPIError()` connect `Components Json` to `RegisterUser201JSONResponse`?**
   _High betweenness centrality (0.025) - this node is a cross-community bridge._
 - **Are the 21 inferred relationships involving `newAuthTestEnv()` (e.g. with `NewPool()` and `NewAuthServer()`) actually correct?**
   _`newAuthTestEnv()` has 21 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Props`, `ResponseType`, `Props` to the rest of the system?**
-  _1071 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1072 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Transaction Form Tsx` be split into smaller, more focused modules?**
   _Cohesion score 0.11764705882352941 - nodes in this community are weakly interconnected._
 - **Should `Dependencies Class Variance Authority` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -50,7 +50,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions",
-      "community": 42,
+      "community": 348,
       "norm_label": "actions.tsx"
     },
     {
@@ -60,7 +60,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions_props",
-      "community": 42,
+      "community": 348,
       "norm_label": "props"
     },
     {
@@ -70,7 +70,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions_actions",
-      "community": 42,
+      "community": 348,
       "norm_label": "actions()"
     },
     {
@@ -130,7 +130,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_categories_actions",
-      "community": 379,
+      "community": 42,
       "norm_label": "actions.tsx"
     },
     {
@@ -140,7 +140,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "app_dashboard_categories_actions_props",
-      "community": 379,
+      "community": 42,
       "norm_label": "props"
     },
     {
@@ -150,7 +150,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "app_dashboard_categories_actions_actions",
-      "community": 379,
+      "community": 42,
       "norm_label": "actions()"
     },
     {
@@ -160,7 +160,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_categories_columns",
-      "community": 432,
+      "community": 42,
       "norm_label": "columns.tsx"
     },
     {
@@ -170,7 +170,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_dashboard_categories_columns_responsetype",
-      "community": 432,
+      "community": 42,
       "norm_label": "responsetype"
     },
     {
@@ -180,7 +180,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_dashboard_categories_columns_columns",
-      "community": 432,
+      "community": 42,
       "norm_label": "columns"
     },
     {
@@ -200,7 +200,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "app_dashboard_categories_page_categoriespage",
-      "community": 518,
+      "community": 376,
       "norm_label": "categoriespage()"
     },
     {
@@ -240,7 +240,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_page",
-      "community": 317,
+      "community": 45,
       "norm_label": "page.tsx"
     },
     {
@@ -250,7 +250,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "app_dashboard_page_dashboardpage",
-      "community": 317,
+      "community": 45,
       "norm_label": "dashboardpage()"
     },
     {
@@ -260,7 +260,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_account_column",
-      "community": 42,
+      "community": 348,
       "norm_label": "account-column.tsx"
     },
     {
@@ -270,7 +270,7 @@
       "source_location": "L2",
       "_origin": "ast",
       "id": "app_dashboard_transactions_account_column_props",
-      "community": 42,
+      "community": 348,
       "norm_label": "props"
     },
     {
@@ -280,7 +280,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "app_dashboard_transactions_account_column_accountcolumn",
-      "community": 42,
+      "community": 348,
       "norm_label": "accountcolumn()"
     },
     {
@@ -370,7 +370,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_dashboard_transactions_columns_columns",
-      "community": 260,
+      "community": 42,
       "norm_label": "columns"
     },
     {
@@ -430,7 +430,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table",
-      "community": 13,
+      "community": 260,
       "norm_label": "import-table.tsx"
     },
     {
@@ -440,7 +440,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table_props",
-      "community": 13,
+      "community": 260,
       "norm_label": "props"
     },
     {
@@ -460,7 +460,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page",
-      "community": 260,
+      "community": 317,
       "norm_label": "page.tsx"
     },
     {
@@ -470,7 +470,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_variants",
-      "community": 260,
+      "community": 317,
       "norm_label": "variants"
     },
     {
@@ -480,7 +480,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_initial_import_results",
-      "community": 260,
+      "community": 317,
       "norm_label": "initial_import_results"
     },
     {
@@ -500,7 +500,7 @@
       "source_location": "L149",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_transactionspagewrapper",
-      "community": 260,
+      "community": 317,
       "norm_label": "transactionspagewrapper()"
     },
     {
@@ -510,7 +510,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select",
-      "community": 317,
+      "community": 260,
       "norm_label": "table-head-select.tsx"
     },
     {
@@ -520,7 +520,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_props",
-      "community": 317,
+      "community": 260,
       "norm_label": "props"
     },
     {
@@ -530,7 +530,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_options",
-      "community": 317,
+      "community": 260,
       "norm_label": "options"
     },
     {
@@ -550,7 +550,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_isimportabletransactionfield",
-      "community": 13,
+      "community": 260,
       "norm_label": "isimportabletransactionfield()"
     },
     {
@@ -560,7 +560,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_tableheadselect",
-      "community": 13,
+      "community": 260,
       "norm_label": "tableheadselect()"
     },
     {
@@ -570,7 +570,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button",
-      "community": 260,
+      "community": 14,
       "norm_label": "upload-button.tsx"
     },
     {
@@ -580,7 +580,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button_props",
-      "community": 260,
+      "community": 14,
       "norm_label": "props"
     },
     {
@@ -590,7 +590,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button_csvreaderrenderprops",
-      "community": 260,
+      "community": 14,
       "norm_label": "csvreaderrenderprops"
     },
     {
@@ -600,7 +600,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button_csvuploadresults",
-      "community": 260,
+      "community": 14,
       "norm_label": "csvuploadresults"
     },
     {
@@ -610,7 +610,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "app_dashboard_transactions_upload_button_uploadbutton",
-      "community": 260,
+      "community": 14,
       "norm_label": "uploadbutton()"
     },
     {
@@ -640,7 +640,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_api_route_categories",
-      "community": 20,
+      "community": 9,
       "norm_label": "categories.ts"
     },
     {
@@ -760,7 +760,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_api_route_summary",
-      "community": 20,
+      "community": 9,
       "norm_label": "summary.ts"
     },
     {
@@ -2551,7 +2551,7 @@
       "source_file": "",
       "source_location": "",
       "_origin": "ast",
-      "id": "category",
+      "id": "backend_internal_db_gen_categories_sql_go_category",
       "community": 58,
       "norm_label": "category"
     },
@@ -3819,7 +3819,7 @@
       "label": "accountInputBody",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L31",
+      "source_location": "L29",
       "_origin": "ast",
       "id": "http_accountinputbody",
       "community": 388,
@@ -3829,7 +3829,7 @@
       "label": "bulkDeleteBody",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L37",
+      "source_location": "L35",
       "_origin": "ast",
       "id": "http_bulkdeletebody",
       "community": 388,
@@ -3839,7 +3839,7 @@
       "label": "ResourceServer",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L44",
+      "source_location": "L42",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_go_http_resourceserver",
       "community": 388,
@@ -3849,7 +3849,7 @@
       "label": ".ListAccounts()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L44",
+      "source_location": "L42",
       "_origin": "ast",
       "id": "http_resourceserver_listaccounts",
       "community": 388,
@@ -3879,7 +3879,7 @@
       "label": ".GetAccount()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L73",
+      "source_location": "L71",
       "_origin": "ast",
       "id": "http_resourceserver_getaccount",
       "community": 388,
@@ -3899,7 +3899,7 @@
       "label": ".CreateAccount()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L107",
+      "source_location": "L105",
       "_origin": "ast",
       "id": "http_resourceserver_createaccount",
       "community": 388,
@@ -3909,7 +3909,7 @@
       "label": ".UpdateAccount()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L167",
+      "source_location": "L165",
       "_origin": "ast",
       "id": "http_resourceserver_updateaccount",
       "community": 388,
@@ -3919,7 +3919,7 @@
       "label": ".DeleteAccount()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L221",
+      "source_location": "L219",
       "_origin": "ast",
       "id": "http_resourceserver_deleteaccount",
       "community": 388,
@@ -3929,7 +3929,7 @@
       "label": ".BulkDeleteAccounts()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L255",
+      "source_location": "L253",
       "_origin": "ast",
       "id": "http_resourceserver_bulkdeleteaccounts",
       "community": 388,
@@ -3939,7 +3939,7 @@
       "label": "validateAccountName()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L302",
+      "source_location": "L300",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_validateaccountname",
       "community": 388,
@@ -3949,7 +3949,7 @@
       "label": "validateBulkDeleteIds()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L313",
+      "source_location": "L308",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_validatebulkdeleteids",
       "community": 388,
@@ -3959,7 +3959,7 @@
       "label": "toAccountSummary()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L330",
+      "source_location": "L325",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_toaccountsummary",
       "community": 388,
@@ -3979,7 +3979,7 @@
       "label": "toAccount()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L338",
+      "source_location": "L333",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_toaccount",
       "community": 388,
@@ -3989,7 +3989,7 @@
       "label": "accountNotFoundError()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L354",
+      "source_location": "L349",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_accountnotfounderror",
       "community": 388,
@@ -3999,7 +3999,7 @@
       "label": "duplicateAccountNameError()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L365",
+      "source_location": "L360",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_duplicateaccountnameerror",
       "community": 388,
@@ -4009,7 +4009,7 @@
       "label": "isUniqueViolation()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L378",
+      "source_location": "L373",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_isuniqueviolation",
       "community": 388,
@@ -4019,21 +4019,11 @@
       "label": "constraintName()",
       "file_type": "code",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L387",
+      "source_location": "L382",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_constraintname",
       "community": 388,
       "norm_label": "constraintname()"
-    },
-    {
-      "label": "logAccountsError()",
-      "file_type": "code",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L399",
-      "_origin": "ast",
-      "id": "backend_internal_http_accounts_logaccountserror",
-      "community": 388,
-      "norm_label": "logaccountserror()"
     },
     {
       "label": "accounts_live_test.go",
@@ -5026,6 +5016,376 @@
       "norm_label": "testauthlive_refresh_cookieisperuseranddoesnotleakidentity()"
     },
     {
+      "label": "categories.go",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories",
+      "community": 388,
+      "norm_label": "categories.go"
+    },
+    {
+      "label": "categoryInputBody",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L23",
+      "_origin": "ast",
+      "id": "http_categoryinputbody",
+      "community": 388,
+      "norm_label": "categoryinputbody"
+    },
+    {
+      "label": "ResourceServer",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_go_http_resourceserver",
+      "community": 388,
+      "norm_label": "resourceserver"
+    },
+    {
+      "label": ".ListCategories()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "http_resourceserver_listcategories",
+      "community": 388,
+      "norm_label": ".listcategories()"
+    },
+    {
+      "label": "ResponseWriter",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_go_responsewriter",
+      "community": 388,
+      "norm_label": "responsewriter"
+    },
+    {
+      "label": "Request",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_go_request",
+      "community": 388,
+      "norm_label": "request"
+    },
+    {
+      "label": ".GetCategory()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L58",
+      "_origin": "ast",
+      "id": "http_resourceserver_getcategory",
+      "community": 388,
+      "norm_label": ".getcategory()"
+    },
+    {
+      "label": "ResourceId",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_go_resourceid",
+      "community": 388,
+      "norm_label": "resourceid"
+    },
+    {
+      "label": ".CreateCategory()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L92",
+      "_origin": "ast",
+      "id": "http_resourceserver_createcategory",
+      "community": 388,
+      "norm_label": ".createcategory()"
+    },
+    {
+      "label": ".UpdateCategory()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L159",
+      "_origin": "ast",
+      "id": "http_resourceserver_updatecategory",
+      "community": 388,
+      "norm_label": ".updatecategory()"
+    },
+    {
+      "label": ".DeleteCategory()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L215",
+      "_origin": "ast",
+      "id": "http_resourceserver_deletecategory",
+      "community": 388,
+      "norm_label": ".deletecategory()"
+    },
+    {
+      "label": ".BulkDeleteCategories()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L250",
+      "_origin": "ast",
+      "id": "http_resourceserver_bulkdeletecategories",
+      "community": 388,
+      "norm_label": ".bulkdeletecategories()"
+    },
+    {
+      "label": "validateCategoryName()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L296",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_validatecategoryname",
+      "community": 388,
+      "norm_label": "validatecategoryname()"
+    },
+    {
+      "label": "toCategorySummary()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L304",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_tocategorysummary",
+      "community": 388,
+      "norm_label": "tocategorysummary()"
+    },
+    {
+      "label": "Category",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_go_category",
+      "community": 388,
+      "norm_label": "category"
+    },
+    {
+      "label": "toCategory()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L311",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_tocategory",
+      "community": 388,
+      "norm_label": "tocategory()"
+    },
+    {
+      "label": "categoryNotFoundError()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L327",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_categorynotfounderror",
+      "community": 388,
+      "norm_label": "categorynotfounderror()"
+    },
+    {
+      "label": "duplicateCategoryNameError()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L337",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_duplicatecategorynameerror",
+      "community": 388,
+      "norm_label": "duplicatecategorynameerror()"
+    },
+    {
+      "label": "categories_live_test.go",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test",
+      "community": 41,
+      "norm_label": "categories_live_test.go"
+    },
+    {
+      "label": "assertCategoryNotFound()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L28",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_assertcategorynotfound",
+      "community": 41,
+      "norm_label": "assertcategorynotfound()"
+    },
+    {
+      "label": "T",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_go_t",
+      "community": 41,
+      "norm_label": "t"
+    },
+    {
+      "label": "ResponseRecorder",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_go_responserecorder",
+      "community": 41,
+      "norm_label": "responserecorder"
+    },
+    {
+      "label": "assertDuplicateCategoryName()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L39",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_assertduplicatecategoryname",
+      "community": 41,
+      "norm_label": "assertduplicatecategoryname()"
+    },
+    {
+      "label": "createTestCategory()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L57",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_createtestcategory",
+      "community": 41,
+      "norm_label": "createtestcategory()"
+    },
+    {
+      "label": "TestCategoriesLive_HappyPath_AllOperations()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L72",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_testcategorieslive_happypath_alloperations",
+      "community": 41,
+      "norm_label": "testcategorieslive_happypath_alloperations()"
+    },
+    {
+      "label": "TestCategoriesLive_ListEmpty_ReturnsEmptyArrayNotNull()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L181",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_testcategorieslive_listempty_returnsemptyarraynotnull",
+      "community": 41,
+      "norm_label": "testcategorieslive_listempty_returnsemptyarraynotnull()"
+    },
+    {
+      "label": "TestCategoriesLive_DuplicateName_OnCreate()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L198",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_oncreate",
+      "community": 41,
+      "norm_label": "testcategorieslive_duplicatename_oncreate()"
+    },
+    {
+      "label": "TestCategoriesLive_DuplicateName_OnUpdate()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L224",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_onupdate",
+      "community": 41,
+      "norm_label": "testcategorieslive_duplicatename_onupdate()"
+    },
+    {
+      "label": "TestCategoriesLive_NotFound_Nonexistent()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L244",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_testcategorieslive_notfound_nonexistent",
+      "community": 41,
+      "norm_label": "testcategorieslive_notfound_nonexistent()"
+    },
+    {
+      "label": "TestCategoriesLive_CrossUserIsolation()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L263",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_testcategorieslive_crossuserisolation",
+      "community": 41,
+      "norm_label": "testcategorieslive_crossuserisolation()"
+    },
+    {
+      "label": "TestCategoriesLive_Unauthorized()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L327",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_testcategorieslive_unauthorized",
+      "community": 41,
+      "norm_label": "testcategorieslive_unauthorized()"
+    },
+    {
+      "label": "TestCategoriesLive_Validation()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L386",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_testcategorieslive_validation",
+      "community": 41,
+      "norm_label": "testcategorieslive_validation()"
+    },
+    {
+      "label": "TestCategoriesLive_DeleteSetsTransactionCategoryNull()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L446",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_testcategorieslive_deletesetstransactioncategorynull",
+      "community": 41,
+      "norm_label": "testcategorieslive_deletesetstransactioncategorynull()"
+    },
+    {
+      "label": "seedTransaction()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L483",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_seedtransaction",
+      "community": 41,
+      "norm_label": "seedtransaction()"
+    },
+    {
+      "label": "Pool",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_go_pool",
+      "community": 41,
+      "norm_label": "pool"
+    },
+    {
+      "label": "UUID",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_go_uuid",
+      "community": 41,
+      "norm_label": "uuid"
+    },
+    {
+      "label": "assertTransactionSurvivesWithNullCategory()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L510",
+      "_origin": "ast",
+      "id": "backend_internal_http_categories_live_test_asserttransactionsurviveswithnullcategory",
+      "community": 41,
+      "norm_label": "asserttransactionsurviveswithnullcategory()"
+    },
+    {
       "label": "email_flows_live_test.go",
       "file_type": "code",
       "source_file": "backend/internal/http/email_flows_live_test.go",
@@ -5979,7 +6339,7 @@
       "label": "decodeResourceBody()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L31",
+      "source_location": "L33",
       "_origin": "ast",
       "id": "backend_internal_http_resources_decoderesourcebody",
       "community": 388,
@@ -6019,7 +6379,7 @@
       "label": "ResourceServer",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L42",
+      "source_location": "L44",
       "_origin": "ast",
       "id": "backend_internal_http_resources_go_http_resourceserver",
       "community": 388,
@@ -6039,27 +6399,27 @@
       "label": "NewResourceServer()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L47",
+      "source_location": "L49",
       "_origin": "ast",
       "id": "backend_internal_http_resources_newresourceserver",
       "community": 388,
       "norm_label": "newresourceserver()"
     },
     {
-      "label": "accountsServerMethods",
+      "label": "resourceServerMethods",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L56",
+      "source_location": "L58",
       "_origin": "ast",
-      "id": "http_accountsservermethods",
+      "id": "http_resourceservermethods",
       "community": 388,
-      "norm_label": "accountsservermethods"
+      "norm_label": "resourceservermethods"
     },
     {
       "label": "withResourceID()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L70",
+      "source_location": "L79",
       "_origin": "ast",
       "id": "backend_internal_http_resources_withresourceid",
       "community": 388,
@@ -6089,7 +6449,7 @@
       "label": ".withUser()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L89",
+      "source_location": "L98",
       "_origin": "ast",
       "id": "http_resourceserver_withuser",
       "community": 388,
@@ -6119,17 +6479,37 @@
       "label": "pgUserID()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L104",
+      "source_location": "L113",
       "_origin": "ast",
       "id": "backend_internal_http_resources_pguserid",
       "community": 388,
       "norm_label": "pguserid()"
     },
     {
+      "label": "validateResourceName()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L122",
+      "_origin": "ast",
+      "id": "backend_internal_http_resources_validateresourcename",
+      "community": 388,
+      "norm_label": "validateresourcename()"
+    },
+    {
+      "label": "logResourceError()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L133",
+      "_origin": "ast",
+      "id": "backend_internal_http_resources_logresourceerror",
+      "community": 388,
+      "norm_label": "logresourceerror()"
+    },
+    {
       "label": "dbError()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L111",
+      "source_location": "L140",
       "_origin": "ast",
       "id": "backend_internal_http_resources_dberror",
       "community": 388,
@@ -11952,7 +12332,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_account_filter_accountfilter",
-      "community": 18,
+      "community": 14,
       "norm_label": "accountfilter()"
     },
     {
@@ -11962,7 +12342,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_amount_input",
-      "community": 45,
+      "community": 13,
       "norm_label": "amount-input.tsx"
     },
     {
@@ -11972,7 +12352,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_amount_input_props",
-      "community": 45,
+      "community": 13,
       "norm_label": "props"
     },
     {
@@ -11982,7 +12362,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "components_amount_input_amountinput",
-      "community": 45,
+      "community": 13,
       "norm_label": "amountinput()"
     },
     {
@@ -12142,7 +12522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_count_up",
-      "community": 9,
+      "community": 45,
       "norm_label": "count-up.tsx"
     },
     {
@@ -12192,7 +12572,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_card",
-      "community": 9,
+      "community": 45,
       "norm_label": "data-card.tsx"
     },
     {
@@ -12202,7 +12582,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "components_data_card_boxvariant",
-      "community": 9,
+      "community": 45,
       "norm_label": "boxvariant"
     },
     {
@@ -12212,7 +12592,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "components_data_card_iconvariant",
-      "community": 9,
+      "community": 45,
       "norm_label": "iconvariant"
     },
     {
@@ -12222,7 +12602,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "components_data_card_boxvariants",
-      "community": 9,
+      "community": 45,
       "norm_label": "boxvariants"
     },
     {
@@ -12232,7 +12612,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "components_data_card_iconvariants",
-      "community": 9,
+      "community": 45,
       "norm_label": "iconvariants"
     },
     {
@@ -12242,7 +12622,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "components_data_card_datacardprops",
-      "community": 9,
+      "community": 45,
       "norm_label": "datacardprops"
     },
     {
@@ -12252,7 +12632,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "components_data_card_datacard",
-      "community": 9,
+      "community": 45,
       "norm_label": "datacard()"
     },
     {
@@ -12262,7 +12642,7 @@
       "source_location": "L100",
       "_origin": "ast",
       "id": "components_data_card_datacardloading",
-      "community": 9,
+      "community": 45,
       "norm_label": "datacardloading()"
     },
     {
@@ -12282,7 +12662,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_data_charts_datacharts",
-      "community": 317,
+      "community": 45,
       "norm_label": "datacharts()"
     },
     {
@@ -12292,7 +12672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_grid",
-      "community": 9,
+      "community": 45,
       "norm_label": "data-grid.tsx"
     },
     {
@@ -12302,7 +12682,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_data_grid_datagrid",
-      "community": 9,
+      "community": 45,
       "norm_label": "datagrid()"
     },
     {
@@ -12312,7 +12692,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_table",
-      "community": 13,
+      "community": 260,
       "norm_label": "data-table.tsx"
     },
     {
@@ -12322,7 +12702,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "components_data_table_datatableprops",
-      "community": 13,
+      "community": 260,
       "norm_label": "datatableprops"
     },
     {
@@ -12382,7 +12762,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "components_date_filter_datefilter",
-      "community": 18,
+      "community": 14,
       "norm_label": "datefilter()"
     },
     {
@@ -12412,7 +12792,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_date_picker_datepicker",
-      "community": 14,
+      "community": 23,
       "norm_label": "datepicker()"
     },
     {
@@ -12422,7 +12802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_filters",
-      "community": 18,
+      "community": 14,
       "norm_label": "filters.tsx"
     },
     {
@@ -12432,7 +12812,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "components_filters_filters",
-      "community": 18,
+      "community": 14,
       "norm_label": "filters()"
     },
     {
@@ -12532,7 +12912,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "components_nav_button_navbutton",
-      "community": 13,
+      "community": 14,
       "norm_label": "navbutton()"
     },
     {
@@ -12542,7 +12922,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_navigation",
-      "community": 376,
+      "community": 518,
       "norm_label": "navigation.tsx"
     },
     {
@@ -12552,7 +12932,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_navigation_routes",
-      "community": 376,
+      "community": 518,
       "norm_label": "routes"
     },
     {
@@ -12902,7 +13282,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "components_ui_card_carddescription",
-      "community": 9,
+      "community": 45,
       "norm_label": "carddescription()"
     },
     {
@@ -12962,7 +13342,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_dialog",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialog.tsx"
     },
     {
@@ -12972,7 +13352,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_ui_dialog_dialog",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialog()"
     },
     {
@@ -12982,7 +13362,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtrigger",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogtrigger()"
     },
     {
@@ -12992,7 +13372,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogportal",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogportal()"
     },
     {
@@ -13002,7 +13382,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogclose",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogclose()"
     },
     {
@@ -13012,7 +13392,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogoverlay",
-      "community": 13,
+      "community": 35,
       "norm_label": "dialogoverlay()"
     },
     {
@@ -13022,7 +13402,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogcontent",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogcontent()"
     },
     {
@@ -13032,7 +13412,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogheader",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogheader()"
     },
     {
@@ -13042,7 +13422,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogfooter",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogfooter()"
     },
     {
@@ -13052,7 +13432,7 @@
       "source_location": "L121",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtitle",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogtitle()"
     },
     {
@@ -13062,7 +13442,7 @@
       "source_location": "L134",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogdescription",
-      "community": 14,
+      "community": 35,
       "norm_label": "dialogdescription()"
     },
     {
@@ -13112,7 +13492,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenucontent",
-      "community": 42,
+      "community": 13,
       "norm_label": "dropdownmenucontent()"
     },
     {
@@ -13132,7 +13512,7 @@
       "source_location": "L62",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuitem",
-      "community": 42,
+      "community": 13,
       "norm_label": "dropdownmenuitem()"
     },
     {
@@ -13622,7 +14002,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_ui_sheet_sheettrigger",
-      "community": 376,
+      "community": 518,
       "norm_label": "sheettrigger()"
     },
     {
@@ -13752,7 +14132,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_table",
-      "community": 13,
+      "community": 260,
       "norm_label": "table.tsx"
     },
     {
@@ -13762,7 +14142,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "components_ui_table_table",
-      "community": 13,
+      "community": 260,
       "norm_label": "table()"
     },
     {
@@ -13772,7 +14152,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_ui_table_tableheader",
-      "community": 13,
+      "community": 260,
       "norm_label": "tableheader()"
     },
     {
@@ -13782,7 +14162,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "components_ui_table_tablebody",
-      "community": 13,
+      "community": 260,
       "norm_label": "tablebody()"
     },
     {
@@ -13792,7 +14172,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "components_ui_table_tablefooter",
-      "community": 13,
+      "community": 260,
       "norm_label": "tablefooter()"
     },
     {
@@ -13802,7 +14182,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "components_ui_table_tablerow",
-      "community": 13,
+      "community": 260,
       "norm_label": "tablerow()"
     },
     {
@@ -13812,7 +14192,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "components_ui_table_tablehead",
-      "community": 13,
+      "community": 260,
       "norm_label": "tablehead()"
     },
     {
@@ -13822,7 +14202,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "components_ui_table_tablecell",
-      "community": 13,
+      "community": 260,
       "norm_label": "tablecell()"
     },
     {
@@ -13832,7 +14212,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_table_tablecaption",
-      "community": 13,
+      "community": 260,
       "norm_label": "tablecaption()"
     },
     {
@@ -13862,7 +14242,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_tooltip",
-      "community": 45,
+      "community": 13,
       "norm_label": "tooltip.tsx"
     },
     {
@@ -13872,7 +14252,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltipprovider",
-      "community": 45,
+      "community": 13,
       "norm_label": "tooltipprovider()"
     },
     {
@@ -13882,7 +14262,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltip",
-      "community": 45,
+      "community": 13,
       "norm_label": "tooltip()"
     },
     {
@@ -13892,7 +14272,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltiptrigger",
-      "community": 45,
+      "community": 13,
       "norm_label": "tooltiptrigger()"
     },
     {
@@ -13902,7 +14282,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltipcontent",
-      "community": 45,
+      "community": 13,
       "norm_label": "tooltipcontent()"
     },
     {
@@ -13912,7 +14292,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_visually_hidden",
-      "community": 376,
+      "community": 518,
       "norm_label": "visually-hidden.tsx"
     },
     {
@@ -13922,7 +14302,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_ui_visually_hidden_visuallyhidden",
-      "community": 376,
+      "community": 518,
       "norm_label": "visuallyhidden()"
     },
     {
@@ -13992,7 +14372,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "db_connection_getdatabaseurl",
-      "community": 49,
+      "community": 354,
       "norm_label": "getdatabaseurl()"
     },
     {
@@ -14062,7 +14442,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "db_drizzle",
-      "community": 354,
+      "community": 9,
       "norm_label": "drizzle.ts"
     },
     {
@@ -14072,7 +14452,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "db_drizzle_pool",
-      "community": 354,
+      "community": 9,
       "norm_label": "pool"
     },
     {
@@ -14082,7 +14462,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "db_drizzle_db",
-      "community": 20,
+      "community": 9,
       "norm_label": "db"
     },
     {
@@ -14132,7 +14512,7 @@
       "source_location": "L43",
       "_origin": "ast",
       "id": "db_schema_categories",
-      "community": 20,
+      "community": 9,
       "norm_label": "categories"
     },
     {
@@ -14232,7 +14612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts",
-      "community": 510,
+      "community": 432,
       "norm_label": "use-bulk-delete-accounts.ts"
     },
     {
@@ -14242,7 +14622,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_responsetype",
-      "community": 510,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -14252,7 +14632,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_requesttype",
-      "community": 510,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -14262,7 +14642,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_usebulkdeleteaccounts",
-      "community": 510,
+      "community": 432,
       "norm_label": "usebulkdeleteaccounts()"
     },
     {
@@ -14272,7 +14652,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account",
-      "community": 432,
+      "community": 510,
       "norm_label": "use-create-account.ts"
     },
     {
@@ -14282,7 +14662,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_responsetype",
-      "community": 432,
+      "community": 510,
       "norm_label": "responsetype"
     },
     {
@@ -14292,7 +14672,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_requesttype",
-      "community": 432,
+      "community": 510,
       "norm_label": "requesttype"
     },
     {
@@ -14302,7 +14682,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_usecreateaccount",
-      "community": 518,
+      "community": 510,
       "norm_label": "usecreateaccount()"
     },
     {
@@ -14342,7 +14722,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_edit_account",
-      "community": 348,
+      "community": 432,
       "norm_label": "use-edit-account.ts"
     },
     {
@@ -14352,7 +14732,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_edit_account_responsetype",
-      "community": 348,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -14362,7 +14742,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_accounts_api_use_edit_account_requesttype",
-      "community": 348,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -14372,7 +14752,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_accounts_api_use_edit_account_useeditaccount",
-      "community": 348,
+      "community": 432,
       "norm_label": "useeditaccount()"
     },
     {
@@ -14392,7 +14772,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_account_usegetaccount",
-      "community": 348,
+      "community": 432,
       "norm_label": "usegetaccount()"
     },
     {
@@ -14412,7 +14792,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_accounts_usegetaccounts",
-      "community": 518,
+      "community": 510,
       "norm_label": "usegetaccounts()"
     },
     {
@@ -14462,7 +14842,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_accounts_components_account_form_accountform",
-      "community": 518,
+      "community": 23,
       "norm_label": "accountform()"
     },
     {
@@ -14502,7 +14882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_components_new_account_sheet",
-      "community": 518,
+      "community": 510,
       "norm_label": "new-account-sheet.tsx"
     },
     {
@@ -14512,7 +14892,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "features_accounts_components_new_account_sheet_formvalues",
-      "community": 518,
+      "community": 510,
       "norm_label": "formvalues"
     },
     {
@@ -14522,7 +14902,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "features_accounts_components_new_account_sheet_newaccountsheet",
-      "community": 518,
+      "community": 510,
       "norm_label": "newaccountsheet()"
     },
     {
@@ -14562,7 +14942,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_open_account",
-      "community": 42,
+      "community": 348,
       "norm_label": "use-open-account.ts"
     },
     {
@@ -14572,7 +14952,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_open_account_openaccountstate",
-      "community": 42,
+      "community": 348,
       "norm_label": "openaccountstate"
     },
     {
@@ -14582,7 +14962,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_open_account_useopenaccount",
-      "community": 42,
+      "community": 348,
       "norm_label": "useopenaccount"
     },
     {
@@ -14592,7 +14972,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account",
-      "community": 14,
+      "community": 35,
       "norm_label": "use-select-account.tsx"
     },
     {
@@ -14602,7 +14982,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account_useselectaccount",
-      "community": 518,
+      "community": 510,
       "norm_label": "useselectaccount()"
     },
     {
@@ -14652,7 +15032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category",
-      "community": 432,
+      "community": 513,
       "norm_label": "use-create-category.ts"
     },
     {
@@ -14662,7 +15042,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_responsetype",
-      "community": 432,
+      "community": 513,
       "norm_label": "responsetype"
     },
     {
@@ -14672,7 +15052,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_requesttype",
-      "community": 432,
+      "community": 513,
       "norm_label": "requesttype"
     },
     {
@@ -14682,7 +15062,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_usecreatecategory",
-      "community": 518,
+      "community": 510,
       "norm_label": "usecreatecategory()"
     },
     {
@@ -14692,7 +15072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category",
-      "community": 379,
+      "community": 432,
       "norm_label": "use-delete-category.ts"
     },
     {
@@ -14702,7 +15082,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category_responsetype",
-      "community": 379,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -14772,7 +15152,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_categories_api_use_get_categories_usegetcategories",
-      "community": 518,
+      "community": 510,
       "norm_label": "usegetcategories()"
     },
     {
@@ -14842,7 +15222,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_categories_components_category_form_categoryform",
-      "community": 23,
+      "community": 518,
       "norm_label": "categoryform()"
     },
     {
@@ -14852,7 +15232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet",
-      "community": 379,
+      "community": 518,
       "norm_label": "edit-category-sheet.tsx"
     },
     {
@@ -14862,7 +15242,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet_formvalues",
-      "community": 379,
+      "community": 518,
       "norm_label": "formvalues"
     },
     {
@@ -14902,7 +15282,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "features_categories_components_new_category_sheet_newcategorysheet",
-      "community": 518,
+      "community": 510,
       "norm_label": "newcategorysheet()"
     },
     {
@@ -14912,7 +15292,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_hooks_use_new_category",
-      "community": 518,
+      "community": 376,
       "norm_label": "use-new-category.ts"
     },
     {
@@ -14922,7 +15302,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_categories_hooks_use_new_category_newcategorystate",
-      "community": 518,
+      "community": 376,
       "norm_label": "newcategorystate"
     },
     {
@@ -14932,7 +15312,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_hooks_use_new_category_usenewcategory",
-      "community": 518,
+      "community": 376,
       "norm_label": "usenewcategory"
     },
     {
@@ -14942,7 +15322,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_hooks_use_open_category",
-      "community": 379,
+      "community": 42,
       "norm_label": "use-open-category.ts"
     },
     {
@@ -14952,7 +15332,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_categories_hooks_use_open_category_opencategorystate",
-      "community": 379,
+      "community": 42,
       "norm_label": "opencategorystate"
     },
     {
@@ -14962,7 +15342,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_categories_hooks_use_open_category_useopencategory",
-      "community": 379,
+      "community": 42,
       "norm_label": "useopencategory"
     },
     {
@@ -14982,7 +15362,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_summary_use_get_summary_usegetsummary",
-      "community": 432,
+      "community": 45,
       "norm_label": "usegetsummary()"
     },
     {
@@ -15102,7 +15482,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_usecreatetransaction",
-      "community": 513,
+      "community": 510,
       "norm_label": "usecreatetransaction()"
     },
     {
@@ -15242,7 +15622,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "features_transactions_components_edit_transaction_sheet_edittransactionsheet",
-      "community": 518,
+      "community": 510,
       "norm_label": "edittransactionsheet()"
     },
     {
@@ -15252,7 +15632,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet",
-      "community": 518,
+      "community": 510,
       "norm_label": "new-transaction-sheet.tsx"
     },
     {
@@ -15262,7 +15642,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet_formvalues",
-      "community": 518,
+      "community": 510,
       "norm_label": "formvalues"
     },
     {
@@ -15272,7 +15652,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet_newtransactionsheet",
-      "community": 518,
+      "community": 510,
       "norm_label": "newtransactionsheet()"
     },
     {
@@ -15332,7 +15712,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "features_transactions_components_transaction_form_transactionform",
-      "community": 518,
+      "community": 510,
       "norm_label": "transactionform()"
     },
     {
@@ -15342,7 +15722,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_new_transaction",
-      "community": 518,
+      "community": 510,
       "norm_label": "use-new-transaction.ts"
     },
     {
@@ -15352,7 +15732,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_new_transaction_newtransactionstate",
-      "community": 518,
+      "community": 510,
       "norm_label": "newtransactionstate"
     },
     {
@@ -15362,7 +15742,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_new_transaction_usenewtransaction",
-      "community": 518,
+      "community": 510,
       "norm_label": "usenewtransaction"
     },
     {
@@ -15402,7 +15782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "hooks_use_confirm",
-      "community": 14,
+      "community": 35,
       "norm_label": "use-confirm.tsx"
     },
     {
@@ -15412,7 +15792,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "hooks_use_confirm_useconfirm",
-      "community": 379,
+      "community": 348,
       "norm_label": "useconfirm()"
     },
     {
@@ -15422,7 +15802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_base_url_test",
-      "community": 432,
+      "community": 378,
       "norm_label": "api-base-url.test.ts"
     },
     {
@@ -15432,7 +15812,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_base_url",
-      "community": 432,
+      "community": 378,
       "norm_label": "api-base-url.ts"
     },
     {
@@ -15442,7 +15822,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_base_url_resolveapibaseurloptions",
-      "community": 432,
+      "community": 378,
       "norm_label": "resolveapibaseurloptions"
     },
     {
@@ -15452,7 +15832,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "lib_api_base_url_resolveapibaseurl",
-      "community": 432,
+      "community": 378,
       "norm_label": "resolveapibaseurl()"
     },
     {
@@ -15652,7 +16032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items_test",
-      "community": 260,
+      "community": 317,
       "norm_label": "chunk-items.test.ts"
     },
     {
@@ -15662,7 +16042,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items",
-      "community": 260,
+      "community": 317,
       "norm_label": "chunk-items.ts"
     },
     {
@@ -15672,7 +16052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items_chunkitems",
-      "community": 260,
+      "community": 317,
       "norm_label": "chunkitems()"
     },
     {
@@ -15972,7 +16352,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "lib_utils_calculatepercentagechange",
-      "community": 20,
+      "community": 9,
       "norm_label": "calculatepercentagechange()"
     },
     {
@@ -15982,7 +16362,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "lib_utils_fillmissingdays",
-      "community": 20,
+      "community": 9,
       "norm_label": "fillmissingdays()"
     },
     {
@@ -16002,7 +16382,7 @@
       "source_location": "L76",
       "_origin": "ast",
       "id": "lib_utils_formatdaterange",
-      "community": 9,
+      "community": 45,
       "norm_label": "formatdaterange()"
     },
     {
@@ -16962,7 +17342,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "providers_sheet_provider",
-      "community": 518,
+      "community": 510,
       "norm_label": "sheet-provider.tsx"
     },
     {
@@ -30928,6 +31308,17 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L335",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_unauthorized",
+      "target": "backend_internal_auth_jwt_issueaccesstoken"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/middleware_live_test.go",
       "source_location": "L121",
       "weight": 1.0,
@@ -35370,7 +35761,7 @@
       "weight": 1.0,
       "context": "return_type",
       "source": "gen_queries_createcategory",
-      "target": "category",
+      "target": "backend_internal_db_gen_categories_sql_go_category",
       "confidence_score": 1.0
     },
     {
@@ -35381,7 +35772,7 @@
       "weight": 1.0,
       "context": "return_type",
       "source": "gen_queries_getcategory",
-      "target": "category",
+      "target": "backend_internal_db_gen_categories_sql_go_category",
       "confidence_score": 1.0
     },
     {
@@ -35392,7 +35783,7 @@
       "weight": 1.0,
       "context": "return_type",
       "source": "gen_queries_listcategories",
-      "target": "category",
+      "target": "backend_internal_db_gen_categories_sql_go_category",
       "confidence_score": 1.0
     },
     {
@@ -35403,7 +35794,7 @@
       "weight": 1.0,
       "context": "return_type",
       "source": "gen_queries_updatecategoryname",
-      "target": "category",
+      "target": "backend_internal_db_gen_categories_sql_go_category",
       "confidence_score": 1.0
     },
     {
@@ -37660,6 +38051,28 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L516",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_asserttransactionsurviveswithnullcategory",
+      "target": "backend_internal_db_rls_withusertx"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L488",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_seedtransaction",
+      "target": "backend_internal_db_rls_withusertx"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/middleware_live_test.go",
       "source_location": "L43",
       "weight": 1.0,
@@ -37683,7 +38096,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L96",
+      "source_location": "L105",
       "weight": 1.0,
       "source": "http_resourceserver_withuser",
       "target": "backend_internal_db_rls_withusertx"
@@ -38188,7 +38601,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L354",
+      "source_location": "L349",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "backend_internal_http_accounts_accountnotfounderror",
@@ -38198,7 +38611,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L387",
+      "source_location": "L382",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "backend_internal_http_accounts_constraintname",
@@ -38208,7 +38621,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L365",
+      "source_location": "L360",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "backend_internal_http_accounts_duplicateaccountnameerror",
@@ -38218,7 +38631,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L378",
+      "source_location": "L373",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "backend_internal_http_accounts_isuniqueviolation",
@@ -38228,17 +38641,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L399",
-      "weight": 1.0,
-      "source": "backend_internal_http_accounts",
-      "target": "backend_internal_http_accounts_logaccountserror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L338",
+      "source_location": "L333",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "backend_internal_http_accounts_toaccount",
@@ -38248,7 +38651,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L330",
+      "source_location": "L325",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "backend_internal_http_accounts_toaccountsummary",
@@ -38258,7 +38661,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L302",
+      "source_location": "L300",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "backend_internal_http_accounts_validateaccountname",
@@ -38268,7 +38671,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L313",
+      "source_location": "L308",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "backend_internal_http_accounts_validatebulkdeleteids",
@@ -38278,7 +38681,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L31",
+      "source_location": "L29",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "http_accountinputbody",
@@ -38288,7 +38691,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L37",
+      "source_location": "L35",
       "weight": 1.0,
       "source": "backend_internal_http_accounts",
       "target": "http_bulkdeletebody",
@@ -38298,7 +38701,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L255",
+      "source_location": "L253",
       "weight": 1.0,
       "source": "backend_internal_http_accounts_go_http_resourceserver",
       "target": "http_resourceserver_bulkdeleteaccounts",
@@ -38308,7 +38711,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L107",
+      "source_location": "L105",
       "weight": 1.0,
       "source": "backend_internal_http_accounts_go_http_resourceserver",
       "target": "http_resourceserver_createaccount",
@@ -38318,7 +38721,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L221",
+      "source_location": "L219",
       "weight": 1.0,
       "source": "backend_internal_http_accounts_go_http_resourceserver",
       "target": "http_resourceserver_deleteaccount",
@@ -38328,7 +38731,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L73",
+      "source_location": "L71",
       "weight": 1.0,
       "source": "backend_internal_http_accounts_go_http_resourceserver",
       "target": "http_resourceserver_getaccount",
@@ -38338,7 +38741,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L44",
+      "source_location": "L42",
       "weight": 1.0,
       "source": "backend_internal_http_accounts_go_http_resourceserver",
       "target": "http_resourceserver_listaccounts",
@@ -38348,7 +38751,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L167",
+      "source_location": "L165",
       "weight": 1.0,
       "source": "backend_internal_http_accounts_go_http_resourceserver",
       "target": "http_resourceserver_updateaccount",
@@ -38358,7 +38761,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L44",
+      "source_location": "L42",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_listaccounts",
@@ -38369,7 +38772,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L44",
+      "source_location": "L42",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_listaccounts",
@@ -38381,18 +38784,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L55",
-      "weight": 1.0,
-      "source": "http_resourceserver_listaccounts",
-      "target": "backend_internal_http_accounts_logaccountserror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L65",
+      "source_location": "L63",
       "weight": 1.0,
       "source": "http_resourceserver_listaccounts",
       "target": "backend_internal_http_accounts_toaccountsummary",
@@ -38404,7 +38796,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L56",
+      "source_location": "L54",
       "weight": 1.0,
       "source": "http_resourceserver_listaccounts",
       "target": "backend_internal_http_resources_dberror"
@@ -38415,7 +38807,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L48",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "http_resourceserver_listaccounts",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/accounts.go",
+      "source_location": "L46",
       "weight": 1.0,
       "source": "http_resourceserver_listaccounts",
       "target": "backend_internal_http_resources_pguserid"
@@ -38424,7 +38827,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L255",
+      "source_location": "L253",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_bulkdeleteaccounts",
@@ -38435,7 +38838,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L107",
+      "source_location": "L105",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_createaccount",
@@ -38446,7 +38849,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L221",
+      "source_location": "L219",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_deleteaccount",
@@ -38457,7 +38860,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L73",
+      "source_location": "L71",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_getaccount",
@@ -38468,7 +38871,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L167",
+      "source_location": "L165",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_updateaccount",
@@ -38479,18 +38882,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L399",
-      "weight": 1.0,
-      "context": "parameter_type",
-      "source": "backend_internal_http_accounts_logaccountserror",
-      "target": "backend_internal_http_accounts_go_request",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "references",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L255",
+      "source_location": "L253",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_bulkdeleteaccounts",
@@ -38501,7 +38893,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L107",
+      "source_location": "L105",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_createaccount",
@@ -38512,7 +38904,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L221",
+      "source_location": "L219",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_deleteaccount",
@@ -38523,7 +38915,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L73",
+      "source_location": "L71",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_getaccount",
@@ -38534,7 +38926,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L167",
+      "source_location": "L165",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_updateaccount",
@@ -38546,7 +38938,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L95",
+      "source_location": "L93",
       "weight": 1.0,
       "source": "http_resourceserver_getaccount",
       "target": "backend_internal_http_accounts_accountnotfounderror",
@@ -38556,7 +38948,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L73",
+      "source_location": "L71",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_getaccount",
@@ -38568,18 +38960,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L98",
-      "weight": 1.0,
-      "source": "http_resourceserver_getaccount",
-      "target": "backend_internal_http_accounts_logaccountserror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L92",
+      "source_location": "L90",
       "weight": 1.0,
       "source": "http_resourceserver_getaccount",
       "target": "backend_internal_http_accounts_toaccountsummary",
@@ -38591,7 +38972,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L99",
+      "source_location": "L97",
       "weight": 1.0,
       "source": "http_resourceserver_getaccount",
       "target": "backend_internal_http_resources_dberror"
@@ -38602,7 +38983,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L76",
+      "source_location": "L96",
+      "weight": 1.0,
+      "source": "http_resourceserver_getaccount",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/accounts.go",
+      "source_location": "L74",
       "weight": 1.0,
       "source": "http_resourceserver_getaccount",
       "target": "backend_internal_http_resources_pguserid"
@@ -38611,7 +39003,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L221",
+      "source_location": "L219",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_deleteaccount",
@@ -38622,7 +39014,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L167",
+      "source_location": "L165",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_updateaccount",
@@ -38634,32 +39026,10 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L152",
+      "source_location": "L150",
       "weight": 1.0,
       "source": "http_resourceserver_createaccount",
       "target": "backend_internal_http_accounts_duplicateaccountnameerror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L151",
-      "weight": 1.0,
-      "source": "http_resourceserver_createaccount",
-      "target": "backend_internal_http_accounts_isuniqueviolation",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L155",
-      "weight": 1.0,
-      "source": "http_resourceserver_createaccount",
-      "target": "backend_internal_http_accounts_logaccountserror",
       "confidence_score": 1.0
     },
     {
@@ -38670,6 +39040,17 @@
       "source_location": "L149",
       "weight": 1.0,
       "source": "http_resourceserver_createaccount",
+      "target": "backend_internal_http_accounts_isuniqueviolation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/accounts.go",
+      "source_location": "L147",
+      "weight": 1.0,
+      "source": "http_resourceserver_createaccount",
       "target": "backend_internal_http_accounts_toaccount",
       "confidence_score": 1.0
     },
@@ -38678,7 +39059,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L115",
+      "source_location": "L113",
       "weight": 1.0,
       "source": "http_resourceserver_createaccount",
       "target": "backend_internal_http_accounts_validateaccountname",
@@ -38690,7 +39071,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L110",
+      "source_location": "L108",
       "weight": 1.0,
       "source": "http_resourceserver_createaccount",
       "target": "backend_internal_http_auth_validationerror"
@@ -38701,7 +39082,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L156",
+      "source_location": "L154",
       "weight": 1.0,
       "source": "http_resourceserver_createaccount",
       "target": "backend_internal_http_resources_dberror"
@@ -38712,7 +39093,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L109",
+      "source_location": "L107",
       "weight": 1.0,
       "source": "http_resourceserver_createaccount",
       "target": "backend_internal_http_resources_decoderesourcebody"
@@ -38723,7 +39104,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L133",
+      "source_location": "L153",
+      "weight": 1.0,
+      "source": "http_resourceserver_createaccount",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/accounts.go",
+      "source_location": "L131",
       "weight": 1.0,
       "source": "http_resourceserver_createaccount",
       "target": "backend_internal_http_resources_pguserid"
@@ -38733,7 +39125,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L206",
+      "source_location": "L204",
       "weight": 1.0,
       "source": "http_resourceserver_updateaccount",
       "target": "backend_internal_http_accounts_accountnotfounderror",
@@ -38744,7 +39136,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L209",
+      "source_location": "L207",
       "weight": 1.0,
       "source": "http_resourceserver_updateaccount",
       "target": "backend_internal_http_accounts_duplicateaccountnameerror",
@@ -38755,7 +39147,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L208",
+      "source_location": "L206",
       "weight": 1.0,
       "source": "http_resourceserver_updateaccount",
       "target": "backend_internal_http_accounts_isuniqueviolation",
@@ -38766,18 +39158,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L212",
-      "weight": 1.0,
-      "source": "http_resourceserver_updateaccount",
-      "target": "backend_internal_http_accounts_logaccountserror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L203",
+      "source_location": "L201",
       "weight": 1.0,
       "source": "http_resourceserver_updateaccount",
       "target": "backend_internal_http_accounts_toaccount",
@@ -38788,7 +39169,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L175",
+      "source_location": "L173",
       "weight": 1.0,
       "source": "http_resourceserver_updateaccount",
       "target": "backend_internal_http_accounts_validateaccountname",
@@ -38800,7 +39181,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L170",
+      "source_location": "L168",
       "weight": 1.0,
       "source": "http_resourceserver_updateaccount",
       "target": "backend_internal_http_auth_validationerror"
@@ -38811,7 +39192,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L213",
+      "source_location": "L211",
       "weight": 1.0,
       "source": "http_resourceserver_updateaccount",
       "target": "backend_internal_http_resources_dberror"
@@ -38822,7 +39203,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L169",
+      "source_location": "L167",
       "weight": 1.0,
       "source": "http_resourceserver_updateaccount",
       "target": "backend_internal_http_resources_decoderesourcebody"
@@ -38833,7 +39214,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L186",
+      "source_location": "L210",
+      "weight": 1.0,
+      "source": "http_resourceserver_updateaccount",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/accounts.go",
+      "source_location": "L184",
       "weight": 1.0,
       "source": "http_resourceserver_updateaccount",
       "target": "backend_internal_http_resources_pguserid"
@@ -38843,7 +39235,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L243",
+      "source_location": "L241",
       "weight": 1.0,
       "source": "http_resourceserver_deleteaccount",
       "target": "backend_internal_http_accounts_accountnotfounderror",
@@ -38852,21 +39244,10 @@
     {
       "relation": "calls",
       "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L246",
-      "weight": 1.0,
-      "source": "http_resourceserver_deleteaccount",
-      "target": "backend_internal_http_accounts_logaccountserror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L247",
+      "source_location": "L245",
       "weight": 1.0,
       "source": "http_resourceserver_deleteaccount",
       "target": "backend_internal_http_resources_dberror"
@@ -38877,7 +39258,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L224",
+      "source_location": "L244",
+      "weight": 1.0,
+      "source": "http_resourceserver_deleteaccount",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/accounts.go",
+      "source_location": "L222",
       "weight": 1.0,
       "source": "http_resourceserver_deleteaccount",
       "target": "backend_internal_http_resources_pguserid"
@@ -38887,18 +39279,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L282",
-      "weight": 1.0,
-      "source": "http_resourceserver_bulkdeleteaccounts",
-      "target": "backend_internal_http_accounts_logaccountserror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L263",
+      "source_location": "L261",
       "weight": 1.0,
       "source": "http_resourceserver_bulkdeleteaccounts",
       "target": "backend_internal_http_accounts_validatebulkdeleteids",
@@ -38910,7 +39291,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L258",
+      "source_location": "L256",
       "weight": 1.0,
       "source": "http_resourceserver_bulkdeleteaccounts",
       "target": "backend_internal_http_auth_validationerror"
@@ -38921,7 +39302,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L283",
+      "source_location": "L281",
       "weight": 1.0,
       "source": "http_resourceserver_bulkdeleteaccounts",
       "target": "backend_internal_http_resources_dberror"
@@ -38932,7 +39313,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L257",
+      "source_location": "L255",
       "weight": 1.0,
       "source": "http_resourceserver_bulkdeleteaccounts",
       "target": "backend_internal_http_resources_decoderesourcebody"
@@ -38943,16 +39324,38 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L274",
+      "source_location": "L280",
+      "weight": 1.0,
+      "source": "http_resourceserver_bulkdeleteaccounts",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/accounts.go",
+      "source_location": "L272",
       "weight": 1.0,
       "source": "http_resourceserver_bulkdeleteaccounts",
       "target": "backend_internal_http_resources_pguserid"
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/accounts.go",
+      "source_location": "L301",
+      "weight": 1.0,
+      "source": "backend_internal_http_accounts_validateaccountname",
+      "target": "backend_internal_http_resources_validateresourcename"
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L302",
+      "source_location": "L300",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_accounts_validateaccountname",
@@ -38963,7 +39366,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L313",
+      "source_location": "L308",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_accounts_validatebulkdeleteids",
@@ -38971,10 +39374,21 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L258",
+      "weight": 1.0,
+      "source": "http_resourceserver_bulkdeletecategories",
+      "target": "backend_internal_http_accounts_validatebulkdeleteids"
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L330",
+      "source_location": "L325",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_accounts_toaccountsummary",
@@ -38985,7 +39399,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L330",
+      "source_location": "L325",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_accounts_toaccountsummary",
@@ -38996,7 +39410,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L338",
+      "source_location": "L333",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_accounts_toaccount",
@@ -39007,7 +39421,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L354",
+      "source_location": "L349",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_accounts_accountnotfounderror",
@@ -39019,7 +39433,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L366",
+      "source_location": "L361",
       "weight": 1.0,
       "source": "backend_internal_http_accounts_duplicateaccountnameerror",
       "target": "backend_internal_http_accounts_constraintname",
@@ -39029,12 +39443,45 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts.go",
-      "source_location": "L365",
+      "source_location": "L360",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_accounts_duplicateaccountnameerror",
       "target": "openapi_duplicateaccountnameerrorjsonresponse",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L134",
+      "weight": 1.0,
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_accounts_isuniqueviolation"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L200",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_accounts_isuniqueviolation"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L338",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_duplicatecategorynameerror",
+      "target": "backend_internal_http_accounts_constraintname"
     },
     {
       "relation": "contains",
@@ -39225,6 +39672,17 @@
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_accounts_live_test_newaccountstestenv",
+      "target": "http_accountstestenv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L57",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_createtestcategory",
       "target": "http_accountstestenv",
       "confidence_score": 1.0
     },
@@ -39445,6 +39903,105 @@
       "source": "backend_internal_http_accounts_live_test_testaccountslive_validation",
       "target": "backend_internal_http_accounts_live_test_newaccountstestenv",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L264",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_crossuserisolation",
+      "target": "backend_internal_http_accounts_live_test_newaccountstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L447",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_deletesetstransactioncategorynull",
+      "target": "backend_internal_http_accounts_live_test_newaccountstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L199",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_oncreate",
+      "target": "backend_internal_http_accounts_live_test_newaccountstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L225",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_onupdate",
+      "target": "backend_internal_http_accounts_live_test_newaccountstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_happypath_alloperations",
+      "target": "backend_internal_http_accounts_live_test_newaccountstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L182",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_listempty_returnsemptyarraynotnull",
+      "target": "backend_internal_http_accounts_live_test_newaccountstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L245",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_notfound_nonexistent",
+      "target": "backend_internal_http_accounts_live_test_newaccountstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L328",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_unauthorized",
+      "target": "backend_internal_http_accounts_live_test_newaccountstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L387",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_validation",
+      "target": "backend_internal_http_accounts_live_test_newaccountstestenv"
     },
     {
       "relation": "references",
@@ -39977,6 +40534,39 @@
     {
       "relation": "calls",
       "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L33",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_assertcategorynotfound",
+      "target": "backend_internal_http_accounts_live_test_decodeaccountsapierror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_assertduplicatecategoryname",
+      "target": "backend_internal_http_accounts_live_test_decodeaccountsapierror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L375",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_unauthorized",
+      "target": "backend_internal_http_accounts_live_test_decodeaccountsapierror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/accounts_live_test.go",
       "source_location": "L369",
@@ -40050,6 +40640,28 @@
       "source": "backend_internal_http_accounts_live_test_testaccountslive_deletecascadestransactions",
       "target": "backend_internal_http_accounts_live_test_createtestaccount",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L452",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_deletesetstransactioncategorynull",
+      "target": "backend_internal_http_accounts_live_test_createtestaccount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L392",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_validation",
+      "target": "backend_internal_http_accounts_live_test_assertvalidationerror"
     },
     {
       "relation": "calls",
@@ -40608,7 +41220,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L32",
+      "source_location": "L34",
       "weight": 1.0,
       "source": "backend_internal_http_resources_decoderesourcebody",
       "target": "backend_internal_http_auth_decodejsonbody"
@@ -40830,6 +41442,28 @@
       "context": "parameter_type",
       "source": "backend_internal_http_auth_newauthserver",
       "target": "mail_mailer",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L296",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_categories_validatecategoryname",
+      "target": "http_apifielderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L122",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_resources_validateresourcename",
+      "target": "http_apifielderror",
       "confidence_score": 1.0
     },
     {
@@ -41403,6 +42037,39 @@
       "source": "backend_internal_http_auth_writeregistervalidationerror",
       "target": "backend_internal_http_auth_validationerror",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L253",
+      "weight": 1.0,
+      "source": "http_resourceserver_bulkdeletecategories",
+      "target": "backend_internal_http_auth_validationerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L95",
+      "weight": 1.0,
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_auth_validationerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_auth_validationerror"
     },
     {
       "relation": "references",
@@ -43208,6 +43875,1223 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L327",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories",
+      "target": "backend_internal_http_categories_categorynotfounderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L337",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories",
+      "target": "backend_internal_http_categories_duplicatecategorynameerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L311",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories",
+      "target": "backend_internal_http_categories_tocategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L304",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories",
+      "target": "backend_internal_http_categories_tocategorysummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L296",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories",
+      "target": "backend_internal_http_categories_validatecategoryname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories",
+      "target": "http_categoryinputbody",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L250",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_go_http_resourceserver",
+      "target": "http_resourceserver_bulkdeletecategories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L92",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_go_http_resourceserver",
+      "target": "http_resourceserver_createcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L215",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_go_http_resourceserver",
+      "target": "http_resourceserver_deletecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_go_http_resourceserver",
+      "target": "http_resourceserver_getcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_go_http_resourceserver",
+      "target": "http_resourceserver_listcategories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L159",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_go_http_resourceserver",
+      "target": "http_resourceserver_updatecategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L29",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_listcategories",
+      "target": "backend_internal_http_categories_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L29",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_listcategories",
+      "target": "backend_internal_http_categories_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "http_resourceserver_listcategories",
+      "target": "backend_internal_http_categories_tocategorysummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "http_resourceserver_listcategories",
+      "target": "backend_internal_http_resources_dberror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "http_resourceserver_listcategories",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L33",
+      "weight": 1.0,
+      "source": "http_resourceserver_listcategories",
+      "target": "backend_internal_http_resources_pguserid"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L250",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_bulkdeletecategories",
+      "target": "backend_internal_http_categories_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L92",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_categories_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L215",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_deletecategory",
+      "target": "backend_internal_http_categories_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_getcategory",
+      "target": "backend_internal_http_categories_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L159",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_categories_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L250",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_bulkdeletecategories",
+      "target": "backend_internal_http_categories_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L92",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_categories_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L215",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_deletecategory",
+      "target": "backend_internal_http_categories_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_getcategory",
+      "target": "backend_internal_http_categories_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L159",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_categories_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "http_resourceserver_getcategory",
+      "target": "backend_internal_http_categories_categorynotfounderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_getcategory",
+      "target": "backend_internal_http_categories_go_resourceid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L77",
+      "weight": 1.0,
+      "source": "http_resourceserver_getcategory",
+      "target": "backend_internal_http_categories_tocategorysummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L84",
+      "weight": 1.0,
+      "source": "http_resourceserver_getcategory",
+      "target": "backend_internal_http_resources_dberror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L83",
+      "weight": 1.0,
+      "source": "http_resourceserver_getcategory",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "http_resourceserver_getcategory",
+      "target": "backend_internal_http_resources_pguserid"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L215",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_deletecategory",
+      "target": "backend_internal_http_categories_go_resourceid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L159",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_categories_go_resourceid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L135",
+      "weight": 1.0,
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_categories_duplicatecategorynameerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L132",
+      "weight": 1.0,
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_categories_tocategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L100",
+      "weight": 1.0,
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_categories_validatecategoryname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L139",
+      "weight": 1.0,
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_resources_dberror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L94",
+      "weight": 1.0,
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_resources_decoderesourcebody"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L138",
+      "weight": 1.0,
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "http_resourceserver_createcategory",
+      "target": "backend_internal_http_resources_pguserid"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L198",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_categories_categorynotfounderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L201",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_categories_duplicatecategorynameerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L195",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_categories_tocategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L167",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_categories_validatecategoryname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L205",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_resources_dberror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L161",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_resources_decoderesourcebody"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L204",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L178",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatecategory",
+      "target": "backend_internal_http_resources_pguserid"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L237",
+      "weight": 1.0,
+      "source": "http_resourceserver_deletecategory",
+      "target": "backend_internal_http_categories_categorynotfounderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L241",
+      "weight": 1.0,
+      "source": "http_resourceserver_deletecategory",
+      "target": "backend_internal_http_resources_dberror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L240",
+      "weight": 1.0,
+      "source": "http_resourceserver_deletecategory",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L218",
+      "weight": 1.0,
+      "source": "http_resourceserver_deletecategory",
+      "target": "backend_internal_http_resources_pguserid"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L278",
+      "weight": 1.0,
+      "source": "http_resourceserver_bulkdeletecategories",
+      "target": "backend_internal_http_resources_dberror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L252",
+      "weight": 1.0,
+      "source": "http_resourceserver_bulkdeletecategories",
+      "target": "backend_internal_http_resources_decoderesourcebody"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L277",
+      "weight": 1.0,
+      "source": "http_resourceserver_bulkdeletecategories",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L269",
+      "weight": 1.0,
+      "source": "http_resourceserver_bulkdeletecategories",
+      "target": "backend_internal_http_resources_pguserid"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L297",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_validatecategoryname",
+      "target": "backend_internal_http_resources_validateresourcename"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L304",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_tocategorysummary",
+      "target": "backend_internal_http_categories_go_category",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L304",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_categories_tocategorysummary",
+      "target": "openapi_categorysummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L311",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_categories_tocategory",
+      "target": "backend_internal_http_categories_go_category",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L327",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_categories_categorynotfounderror",
+      "target": "openapi_categorynotfounderrorjsonresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories.go",
+      "source_location": "L337",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_categories_duplicatecategorynameerror",
+      "target": "openapi_duplicatecategorynameerrorjsonresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_assertcategorynotfound",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_assertduplicatecategoryname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L510",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_asserttransactionsurviveswithnullcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_createtestcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L483",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_seedtransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L263",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_testcategorieslive_crossuserisolation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L446",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_testcategorieslive_deletesetstransactioncategorynull",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L198",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_oncreate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L224",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_onupdate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L72",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_testcategorieslive_happypath_alloperations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L181",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_testcategorieslive_listempty_returnsemptyarraynotnull",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L244",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_testcategorieslive_notfound_nonexistent",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L327",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_testcategorieslive_unauthorized",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L386",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test",
+      "target": "backend_internal_http_categories_live_test_testcategorieslive_validation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L28",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_assertcategorynotfound",
+      "target": "backend_internal_http_categories_live_test_go_responserecorder",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L28",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_assertcategorynotfound",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L272",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_crossuserisolation",
+      "target": "backend_internal_http_categories_live_test_assertcategorynotfound",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L251",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_notfound_nonexistent",
+      "target": "backend_internal_http_categories_live_test_assertcategorynotfound",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L39",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_assertduplicatecategoryname",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L510",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_asserttransactionsurviveswithnullcategory",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L57",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_createtestcategory",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L483",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_seedtransaction",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L263",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_crossuserisolation",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L446",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_deletesetstransactioncategorynull",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L198",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_oncreate",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L224",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_onupdate",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L72",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_happypath_alloperations",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L181",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_listempty_returnsemptyarraynotnull",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L244",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_notfound_nonexistent",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L327",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_unauthorized",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L386",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_validation",
+      "target": "backend_internal_http_categories_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L39",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_assertduplicatecategoryname",
+      "target": "backend_internal_http_categories_live_test_go_responserecorder",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L206",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_oncreate",
+      "target": "backend_internal_http_categories_live_test_assertduplicatecategoryname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L233",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_onupdate",
+      "target": "backend_internal_http_categories_live_test_assertduplicatecategoryname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L268",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_crossuserisolation",
+      "target": "backend_internal_http_categories_live_test_createtestcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L451",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_deletesetstransactioncategorynull",
+      "target": "backend_internal_http_categories_live_test_createtestcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L202",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_oncreate",
+      "target": "backend_internal_http_categories_live_test_createtestcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L228",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_duplicatename_onupdate",
+      "target": "backend_internal_http_categories_live_test_createtestcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L167",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_happypath_alloperations",
+      "target": "backend_internal_http_categories_live_test_createtestcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L333",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_unauthorized",
+      "target": "backend_internal_http_categories_live_test_createtestcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L403",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_validation",
+      "target": "backend_internal_http_categories_live_test_createtestcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L460",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_deletesetstransactioncategorynull",
+      "target": "backend_internal_http_categories_live_test_asserttransactionsurviveswithnullcategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L453",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_testcategorieslive_deletesetstransactioncategorynull",
+      "target": "backend_internal_http_categories_live_test_seedtransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L483",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_seedtransaction",
+      "target": "backend_internal_http_categories_live_test_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L483",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_seedtransaction",
+      "target": "backend_internal_http_categories_live_test_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L510",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_asserttransactionsurviveswithnullcategory",
+      "target": "backend_internal_http_categories_live_test_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L510",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_categories_live_test_asserttransactionsurviveswithnullcategory",
+      "target": "backend_internal_http_categories_live_test_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/categories_live_test.go",
+      "source_location": "L517",
+      "weight": 1.0,
+      "source": "backend_internal_http_categories_live_test_asserttransactionsurviveswithnullcategory",
+      "target": "backend_internal_http_resources_pguserid"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/email_flows_live_test.go",
       "source_location": "L149",
       "weight": 1.0,
@@ -44304,7 +46188,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L90",
+      "source_location": "L99",
       "weight": 1.0,
       "source": "http_resourceserver_withuser",
       "target": "backend_internal_http_middleware_useridfromcontext"
@@ -44469,7 +46353,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L92",
+      "source_location": "L101",
       "weight": 1.0,
       "source": "http_resourceserver_withuser",
       "target": "backend_internal_http_middleware_writeunauthorizederror"
@@ -45231,7 +47115,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L111",
+      "source_location": "L140",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_dberror",
@@ -45241,7 +47125,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L31",
+      "source_location": "L33",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_decoderesourcebody",
@@ -45251,7 +47135,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L42",
+      "source_location": "L44",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_go_http_resourceserver",
@@ -45261,7 +47145,17 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L47",
+      "source_location": "L133",
+      "weight": 1.0,
+      "source": "backend_internal_http_resources",
+      "target": "backend_internal_http_resources_logresourceerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L49",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_newresourceserver",
@@ -45271,7 +47165,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L104",
+      "source_location": "L113",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_pguserid",
@@ -45281,7 +47175,17 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L70",
+      "source_location": "L122",
+      "weight": 1.0,
+      "source": "backend_internal_http_resources",
+      "target": "backend_internal_http_resources_validateresourcename",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L79",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_withresourceid",
@@ -45291,17 +47195,17 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L56",
+      "source_location": "L58",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
-      "target": "http_accountsservermethods",
+      "target": "http_resourceservermethods",
       "confidence_score": 1.0
     },
     {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L31",
+      "source_location": "L33",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_decoderesourcebody",
@@ -45312,7 +47216,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L31",
+      "source_location": "L33",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_decoderesourcebody",
@@ -45323,7 +47227,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L31",
+      "source_location": "L33",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_decoderesourcebody",
@@ -45334,7 +47238,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L70",
+      "source_location": "L79",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -45345,7 +47249,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L89",
+      "source_location": "L98",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -45356,7 +47260,18 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L70",
+      "source_location": "L133",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_resources_logresourceerror",
+      "target": "backend_internal_http_resources_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L79",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -45367,7 +47282,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L89",
+      "source_location": "L98",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -45378,7 +47293,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L43",
+      "source_location": "L45",
       "weight": 1.0,
       "context": "field",
       "source": "backend_internal_http_resources_go_http_resourceserver",
@@ -45389,7 +47304,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L89",
+      "source_location": "L98",
       "weight": 1.0,
       "source": "backend_internal_http_resources_go_http_resourceserver",
       "target": "http_resourceserver_withuser",
@@ -45399,7 +47314,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L47",
+      "source_location": "L49",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_newresourceserver",
@@ -45410,7 +47325,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L47",
+      "source_location": "L49",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_newresourceserver",
@@ -45421,7 +47336,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L70",
+      "source_location": "L79",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -45432,7 +47347,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L70",
+      "source_location": "L79",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -45454,7 +47369,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L89",
+      "source_location": "L98",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -45465,7 +47380,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L89",
+      "source_location": "L98",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -45476,7 +47391,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L104",
+      "source_location": "L113",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_pguserid",
@@ -45487,7 +47402,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L111",
+      "source_location": "L140",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_dberror",
@@ -75511,5 +77426,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "dbb52bcca31fb4df4a661fb01e8cea613709eb03"
+  "built_at_commit": "552a6b3337eecee44f541ea93592ac49d74a6530"
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -160,8 +160,8 @@
     "semantic_hash": ""
   },
   "backend/internal/http/router.go": {
-    "mtime": 1785295957.3746812,
-    "ast_hash": "4ad5369be08f75031dc785e4e7df1f4c",
+    "mtime": 1785297534.8347049,
+    "ast_hash": "9019405dedfd2632fa74953d9ef78f42",
     "semantic_hash": ""
   },
   "components.json": {
@@ -1240,8 +1240,8 @@
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0005-category-duplicate-update-500.md": {
-    "mtime": 1783742985.0225415,
-    "ast_hash": "7189807e1baa9d12447a80f759612924",
+    "mtime": 1785297816.0633097,
+    "ast_hash": "3ca1effceff479aa718196dc8ddfb53b",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0006-amount-int32-milliunit-cap.md": {
@@ -1485,8 +1485,8 @@
     "semantic_hash": ""
   },
   "backend/internal/http/accounts.go": {
-    "mtime": 1785295957.359138,
-    "ast_hash": "b23e480022b74d2d8cb5ef3d2cd6b3e6",
+    "mtime": 1785297541.1888335,
+    "ast_hash": "90a2f62231fe98ac838506f3d100c83d",
     "semantic_hash": ""
   },
   "backend/internal/http/accounts_live_test.go": {
@@ -1495,8 +1495,8 @@
     "semantic_hash": ""
   },
   "backend/internal/http/resources.go": {
-    "mtime": 1785295957.372681,
-    "ast_hash": "f55b29f3d371b612fd22935c4d1f5e6c",
+    "mtime": 1785297526.6946864,
+    "ast_hash": "0b2d8677ebda54fd42bc8b9072333294",
     "semantic_hash": ""
   },
   "backend/internal/id/cuid2.go": {
@@ -1512,6 +1512,16 @@
   "post-migration-improvements/claude-backend-improvements/0013-no-request-body-size-cap-on-resource-endpoints.md": {
     "mtime": 1785295957.3943532,
     "ast_hash": "971125d26b3207e86db94ba74797ed99",
+    "semantic_hash": ""
+  },
+  "backend/internal/http/categories.go": {
+    "mtime": 1785297476.7353084,
+    "ast_hash": "5b0189e0f4f2d1a284fd7626828bc12b",
+    "semantic_hash": ""
+  },
+  "backend/internal/http/categories_live_test.go": {
+    "mtime": 1785297786.2536402,
+    "ast_hash": "35a4159d0d68143caf47847f860414bb",
     "semantic_hash": ""
   }
 }

--- a/post-migration-improvements/claude-backend-improvements/0005-category-duplicate-update-500.md
+++ b/post-migration-improvements/claude-backend-improvements/0005-category-duplicate-update-500.md
@@ -32,9 +32,23 @@ the API surface.
 
 ## Proposed improvement
 
-Make duplicate-name update return `409` with the same error shape as
-duplicate-name create — the Go query layer already surfaces the unique
-violation (SQLSTATE 23505) cleanly, so the handler change is trivial. Needs
-a coordinated OpenAPI + fixtures + frontend-toast update, hence post-parity.
-Should be among the first optimization tickets: user-visible, low effort,
-removes a false-alarm class from error monitoring.
+**Resolved during the migration — this entry is closed, kept for history.**
+
+The contract was the deciding authority per `spec.md` line 104 ("Decide
+current mismatches explicitly in OpenAPI instead of inheriting them
+accidentally, especially category duplicate update returning `500` while
+category duplicate create returns `409`"), and `updateCategory` in
+`openapi/nuchi.openapi.json` declares `409` with the shared
+`DuplicateCategoryNameError` shape. #45 therefore shipped `409`, matching
+duplicate-name create, rather than porting the legacy `500`.
+
+This is the one deliberate behavior divergence in #45. It is not a parity
+break: parity defers to the contract where the contract made an explicit
+decision, which is exactly what the spec line above instructed. Frozen by
+`TestCategoriesLive_DuplicateName_OnUpdate`, which covers both the exact and
+case-differing (citext) collisions and fails if the handler regresses to
+`500`.
+
+Fixtures line 321 still documents the legacy `500` as *current Hono*
+behavior; that description stays accurate for the legacy stack until #27
+removes it.


### PR DESCRIPTION
Closes #45.

Adds the six category endpoints, following the pattern #44 established. Most of this diff is deliberately symmetric with accounts; the value is in the two places categories genuinely differ.

## Endpoints

`GET|POST /api/categories`, `GET|PATCH|DELETE /api/categories/{id}`, `POST /api/categories/bulk-delete` — all inside the `RequireAuth` group, every query through `db.WithUserTx`.

## Structure

Handlers are methods on the existing `ResourceServer`, not a new type, reusing `withUser`, `withResourceID`, `decodeResourceBody`, `pgUserID`, `dbError`, `isUniqueViolation` and `constraintName` unchanged. Two helpers that were accounts-shaped but not accounts-specific moved to `resources.go` as `validateResourceName` and `logResourceError`; `accountsServerMethods` became `resourceServerMethods` and now covers both resources, so #46-#48 stay additive.

Carried over from #44 without change: identity only from `UserIDFromContext`, no `dbgen.New(pool)`, SQL ownership predicates alongside RLS, cuid2 ids via `internal/id`, no request-body cap, `[]` rather than `null` for empty collections, driver errors logged server-side only.

## The two real differences

**1. Duplicate-name PATCH returns 409, not legacy's 500.** Legacy `categories.ts` wraps its UPDATE in a bare `catch` with no `23505` branch, so renaming a category onto an existing name surfaces as a server error (fixtures line 321). `spec.md` line 104 requires this specific mismatch to be *decided in OpenAPI instead of inherited accidentally*, and `updateCategory` declares 409 with the shared `DuplicateCategoryNameError` shape. This PR ships 409 and updates post-migration improvement 0005 to record that the contract resolved it. Frozen by `TestCategoriesLive_DuplicateName_OnUpdate` (exact + case-differing).

**2. Category delete nulls transactions rather than deleting them.** `transactions.category_id` is `ON DELETE SET NULL`, the inverse of `account_id`'s `ON DELETE CASCADE`. `TestCategoriesLive_DeleteSetsTransactionCategoryNull` covers **both** delete paths and asserts the transaction *survives* with a null category — a test asserting only "the transaction is gone" would pass for the wrong reason here.

While writing that test, seeding a transaction through a bare pool was correctly rejected by RLS (`SQLSTATE 42501`, `transactions_owner`'s WITH CHECK needs a bound `app.user_id`). The seed helper now goes through `WithUserTx`, same as the request path.

## Verification

- `go build ./...`, `go vet ./...` — clean.
- `go test ./... -count=1` against live PostgreSQL — all packages pass, `internal/http` 9.4s. Every `TestCategoriesLive_*` group confirmed executing, not skipping.
- `bun run openapi:validate` — 28 operations, contract untouched (no contract change needed).

Coverage: all six operations with exact bodies, empty list as raw `{"data":[]}`, duplicates on create and update (both case variants), 404 for missing ids, cross-user isolation (by-id 404s, list exclusion, mixed-owner bulk-delete, B's row surviving), unauthorized across four failure modes on all six routes, validation including the large-body-accepted guard, and the FK behavior above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)