### PR TITLE
[Issue - #48] Implement summary API parity

### DIFF
--- a/backend/internal/db/rls.go
+++ b/backend/internal/db/rls.go
@@ -6,6 +6,7 @@ import (
 
 	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -35,7 +36,21 @@ import (
 // easy to ship by accident, which is why every owned-resource query must
 // route through this helper instead.
 func WithUserTx(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, fn func(*dbgen.Queries) error) error {
-	tx, err := pool.Begin(ctx)
+	return WithUserTxOptions(ctx, pool, userID, pgx.TxOptions{}, fn)
+}
+
+// WithUserTxOptions is WithUserTx with explicit transaction semantics.
+// Callers that issue several related reads can request RepeatableRead so every
+// statement observes one database snapshot while retaining the same mandatory
+// transaction-local RLS binding.
+func WithUserTxOptions(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	userID uuid.UUID,
+	options pgx.TxOptions,
+	fn func(*dbgen.Queries) error,
+) error {
+	tx, err := pool.BeginTx(ctx, options)
 	if err != nil {
 		return fmt.Errorf("db: begin user tx: %w", err)
 	}

--- a/backend/internal/db/rls_test.go
+++ b/backend/internal/db/rls_test.go
@@ -267,6 +267,76 @@ func TestWithUserTx_RollsBackOnError_LiveDatabase(t *testing.T) {
 	}
 }
 
+// TestWithUserTxOptions_RepeatableReadUsesOneSnapshot_LiveDatabase proves the
+// option used by the summary handler, rather than merely checking a constant.
+// A row committed between two reads must stay outside the reader's snapshot
+// until that repeatable-read transaction ends.
+func TestWithUserTxOptions_RepeatableReadUsesOneSnapshot_LiveDatabase(t *testing.T) {
+	databaseURL := liveDatabaseURL(t, "WithUserTxOptions repeatable-read test")
+
+	ctx := context.Background()
+	pool, err := NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("expected successful connection, got error: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	userID := createRLSTestUser(ctx, t, pool, "withusertx-repeatable-read")
+	t.Cleanup(func() { deleteRLSTestUsers(ctx, t, pool, userID) })
+
+	owner := pgtype.UUID{Bytes: [16]byte(userID), Valid: true}
+	accountID := "wut-repeatable-" + uuid.NewString()
+
+	err = WithUserTxOptions(ctx, pool, userID, pgx.TxOptions{IsoLevel: pgx.RepeatableRead}, func(q *dbgen.Queries) error {
+		before, err := q.ListAccounts(ctx, owner)
+		if err != nil {
+			return fmt.Errorf("first snapshot read: %w", err)
+		}
+		if len(before) != 0 {
+			return fmt.Errorf("first snapshot read: expected no accounts, got %d", len(before))
+		}
+
+		writeDone := make(chan error, 1)
+		go func() {
+			writeDone <- WithUserTx(ctx, pool, userID, func(writeQueries *dbgen.Queries) error {
+				_, err := writeQueries.CreateAccount(ctx, dbgen.CreateAccountParams{
+					ID: accountID, Name: "Committed Between Reads", UserID: owner,
+				})
+				return err
+			})
+		}()
+		if err := <-writeDone; err != nil {
+			return fmt.Errorf("concurrent account insert: %w", err)
+		}
+
+		after, err := q.ListAccounts(ctx, owner)
+		if err != nil {
+			return fmt.Errorf("second snapshot read: %w", err)
+		}
+		if len(after) != 0 {
+			return fmt.Errorf("repeatable-read snapshot changed: expected 0 accounts, got %d", len(after))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("repeatable-read transaction: %v", err)
+	}
+
+	err = WithUserTx(ctx, pool, userID, func(q *dbgen.Queries) error {
+		accounts, err := q.ListAccounts(ctx, owner)
+		if err != nil {
+			return err
+		}
+		if len(accounts) != 1 || accounts[0].ID != accountID {
+			return fmt.Errorf("expected committed account %q after snapshot ended, got %+v", accountID, accounts)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("post-snapshot read: %v", err)
+	}
+}
+
 // TestVerifyRLSActive_PassesForOrdinaryRole_LiveDatabase is the positive half
 // of the startup guard: the ordinary application role the migrations run as
 // has RLS active on every owned table, so VerifyRLSActive accepts it.

--- a/backend/internal/http/resources.go
+++ b/backend/internal/http/resources.go
@@ -16,6 +16,7 @@ import (
 	"github.com/GonzaloSecades/nuchi/backend/internal/ratelimit"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -254,13 +255,26 @@ func withSummaryParams(fn func(w http.ResponseWriter, r *http.Request, params op
 // 6.4) against ever binding app.user_id to the zero UUID. Callers must
 // check ok before using err.
 func (s *ResourceServer) withUser(w http.ResponseWriter, r *http.Request, fn func(userID uuid.UUID, q *dbgen.Queries) error) (err error, ok bool) {
+	return s.withUserTxOptions(w, r, pgx.TxOptions{}, fn)
+}
+
+// withUserTxOptions is withUser with explicit transaction options. Most
+// resource operations use PostgreSQL's defaults through withUser; aggregate
+// read models can opt into a stable snapshot without bypassing the shared RLS
+// binding path.
+func (s *ResourceServer) withUserTxOptions(
+	w http.ResponseWriter,
+	r *http.Request,
+	options pgx.TxOptions,
+	fn func(userID uuid.UUID, q *dbgen.Queries) error,
+) (err error, ok bool) {
 	userID, ok := UserIDFromContext(r.Context())
 	if !ok {
 		writeUnauthorizedError(w)
 		return nil, false
 	}
 
-	err = db.WithUserTx(r.Context(), s.pool, userID, func(q *dbgen.Queries) error {
+	err = db.WithUserTxOptions(r.Context(), s.pool, userID, options, func(q *dbgen.Queries) error {
 		return fn(userID, q)
 	})
 	return err, true

--- a/backend/internal/http/resources.go
+++ b/backend/internal/http/resources.go
@@ -217,7 +217,11 @@ func accountIDFilter(accountID *string) (pgtype.Text, error) {
 		return pgtype.Text{}, nil
 	}
 	if *accountID == "" {
-		return pgtype.Text{}, dateRangeError{"accountId must not be empty."}
+		// A plain error, not dateRangeError: that type is documented as carrying
+		// one of the three date-range messages, and widening it to cover
+		// accountId would make its own documentation untrue. The response is
+		// identical either way -- the caller only reads Error().
+		return pgtype.Text{}, errors.New("accountId must not be empty.")
 	}
 	return pgtype.Text{String: *accountID, Valid: true}, nil
 }

--- a/backend/internal/http/resources.go
+++ b/backend/internal/http/resources.go
@@ -153,6 +153,8 @@ type resourceServerMethods interface {
 	DeleteTransaction(w http.ResponseWriter, r *http.Request, id openapi.ResourceId)
 	BulkCreateTransactions(w http.ResponseWriter, r *http.Request)
 	BulkDeleteTransactions(w http.ResponseWriter, r *http.Request)
+
+	GetSummary(w http.ResponseWriter, r *http.Request, params openapi.GetSummaryParams)
 }
 
 var _ resourceServerMethods = (*ResourceServer)(nil)
@@ -200,6 +202,38 @@ func optionalQueryParam(query url.Values, key string) *string {
 	}
 	value := query.Get(key)
 	return &value
+}
+
+// accountIDFilter converts the optional accountId query parameter into the
+// nullable value the transaction and summary queries take.
+//
+// nil means the parameter was omitted, so no filter applies. A present but
+// empty value is rejected: accountId references ResourceId (minLength 1), so
+// `?accountId=` is malformed for the same reason `?from=` is, rather than
+// silently meaning "no filter". Shared by ListTransactions and GetSummary so
+// the two cannot drift.
+func accountIDFilter(accountID *string) (pgtype.Text, error) {
+	if accountID == nil {
+		return pgtype.Text{}, nil
+	}
+	if *accountID == "" {
+		return pgtype.Text{}, dateRangeError{"accountId must not be empty."}
+	}
+	return pgtype.Text{String: *accountID, Valid: true}, nil
+}
+
+// withSummaryParams adapts the generated (w, r, params) signature to a plain
+// chi handler. Like the transaction list, from/to are left for the handler to
+// read raw — openapi_types.Date cannot carry a malformed value, and the three
+// INVALID_QUERY messages exist precisely for those inputs.
+func withSummaryParams(fn func(w http.ResponseWriter, r *http.Request, params openapi.GetSummaryParams)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var params openapi.GetSummaryParams
+		if accountID := optionalQueryParam(r.URL.Query(), "accountId"); accountID != nil {
+			params.AccountId = accountID
+		}
+		fn(w, r, params)
+	}
 }
 
 // withUser resolves the authenticated user id from r's context and, if

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -73,6 +73,8 @@ func NewRouter(authServer *AuthServer, resources *ResourceServer) http.Handler {
 					r.Patch("/{id}", withResourceID(resources.UpdateTransaction))
 					r.Delete("/{id}", withResourceID(resources.DeleteTransaction))
 				})
+
+				r.Get("/api/summary", withSummaryParams(resources.GetSummary))
 			}
 		})
 	}

--- a/backend/internal/http/summary.go
+++ b/backend/internal/http/summary.go
@@ -1,0 +1,222 @@
+package httpapi
+
+import (
+	"net/http"
+	"time"
+
+	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
+	"github.com/GonzaloSecades/nuchi/backend/internal/openapi"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// maxSummaryCategories is how many expense categories are returned
+// individually. Anything past this is summed into a single "Other" entry, so
+// the chart stays readable regardless of how many categories a user has.
+const maxSummaryCategories = 3
+
+// otherCategoryName is the label for that bucket. It is a literal rather than
+// a translated string because legacy emits exactly this and the frontend
+// matches on it.
+const otherCategoryName = "Other"
+
+// GetSummary implements GET /api/summary.
+//
+// Four queries run inside one WithUserTx: current-period totals, the previous
+// period's totals for the change percentages, the category breakdown, and the
+// per-day series. Sharing a transaction gives all four one RLS binding and a
+// consistent snapshot — legacy fires them independently, so a write landing
+// mid-request can make its totals disagree with its own daily series.
+//
+// The aggregation itself is deliberately split: SQL sums, Go shapes. Bucketing
+// and zero-filling stay here because they are presentation decisions, and
+// because that is where legacy does them (lib/utils.ts), so the arithmetic can
+// be compared line for line.
+func (s *ResourceServer) GetSummary(w http.ResponseWriter, r *http.Request, params openapi.GetSummaryParams) {
+	query := r.URL.Query()
+	start, end, dateErr := parseDateRange(
+		optionalQueryParam(query, "from"),
+		optionalQueryParam(query, "to"),
+		s.now(),
+	)
+	if dateErr != nil {
+		resp := openapi.GetSummary400JSONResponse{InvalidQueryErrorJSONResponse: invalidDateQueryError(dateErr)}
+		_ = resp.VisitGetSummaryResponse(w)
+		return
+	}
+
+	accountID, accountErr := accountIDFilter(params.AccountId)
+	if accountErr != nil {
+		resp := openapi.GetSummary400JSONResponse{InvalidQueryErrorJSONResponse: invalidQueryError(accountErr.Error())}
+		_ = resp.VisitGetSummaryResponse(w)
+		return
+	}
+
+	// The comparison window is the same length as the selected one, immediately
+	// before it — not the previous calendar month. Legacy computes it as
+	// differenceInCalendarDays(end, start) + 1 and subtracts that from both
+	// ends, so a 30-day view compares against the 30 days before it.
+	periodLength := calendarDaysBetween(start, end) + 1
+	previousStart := start.AddDate(0, 0, -periodLength)
+	previousEnd := end.AddDate(0, 0, -periodLength)
+
+	var current, previous dbgen.GetPeriodTotalsRow
+	var categoryRows []dbgen.GetCategorySpendingRow
+	var dailyRows []dbgen.GetDailyTotalsRow
+
+	err, ok := s.withUser(w, r, func(userID uuid.UUID, q *dbgen.Queries) error {
+		var err error
+		current, err = q.GetPeriodTotals(r.Context(), dbgen.GetPeriodTotalsParams{
+			UserID:    pgUserID(userID),
+			StartDate: pgTimestamp(start),
+			EndDate:   pgTimestamp(end),
+			AccountID: accountID,
+		})
+		if err != nil {
+			return err
+		}
+
+		previous, err = q.GetPeriodTotals(r.Context(), dbgen.GetPeriodTotalsParams{
+			UserID:    pgUserID(userID),
+			StartDate: pgTimestamp(previousStart),
+			EndDate:   pgTimestamp(previousEnd),
+			AccountID: accountID,
+		})
+		if err != nil {
+			return err
+		}
+
+		categoryRows, err = q.GetCategorySpending(r.Context(), dbgen.GetCategorySpendingParams{
+			UserID:    pgUserID(userID),
+			StartDate: pgTimestamp(start),
+			EndDate:   pgTimestamp(end),
+			AccountID: accountID,
+		})
+		if err != nil {
+			return err
+		}
+
+		dailyRows, err = q.GetDailyTotals(r.Context(), dbgen.GetDailyTotalsParams{
+			UserID:    pgUserID(userID),
+			StartDate: pgTimestamp(start),
+			EndDate:   pgTimestamp(end),
+			AccountID: accountID,
+		})
+		return err
+	})
+	if !ok {
+		return
+	}
+	if err != nil {
+		logResourceError(r, "fetch summary", err)
+		resp := openapi.GetSummary500JSONResponse{DatabaseErrorJSONResponse: dbError("DatabaseError - Failed to fetch summary")}
+		_ = resp.VisitGetSummaryResponse(w)
+		return
+	}
+
+	resp := openapi.GetSummary200JSONResponse{Data: openapi.Summary{
+		RemainingAmount: current.Remaining,
+		RemainingChange: percentageChange(current.Remaining, previous.Remaining),
+		IncomeAmount:    current.Income,
+		IncomeChange:    percentageChange(current.Income, previous.Income),
+		ExpensesAmount:  current.Expenses,
+		ExpensesChange:  percentageChange(current.Expenses, previous.Expenses),
+		Categories:      bucketCategories(categoryRows),
+		Days:            fillMissingDays(dailyRows, start, end),
+	}}
+	_ = resp.VisitGetSummaryResponse(w)
+}
+
+// percentageChange ports lib/utils.ts calculatePercentageChange exactly.
+//
+// The zero rule is the part worth stating: when the previous period is 0 the
+// ratio is undefined, and legacy answers 0 if the current period is also 0 and
+// 100 otherwise. That is a product decision ("everything is new growth"),
+// not a divide-by-zero guard bolted on afterwards, so both branches are
+// deliberate.
+//
+// This is the one place in the money path that returns a float. It is a ratio,
+// not an amount — amounts stay integer milliunits everywhere.
+func percentageChange(current, previous int64) float32 {
+	if previous == 0 {
+		if current == 0 {
+			return 0
+		}
+		return 100
+	}
+	return float32(float64(current-previous) / float64(previous) * 100)
+}
+
+// bucketCategories returns the largest maxSummaryCategories entries as-is and
+// folds everything past them into a single "Other" row.
+//
+// The query already orders by value descending, so this is a slice rather than
+// a sort. With exactly maxSummaryCategories entries there is no remainder and
+// no "Other" row is added — the boundary legacy also has.
+//
+// Note what the query excludes and this therefore inherits: only negative
+// amounts, and only those with a category. Uncategorized spending is absent
+// from this breakdown while still counted in expensesAmount, so the chart does
+// not sum to the expenses total. That is legacy behavior, ported deliberately
+// and recorded as post-migration improvement 0017.
+func bucketCategories(rows []dbgen.GetCategorySpendingRow) []openapi.SummaryCategory {
+	categories := make([]openapi.SummaryCategory, 0, min(len(rows), maxSummaryCategories)+1)
+
+	for i, row := range rows {
+		if i >= maxSummaryCategories {
+			break
+		}
+		categories = append(categories, openapi.SummaryCategory{Name: row.Name, Value: row.Value})
+	}
+
+	if len(rows) <= maxSummaryCategories {
+		return categories
+	}
+
+	var other int64
+	for _, row := range rows[maxSummaryCategories:] {
+		other += row.Value
+	}
+	return append(categories, openapi.SummaryCategory{Name: otherCategoryName, Value: other})
+}
+
+// fillMissingDays returns one entry per calendar day in [start, end], using the
+// queried totals where a day has transactions and zeros where it does not.
+//
+// Ports lib/utils.ts fillMissingDays. The chart needs a continuous series: a
+// gap would otherwise be drawn as a line straight from one active day to the
+// next, implying activity that did not happen.
+//
+// Keyed by yyyy-MM-dd in UTC, matching the query's GROUP BY t.date::date. That
+// cast is load-bearing rather than cosmetic — grouping by the raw timestamp
+// would split one calendar day into several rows if any write path ever stored
+// a time of day, and this map would then keep only the last of them.
+func fillMissingDays(rows []dbgen.GetDailyTotalsRow, start, end time.Time) []openapi.SummaryDay {
+	totals := make(map[string]dbgen.GetDailyTotalsRow, len(rows))
+	for _, row := range rows {
+		totals[row.Day.Time.UTC().Format(time.DateOnly)] = row
+	}
+
+	// Day boundaries, not the raw range: `end` is the last instant of its day,
+	// so iterating from midnight to midnight covers every day inclusively.
+	day := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+	last := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, time.UTC)
+
+	days := make([]openapi.SummaryDay, 0, calendarDaysBetween(start, end)+1)
+	for !day.After(last) {
+		entry := openapi.SummaryDay{Date: day}
+		if row, found := totals[day.Format(time.DateOnly)]; found {
+			entry.Income = row.Income
+			entry.Expenses = row.Expenses
+		}
+		days = append(days, entry)
+		day = day.AddDate(0, 0, 1)
+	}
+	return days
+}
+
+// pgTimestamp converts a UTC instant into the pgtype.Timestamp the summary
+// query parameters expect.
+func pgTimestamp(at time.Time) pgtype.Timestamp {
+	return pgtype.Timestamp{Time: at, Valid: true}
+}

--- a/backend/internal/http/summary.go
+++ b/backend/internal/http/summary.go
@@ -7,6 +7,7 @@ import (
 	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
 	"github.com/GonzaloSecades/nuchi/backend/internal/openapi"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -24,9 +25,10 @@ const otherCategoryName = "Other"
 //
 // Four queries run inside one WithUserTx: current-period totals, the previous
 // period's totals for the change percentages, the category breakdown, and the
-// per-day series. Sharing a transaction gives all four one RLS binding and a
-// consistent snapshot — legacy fires them independently, so a write landing
-// mid-request can make its totals disagree with its own daily series.
+// per-day series. The transaction uses repeatable-read isolation, giving all
+// four one RLS binding and one snapshot — legacy fires them independently, so
+// a write landing mid-request can make its totals disagree with its own daily
+// series.
 //
 // The aggregation itself is deliberately split: SQL sums, Go shapes. Bucketing
 // and zero-filling stay here because they are presentation decisions, and
@@ -64,7 +66,7 @@ func (s *ResourceServer) GetSummary(w http.ResponseWriter, r *http.Request, para
 	var categoryRows []dbgen.GetCategorySpendingRow
 	var dailyRows []dbgen.GetDailyTotalsRow
 
-	err, ok := s.withUser(w, r, func(userID uuid.UUID, q *dbgen.Queries) error {
+	err, ok := s.withUserTxOptions(w, r, pgx.TxOptions{IsoLevel: pgx.RepeatableRead}, func(userID uuid.UUID, q *dbgen.Queries) error {
 		var err error
 		current, err = q.GetPeriodTotals(r.Context(), dbgen.GetPeriodTotalsParams{
 			UserID:    pgUserID(userID),
@@ -144,7 +146,9 @@ func percentageChange(current, previous int64) float32 {
 		}
 		return 100
 	}
-	return float32(float64(current-previous) / float64(previous) * 100)
+	// Widen before subtracting: current-previous can overflow int64 even though
+	// each operand is valid on its own.
+	return float32((float64(current) - float64(previous)) / float64(previous) * 100)
 }
 
 // bucketCategories returns the largest maxSummaryCategories entries as-is and

--- a/backend/internal/http/summary_live_test.go
+++ b/backend/internal/http/summary_live_test.go
@@ -1,0 +1,363 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GonzaloSecades/nuchi/backend/internal/auth"
+	"github.com/GonzaloSecades/nuchi/backend/internal/openapi"
+	"github.com/google/uuid"
+)
+
+// getSummary issues a summary request and decodes it, failing on anything but
+// 200.
+func getSummary(t *testing.T, env transactionsTestEnv, token, query string) openapi.Summary {
+	t.Helper()
+	rec := env.do(t, http.MethodGet, "/api/summary"+query, token, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("summary%s: expected 200, got %d (body: %s)", query, rec.Code, rec.Body.String())
+	}
+	var parsed openapi.SummaryResponse
+	if err := json.NewDecoder(rec.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	return parsed.Data
+}
+
+// seedSummaryTransaction creates a transaction on the given date through the
+// API, so it travels the same validated path a real client would.
+func seedSummaryTransaction(t *testing.T, env transactionsTestEnv, token, accountID, date string, amount int64, categoryID *string) {
+	t.Helper()
+	body := validTransactionBody(accountID)
+	body.Date = date
+	body.Amount = amount
+	body.CategoryID = categoryID
+	createTestTransaction(t, env, token, body)
+}
+
+func TestSummaryLive_Totals(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "summary-totals")
+	accountID := createTestAccount(t, env.accountsTestEnv, token, "Cash")
+
+	// Inside the default 30-day window ending at the pinned clock (2026-07-29).
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-20", 500000, nil) // income
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-21", -12500, nil) // expense
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-22", -7500, nil)  // expense
+
+	got := getSummary(t, env, token, "")
+
+	if got.IncomeAmount != 500000 {
+		t.Errorf("expected income 500000, got %d", got.IncomeAmount)
+	}
+	// expenses is the sum of absolute values of negative amounts.
+	if got.ExpensesAmount != 20000 {
+		t.Errorf("expected expenses 20000, got %d", got.ExpensesAmount)
+	}
+	// remaining is the signed sum, so income minus expenses.
+	if got.RemainingAmount != 480000 {
+		t.Errorf("expected remaining 480000, got %d", got.RemainingAmount)
+	}
+}
+
+// TestSummaryLive_EmptyStateIsZerosAndFilledDays covers what the dashboard
+// renders for a brand-new user: zeros rather than nulls, an empty category
+// list, and a fully populated day series so the chart still draws a flat line.
+func TestSummaryLive_EmptyStateIsZerosAndFilledDays(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "summary-empty")
+
+	rec := env.do(t, http.MethodGet, "/api/summary", token, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	raw := rec.Body.String()
+
+	var parsed openapi.SummaryResponse
+	if err := json.NewDecoder(strings.NewReader(raw)).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := parsed.Data
+
+	for name, value := range map[string]int64{
+		"remainingAmount": got.RemainingAmount,
+		"incomeAmount":    got.IncomeAmount,
+		"expensesAmount":  got.ExpensesAmount,
+	} {
+		if value != 0 {
+			t.Errorf("%s: expected 0 for an empty period, got %d", name, value)
+		}
+	}
+	for name, value := range map[string]float32{
+		"remainingChange": got.RemainingChange,
+		"incomeChange":    got.IncomeChange,
+		"expensesChange":  got.ExpensesChange,
+	} {
+		if value != 0 {
+			t.Errorf("%s: expected 0 when both periods are empty, got %v", name, value)
+		}
+	}
+
+	// Arrays must be [] on the wire, never null — the dashboard maps over both.
+	if !strings.Contains(raw, `"categories":[]`) {
+		t.Errorf("expected categories to serialize as [], got %s", raw)
+	}
+	// 31 days: the default 30-day window is inclusive at both ends.
+	if len(got.Days) != 31 {
+		t.Errorf("expected the default range fully zero-filled (31 days), got %d", len(got.Days))
+	}
+	for _, day := range got.Days {
+		if day.Income != 0 || day.Expenses != 0 {
+			t.Errorf("expected a zero day, got %+v", day)
+		}
+	}
+}
+
+// TestSummaryLive_ChangeComparesThePrecedingWindow pins that the comparison
+// period is the same length immediately before the selected one, rather than
+// the previous calendar month.
+func TestSummaryLive_ChangeComparesThePrecedingWindow(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "summary-change")
+	accountID := createTestAccount(t, env.accountsTestEnv, token, "Cash")
+
+	// Selected window is 2026-07-11..2026-07-20 (10 days), so the comparison
+	// window is 2026-07-01..2026-07-10.
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-15", 200000, nil) // current
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-05", 100000, nil) // previous
+
+	got := getSummary(t, env, token, "?from=2026-07-11&to=2026-07-20")
+
+	if got.IncomeAmount != 200000 {
+		t.Errorf("expected only the current window's income, got %d", got.IncomeAmount)
+	}
+	// 200000 vs 100000 is +100%.
+	if got.IncomeChange != 100 {
+		t.Errorf("expected incomeChange 100, got %v", got.IncomeChange)
+	}
+}
+
+func TestSummaryLive_ChangeIs100WhenPreviousPeriodIsEmpty(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "summary-change-empty")
+	accountID := createTestAccount(t, env.accountsTestEnv, token, "Cash")
+
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-15", 200000, nil)
+
+	got := getSummary(t, env, token, "?from=2026-07-11&to=2026-07-20")
+	if got.IncomeChange != 100 {
+		t.Errorf("expected 100 when the previous period had nothing, got %v", got.IncomeChange)
+	}
+	if got.ExpensesChange != 0 {
+		t.Errorf("expected 0 when both periods had no expenses, got %v", got.ExpensesChange)
+	}
+}
+
+// TestSummaryLive_CategoryBreakdown covers the bucketing against real data,
+// including the two exclusions that make the chart disagree with the expenses
+// total.
+func TestSummaryLive_CategoryBreakdown(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "summary-categories")
+	accountID := createTestAccount(t, env.accountsTestEnv, token, "Cash")
+
+	ids := make([]string, 0, 4)
+	for _, name := range []string{"Rent", "Food", "Transport", "Books"} {
+		id := createTestCategory(t, env.accountsTestEnv, token, name)
+		ids = append(ids, id)
+	}
+
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-20", -90000, &ids[0])
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-20", -50000, &ids[1])
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-20", -10000, &ids[2])
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-20", -4000, &ids[3])
+	// Excluded from the breakdown but still counted in expensesAmount.
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-20", -1000, nil)
+	// Income is never in the breakdown at all.
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-20", 300000, &ids[0])
+
+	got := getSummary(t, env, token, "")
+
+	if len(got.Categories) != 4 {
+		t.Fatalf("expected 3 categories plus Other, got %d: %+v", len(got.Categories), got.Categories)
+	}
+	if got.Categories[0].Name != "Rent" || got.Categories[0].Value != 90000 {
+		t.Errorf("expected Rent=90000 first (ordered by value), got %+v", got.Categories[0])
+	}
+	last := got.Categories[len(got.Categories)-1]
+	if last.Name != "Other" || last.Value != 4000 {
+		t.Errorf("expected Other=4000, got %+v", last)
+	}
+
+	// The uncategorized 1000 is in the total but not the chart, and the income
+	// on a category does not appear either. This is legacy behavior, recorded
+	// as improvement 0017.
+	if got.ExpensesAmount != 155000 {
+		t.Errorf("expected expenses to include the uncategorized 1000 (155000), got %d", got.ExpensesAmount)
+	}
+	var charted int64
+	for _, c := range got.Categories {
+		charted += c.Value
+	}
+	if charted != 154000 {
+		t.Errorf("expected the chart to sum to 154000, excluding uncategorized, got %d", charted)
+	}
+}
+
+func TestSummaryLive_DailySeries(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "summary-days")
+	accountID := createTestAccount(t, env.accountsTestEnv, token, "Cash")
+
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-11", 100000, nil)
+	seedSummaryTransaction(t, env, token, accountID, "2026-07-13", -25000, nil)
+
+	got := getSummary(t, env, token, "?from=2026-07-11&to=2026-07-15")
+
+	if len(got.Days) != 5 {
+		t.Fatalf("expected 5 inclusive days, got %d", len(got.Days))
+	}
+	byDay := make(map[string]openapi.SummaryDay, len(got.Days))
+	for _, day := range got.Days {
+		byDay[day.Date.Format(time.DateOnly)] = day
+	}
+	if d := byDay["2026-07-11"]; d.Income != 100000 || d.Expenses != 0 {
+		t.Errorf("2026-07-11: expected income 100000, got %+v", d)
+	}
+	if d := byDay["2026-07-13"]; d.Expenses != 25000 || d.Income != 0 {
+		t.Errorf("2026-07-13: expected expenses 25000, got %+v", d)
+	}
+	for _, gap := range []string{"2026-07-12", "2026-07-14", "2026-07-15"} {
+		if d, ok := byDay[gap]; !ok {
+			t.Errorf("%s missing from the series", gap)
+		} else if d.Income != 0 || d.Expenses != 0 {
+			t.Errorf("%s: expected a zero-filled day, got %+v", gap, d)
+		}
+	}
+}
+
+func TestSummaryLive_AccountFilter(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "summary-accfilter")
+	cash := createTestAccount(t, env.accountsTestEnv, token, "Cash")
+	savings := createTestAccount(t, env.accountsTestEnv, token, "Savings")
+
+	seedSummaryTransaction(t, env, token, cash, "2026-07-20", 100000, nil)
+	seedSummaryTransaction(t, env, token, savings, "2026-07-20", 400000, nil)
+
+	t.Run("narrows to the named account", func(t *testing.T) {
+		got := getSummary(t, env, token, "?accountId="+cash)
+		if got.IncomeAmount != 100000 {
+			t.Errorf("expected only Cash income 100000, got %d", got.IncomeAmount)
+		}
+	})
+
+	// An account the caller does not own yields zeros rather than a 404: the
+	// join simply matches nothing, and confirming the account exists would leak
+	// another user's data.
+	t.Run("an unowned account yields zeros, not 404", func(t *testing.T) {
+		got := getSummary(t, env, token, "?accountId=does-not-exist")
+		if got.IncomeAmount != 0 || got.ExpensesAmount != 0 || got.RemainingAmount != 0 {
+			t.Errorf("expected zeros for an unowned account, got %+v", got)
+		}
+	})
+}
+
+func TestSummaryLive_CrossUserIsolation(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	_, tokenA := env.createAccountsTestUser(t, "summary-iso-a")
+	_, tokenB := env.createAccountsTestUser(t, "summary-iso-b")
+
+	accountA := createTestAccount(t, env.accountsTestEnv, tokenA, "A Cash")
+	accountB := createTestAccount(t, env.accountsTestEnv, tokenB, "B Cash")
+	categoryB := createTestCategory(t, env.accountsTestEnv, tokenB, "B Rent")
+
+	seedSummaryTransaction(t, env, tokenA, accountA, "2026-07-20", 100000, nil)
+	seedSummaryTransaction(t, env, tokenB, accountB, "2026-07-20", 999999, nil)
+	seedSummaryTransaction(t, env, tokenB, accountB, "2026-07-20", -55555, &categoryB)
+
+	got := getSummary(t, env, tokenA, "")
+
+	if got.IncomeAmount != 100000 {
+		t.Errorf("A's income must exclude B's rows, got %d", got.IncomeAmount)
+	}
+	if got.ExpensesAmount != 0 {
+		t.Errorf("A has no expenses; B's must not leak, got %d", got.ExpensesAmount)
+	}
+	if len(got.Categories) != 0 {
+		t.Errorf("B's category must not appear in A's breakdown, got %+v", got.Categories)
+	}
+
+	// Filtering by another user's account must not expose its totals either.
+	filtered := getSummary(t, env, tokenA, "?accountId="+accountB)
+	if filtered.IncomeAmount != 0 || filtered.ExpensesAmount != 0 {
+		t.Errorf("filtering by B's account must yield zeros for A, got %+v", filtered)
+	}
+}
+
+func TestSummaryLive_DateQueryErrors(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	_, token := env.createAccountsTestUser(t, "summary-dates")
+
+	cases := []struct {
+		query   string
+		message string
+	}{
+		{"?from=2026/07/01", "from and to must use yyyy-MM-dd dates."},
+		{"?from=", "from and to must use yyyy-MM-dd dates."},
+		{"?from=2026-07-30&to=2026-07-01", "from must be less than or equal to to."},
+		{"?from=2024-01-01&to=2026-07-01", "Date range cannot exceed 366 days."},
+		{"?accountId=", "accountId must not be empty."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			rec := env.do(t, http.MethodGet, "/api/summary"+tc.query, token, nil)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d (body: %s)", rec.Code, rec.Body.String())
+			}
+			// Decoded once: the recorder's body is a reader, so a second decode
+			// would see EOF and assert nothing.
+			body := decodeAccountsAPIError(t, rec)
+			if body.Error.Code != "INVALID_QUERY" {
+				t.Errorf("expected code INVALID_QUERY, got %q", body.Error.Code)
+			}
+			if body.Error.Message != tc.message {
+				t.Errorf("expected %q, got %q", tc.message, body.Error.Message)
+			}
+		})
+	}
+}
+
+func TestSummaryLive_Unauthorized(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+
+	wrongSecretToken, _, err := auth.IssueAccessToken([]byte("a-totally-different-secret-32-bytes!!"), uuid.New(), 30*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken wrong secret: %v", err)
+	}
+	expiredToken, _, err := auth.IssueAccessToken(env.secret, uuid.New(), -1*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAccessToken expired: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		token    string
+		wantCode string
+	}{
+		{"no-header", "", "UNAUTHORIZED"},
+		{"malformed-header", "not-a-jwt", "UNAUTHORIZED"},
+		{"bad-signature", wrongSecretToken, "UNAUTHORIZED"},
+		{"expired", expiredToken, "ACCESS_TOKEN_EXPIRED"},
+	} {
+		t.Run(fmt.Sprintf("GET /api/summary/%s", tc.name), func(t *testing.T) {
+			rec := env.do(t, http.MethodGet, "/api/summary", tc.token, nil)
+			assertTransactionAPIError(t, rec, http.StatusUnauthorized, tc.wantCode)
+		})
+	}
+}

--- a/backend/internal/http/summary_test.go
+++ b/backend/internal/http/summary_test.go
@@ -1,0 +1,198 @@
+package httpapi
+
+import (
+	"testing"
+	"time"
+
+	dbgen "github.com/GonzaloSecades/nuchi/backend/internal/db/gen"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TestPercentageChange pins the zero rule, which is the part of this function
+// that looks like a divide-by-zero guard and is actually a product decision:
+// with no previous activity, legacy reports 0 when there is still none and 100
+// when there is some, rather than an undefined or infinite ratio.
+func TestPercentageChange(t *testing.T) {
+	cases := []struct {
+		name              string
+		current, previous int64
+		want              float32
+	}{
+		{"both zero is zero, not 100", 0, 0, 0},
+		{"something from nothing is 100", 5000, 0, 100},
+		{"negative something from nothing is still 100", -5000, 0, 100},
+		{"doubling is +100", 2000, 1000, 100},
+		{"halving is -50", 500, 1000, -50},
+		{"unchanged is 0", 1000, 1000, 0},
+		{"to zero is -100", 0, 1000, -100},
+		// Sign of the previous period carries through the division, so a
+		// negative baseline flips the direction. Legacy has the same behavior.
+		{"negative previous", -500, -1000, -50},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := percentageChange(tc.current, tc.previous); got != tc.want {
+				t.Errorf("percentageChange(%d, %d) = %v, want %v", tc.current, tc.previous, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPercentageChange_UsesFloatDivision guards against an integer-division
+// port, which would silently truncate every fractional change to zero.
+func TestPercentageChange_UsesFloatDivision(t *testing.T) {
+	// 1000 -> 1005 is +0.5%, which integer division would report as 0.
+	if got := percentageChange(1005, 1000); got != 0.5 {
+		t.Errorf("expected 0.5, got %v — a truncating division would give 0", got)
+	}
+}
+
+func categoryRow(name string, value int64) dbgen.GetCategorySpendingRow {
+	return dbgen.GetCategorySpendingRow{Name: name, Value: value}
+}
+
+func TestBucketCategories(t *testing.T) {
+	t.Run("fewer than the cap are returned as-is with no Other", func(t *testing.T) {
+		got := bucketCategories([]dbgen.GetCategorySpendingRow{
+			categoryRow("Rent", 900), categoryRow("Food", 500),
+		})
+		if len(got) != 2 {
+			t.Fatalf("expected 2 categories, got %d: %+v", len(got), got)
+		}
+		for _, c := range got {
+			if c.Name == otherCategoryName {
+				t.Error("no Other bucket should appear when nothing was left over")
+			}
+		}
+	})
+
+	// The boundary: exactly the cap means nothing remains, so adding an empty
+	// "Other" row here would be a visible defect in the chart.
+	t.Run("exactly the cap produces no Other", func(t *testing.T) {
+		got := bucketCategories([]dbgen.GetCategorySpendingRow{
+			categoryRow("Rent", 900), categoryRow("Food", 500), categoryRow("Transport", 100),
+		})
+		if len(got) != maxSummaryCategories {
+			t.Fatalf("expected %d categories, got %d: %+v", maxSummaryCategories, len(got), got)
+		}
+		if got[len(got)-1].Name == otherCategoryName {
+			t.Error("exactly the cap must not produce an Other bucket")
+		}
+	})
+
+	t.Run("one past the cap folds the remainder into Other", func(t *testing.T) {
+		got := bucketCategories([]dbgen.GetCategorySpendingRow{
+			categoryRow("Rent", 900), categoryRow("Food", 500),
+			categoryRow("Transport", 100), categoryRow("Books", 40),
+		})
+		if len(got) != maxSummaryCategories+1 {
+			t.Fatalf("expected %d entries, got %d: %+v", maxSummaryCategories+1, len(got), got)
+		}
+		last := got[len(got)-1]
+		if last.Name != otherCategoryName || last.Value != 40 {
+			t.Errorf("expected Other=40, got %+v", last)
+		}
+	})
+
+	t.Run("Other sums every remaining category", func(t *testing.T) {
+		got := bucketCategories([]dbgen.GetCategorySpendingRow{
+			categoryRow("A", 900), categoryRow("B", 500), categoryRow("C", 100),
+			categoryRow("D", 40), categoryRow("E", 30), categoryRow("F", 5),
+		})
+		last := got[len(got)-1]
+		if last.Value != 75 {
+			t.Errorf("expected Other to sum 40+30+5=75, got %d", last.Value)
+		}
+	})
+
+	t.Run("no categories yields an empty slice, not nil", func(t *testing.T) {
+		got := bucketCategories(nil)
+		if got == nil {
+			t.Fatal("expected an empty slice so it serializes as [], not null")
+		}
+		if len(got) != 0 {
+			t.Errorf("expected no categories, got %+v", got)
+		}
+	})
+}
+
+func dailyRow(day string, income, expenses int64) dbgen.GetDailyTotalsRow {
+	parsed, _ := time.Parse(time.DateOnly, day)
+	return dbgen.GetDailyTotalsRow{
+		Day:      pgtype.Date{Time: parsed, Valid: true},
+		Income:   income,
+		Expenses: expenses,
+	}
+}
+
+func TestFillMissingDays(t *testing.T) {
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 6, 5, 23, 59, 59, 0, time.UTC)
+
+	t.Run("fills gaps at both ends and the middle", func(t *testing.T) {
+		got := fillMissingDays([]dbgen.GetDailyTotalsRow{
+			dailyRow("2026-06-02", 1000, 0),
+			dailyRow("2026-06-04", 0, 250),
+		}, start, end)
+
+		if len(got) != 5 {
+			t.Fatalf("expected one entry per day in the inclusive range (5), got %d", len(got))
+		}
+		want := []struct {
+			day              string
+			income, expenses int64
+		}{
+			{"2026-06-01", 0, 0},
+			{"2026-06-02", 1000, 0},
+			{"2026-06-03", 0, 0},
+			{"2026-06-04", 0, 250},
+			{"2026-06-05", 0, 0},
+		}
+		for i, w := range want {
+			if got[i].Date.Format(time.DateOnly) != w.day {
+				t.Errorf("position %d: expected %s, got %s", i, w.day, got[i].Date.Format(time.DateOnly))
+			}
+			if got[i].Income != w.income || got[i].Expenses != w.expenses {
+				t.Errorf("%s: expected income=%d expenses=%d, got %d/%d",
+					w.day, w.income, w.expenses, got[i].Income, got[i].Expenses)
+			}
+		}
+	})
+
+	t.Run("a range with no activity is still fully populated", func(t *testing.T) {
+		got := fillMissingDays(nil, start, end)
+		if len(got) != 5 {
+			t.Fatalf("expected 5 zero-filled days, got %d", len(got))
+		}
+		for _, day := range got {
+			if day.Income != 0 || day.Expenses != 0 {
+				t.Errorf("expected zeros, got %+v", day)
+			}
+		}
+	})
+
+	t.Run("a single-day range yields one entry", func(t *testing.T) {
+		single := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+		got := fillMissingDays(nil, single, single.Add(24*time.Hour-time.Nanosecond))
+		if len(got) != 1 {
+			t.Fatalf("expected 1 day, got %d", len(got))
+		}
+	})
+
+	// The end boundary is the last instant of its day, so iterating on raw
+	// timestamps rather than day boundaries would drop the final day.
+	t.Run("the last day of the range is included", func(t *testing.T) {
+		got := fillMissingDays([]dbgen.GetDailyTotalsRow{dailyRow("2026-06-05", 7, 0)}, start, end)
+		last := got[len(got)-1]
+		if last.Date.Format(time.DateOnly) != "2026-06-05" || last.Income != 7 {
+			t.Errorf("expected the end day present with its totals, got %+v", last)
+		}
+	})
+
+	t.Run("days always serialize as a slice, never nil", func(t *testing.T) {
+		if got := fillMissingDays(nil, start, end); got == nil {
+			t.Error("expected an empty slice rather than nil")
+		}
+	})
+}

--- a/backend/internal/http/summary_test.go
+++ b/backend/internal/http/summary_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -45,6 +46,17 @@ func TestPercentageChange_UsesFloatDivision(t *testing.T) {
 	// 1000 -> 1005 is +0.5%, which integer division would report as 0.
 	if got := percentageChange(1005, 1000); got != 0.5 {
 		t.Errorf("expected 0.5, got %v — a truncating division would give 0", got)
+	}
+}
+
+func TestPercentageChange_WidensBeforeSubtracting(t *testing.T) {
+	// Subtracting in int64 wraps both of these cases and flips the sign before
+	// the result reaches float64.
+	if got := percentageChange(math.MaxInt64, -1); got >= 0 {
+		t.Errorf("expected a negative change for MaxInt64 versus -1, got %v", got)
+	}
+	if got := percentageChange(math.MinInt64, 1); got >= 0 {
+		t.Errorf("expected a negative change for MinInt64 versus 1, got %v", got)
 	}
 }
 

--- a/backend/internal/http/transactions.go
+++ b/backend/internal/http/transactions.go
@@ -93,17 +93,11 @@ func (s *ResourceServer) ListTransactions(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// accountId references ResourceId (minLength 1), so an explicitly empty
-	// value is rejected for the same reason as an empty date rather than
-	// silently meaning "no filter".
-	accountID := pgtype.Text{}
-	if params.AccountId != nil {
-		if *params.AccountId == "" {
-			resp := openapi.ListTransactions400JSONResponse{InvalidQueryErrorJSONResponse: invalidQueryError("accountId must not be empty.")}
-			_ = resp.VisitListTransactionsResponse(w)
-			return
-		}
-		accountID = pgtype.Text{String: *params.AccountId, Valid: true}
+	accountID, accountErr := accountIDFilter(params.AccountId)
+	if accountErr != nil {
+		resp := openapi.ListTransactions400JSONResponse{InvalidQueryErrorJSONResponse: invalidQueryError(accountErr.Error())}
+		_ = resp.VisitListTransactionsResponse(w)
+		return
 	}
 
 	var rows []dbgen.ListTransactionsRow

--- a/docs/api/summary.md
+++ b/docs/api/summary.md
@@ -1,0 +1,151 @@
+# Summary API — Technical Reference
+
+Go implementation reference for `GET /api/summary`, the dashboard's single
+aggregate endpoint. Companion to the contract
+(`openapi/nuchi.openapi.json`), which is authoritative for shapes and status
+codes; this covers what the contract cannot express.
+
+Shipped in [#48](https://github.com/GonzaloSecades/nuchi/issues/48).
+
+## The operation
+
+| Method | Path | Operation |
+| --- | --- | --- |
+| GET | `/api/summary` | `getSummary` |
+
+Mounted inside the `RequireAuth` group. Read-only, so no rate limiting — the
+mutation limiter covers writes only.
+
+Takes the **same three query parameters as the transaction list** —
+`from`, `to`, `accountId` — with identical semantics. That is not a
+coincidence to preserve loosely: the dashboard filters both views from one
+control, so a difference between them would show up as the list and the chart
+disagreeing about what period is on screen.
+
+## Date handling is shared, not reimplemented
+
+`parseDateRange` (`daterange.go`) is used verbatim. Defaults, the
+"provided `to` does not re-anchor the default `from`" rule, start/end-of-day
+boundaries, the 366-day cap, UTC pinning, and the three exact `INVALID_QUERY`
+messages all come from there. See the [transactions
+reference](transactions.md) for the full rules.
+
+`accountId` goes through `accountIDFilter`, also shared. An explicitly empty
+`?accountId=` is a 400, not "no filter".
+
+## Four queries, one transaction
+
+`GetPeriodTotals` runs twice — current window and comparison window — alongside
+`GetCategorySpending` and `GetDailyTotals`, all inside a single `WithUserTx`.
+
+Two reasons this matters beyond tidiness:
+
+- One RLS binding covers all four.
+- All four see **one snapshot**. Legacy fires them independently, so a write
+  landing mid-request can produce totals that disagree with the endpoint's own
+  daily series.
+
+## The comparison period
+
+Length-based, not calendar-based:
+
+```
+periodLength  = calendarDays(end, start) + 1
+previousStart = start - periodLength days
+previousEnd   = end   - periodLength days
+```
+
+A 30-day view compares against the 30 days immediately before it — **not** the
+previous calendar month. A March view does not compare against February. This
+reads as wrong at first glance and is a faithful port; legacy computes it the
+same way with `differenceInCalendarDays` and `subDays`.
+
+## Percentage change
+
+`percentageChange` ports `calculatePercentageChange` from `lib/utils.ts`:
+
+| previous | current | result |
+| --- | --- | --- |
+| 0 | 0 | `0` |
+| 0 | anything else | `100` |
+| non-zero | any | `(current − previous) / previous × 100` |
+
+The zero rule looks like a divide-by-zero guard and is a product decision:
+"everything is new growth". Both branches are deliberate and both are tested.
+
+This is the **only float in the money path**. It is a ratio, not an amount —
+amounts remain integer milliunits everywhere. The division is done in `float64`
+and narrowed once at the end; an integer division here would silently truncate
+every sub-1% change to zero.
+
+## Category breakdown
+
+The query returns expense totals per category, ordered by value descending. The
+handler takes the top three as-is and folds everything past them into a single
+`Other` entry.
+
+- Exactly three categories → **no** `Other` row. Adding an empty one would be a
+  visible defect.
+- `Other` sums every remaining category, not just the fourth.
+
+### What the breakdown excludes
+
+Two exclusions, both inherited from legacy's `innerJoin`:
+
+- **Income is never included** — the query filters `t.amount < 0`.
+- **Uncategorized expenses are excluded**, while still counted in
+  `expensesAmount`.
+
+So **the chart does not sum to the expenses total** when the user has
+uncategorized spending, and nothing in the response explains the gap. Ported
+deliberately; recorded as improvement 0017 with the product options.
+
+## Daily series
+
+`fillMissingDays` returns one entry per calendar day in the inclusive range,
+using queried totals where a day has activity and zeros where it does not. The
+chart needs a continuous series — a gap would otherwise be drawn as a straight
+line between active days, implying activity that did not happen.
+
+Keyed by `yyyy-MM-dd` in UTC, matching the query's `GROUP BY t.date::date`.
+That cast is load-bearing: grouping by the raw timestamp would split one
+calendar day into several rows if any write path ever stored a time of day, and
+this map would then keep only the last of them.
+
+Iteration runs over **day boundaries**, not the raw range, because `end` is the
+last instant of its day — iterating on raw timestamps would drop the final day.
+
+## Empty state
+
+A period with no transactions returns zeros for all three amounts, zeros for
+all three changes, `categories: []`, and a **fully populated** `days` array of
+zero entries. Both arrays serialize as `[]`, never `null`; the dashboard maps
+over them.
+
+An `accountId` the caller does not own yields the same zeros rather than a 404 —
+the ownership join simply matches nothing, and confirming the account exists
+would leak another user's data.
+
+## Where the code lives
+
+| Concern | File |
+| --- | --- |
+| Handler, percentage change, bucketing, day filling | `backend/internal/http/summary.go` |
+| Date range semantics | `backend/internal/http/daterange.go` |
+| Shared `accountId` filter | `backend/internal/http/resources.go` |
+| Queries | `backend/internal/db/queries/summary.sql` |
+
+## Divergences and gaps
+
+| Entry | Note |
+| --- | --- |
+| 0014 | Date filters parsed in UTC rather than the host timezone (shared with transactions) |
+| 0017 | Category chart excludes uncategorized spending while the total includes it |
+
+The aggregates already cast to `::bigint` (from #40), so they were unaffected by
+the `amount` widening in #46 — a sum of many large amounts cannot overflow the
+way a single `int4` column could.
+
+No pagination or caching: the endpoint recomputes everything per request. Fine
+at personal-finance scale, and the first thing to revisit if a user's history
+grows large.

--- a/docs/api/summary.md
+++ b/docs/api/summary.md
@@ -38,7 +38,8 @@ reference](transactions.md) for the full rules.
 `GetPeriodTotals` runs twice — current window and comparison window — alongside
 `GetCategorySpending` and `GetDailyTotals`, all inside a single `WithUserTx`.
 
-Two reasons this matters beyond tidiness:
+The handler requests PostgreSQL `REPEATABLE READ`, rather than relying on the
+default `READ COMMITTED` transaction. Two reasons this matters beyond tidiness:
 
 - One RLS binding covers all four.
 - All four see **one snapshot**. Legacy fires them independently, so a write
@@ -142,9 +143,12 @@ would leak another user's data.
 | 0014 | Date filters parsed in UTC rather than the host timezone (shared with transactions) |
 | 0017 | Category chart excludes uncategorized spending while the total includes it |
 
-The aggregates already cast to `::bigint` (from #40), so they were unaffected by
-the `amount` widening in #46 — a sum of many large amounts cannot overflow the
-way a single `int4` column could.
+Individual amounts fit the contract, but a sufficiently large aggregate can
+still exceed PostgreSQL `bigint` or the stricter JavaScript-safe range declared
+for summary fields. Resolving that requires an explicit response-contract
+decision; it is tracked in
+[`Codex-summary-aggregate-contract-range.md`](../../post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md)
+rather than silently clamping or changing parity behavior in this migration.
 
 No pagination or caching: the endpoint recomputes everything per request. Fine
 at personal-finance scale, and the first thing to revisit if a user's history

--- a/docs/product/summary.md
+++ b/docs/product/summary.md
@@ -1,0 +1,119 @@
+# Summary — Product Behavior
+
+What the dashboard shows, how each number is worked out, and the two places
+where the figures look wrong but aren't.
+
+Written for product decisions and support answers. For endpoint shapes see
+[the technical reference](../api/summary.md).
+
+## What the dashboard shows
+
+One request produces everything on the overview screen:
+
+| Figure | Meaning |
+| --- | --- |
+| Remaining | Income minus expenses for the period |
+| Income | Everything received |
+| Expenses | Everything spent, as a positive number |
+| Change % | How each of the three compares with the previous period |
+| Category chart | Where the categorized spending went |
+| Daily chart | Income and expenses per day across the period |
+
+## The period
+
+Same filters as the transaction list, and deliberately so — one date control
+drives both, so the list and the charts always describe the same window.
+
+Default is **the last 30 days**. Both ends are inclusive, and the longest
+allowed range is 366 days.
+
+## "Compared to previous period" means the period immediately before
+
+This is the single most likely support question.
+
+The comparison is against **the same number of days, immediately preceding** the
+selected range — not the previous calendar month.
+
+Looking at 1–31 March compares against 29 January – 28 February, not "February"
+as a month. Viewing the last 7 days compares against the 7 days before that. A
+user expecting month-over-month will read the percentage as wrong when it is
+working as designed.
+
+### Why a change can read 100%
+
+When the previous period had **nothing** and the current one has **something**,
+the change is reported as **100%**, not infinity and not a blank. There is no
+meaningful percentage increase from zero, and 100% is the app's way of saying
+"all of this is new".
+
+When both periods are empty the change is **0%**, not 100%.
+
+So a brand-new user's first month shows +100% on income and expenses, and a
+user with no activity at all sees 0% everywhere. Both are correct.
+
+## The category chart does not add up to the expenses total
+
+The second likely support question, and a real quirk rather than a bug in the
+arithmetic.
+
+The chart includes only expenses that **have a category**. Uncategorized
+spending still counts toward the Expenses figure but does not appear in the
+chart, and nothing on screen explains the difference.
+
+A user with 155,000 in expenses, 1,000 of it uncategorized, sees a chart
+totalling 154,000. The gap is invisible.
+
+This is inherited from the previous implementation and was kept deliberately
+during the migration so behavior did not change mid-flight. It is queued to be
+addressed — most likely by showing uncategorized spending explicitly, so the
+chart reconciles with the total and the user gets a nudge to categorize.
+
+Income never appears in the category chart either, even when the transaction
+has a category. The chart is about spending only.
+
+### "Other"
+
+Only the three largest categories are shown individually. Everything else is
+summed into a single **Other** slice.
+
+With exactly three categories there is no Other slice. And note Other covers
+only *smaller categories* — it does **not** include uncategorized spending,
+which is a reasonable thing for a user to assume and is not the case.
+
+## The daily chart always covers every day
+
+Days with no transactions appear as zero rather than being skipped, so the
+chart draws a continuous line across the period. Without this, a gap would be
+drawn as a straight line between two active days and imply activity that never
+happened.
+
+A period with no transactions at all still returns a full set of zero days, so
+the chart renders flat rather than empty.
+
+## Filtering by one account
+
+Narrows every figure on the screen — totals, changes, both charts.
+
+Filtering by an account that isn't the user's own returns zeros rather than an
+error. The app does not confirm or deny that another user's account exists.
+
+## What this deliberately cannot do yet
+
+1. **Uncategorized spending is invisible in the chart** (above). The most
+   user-visible item here.
+2. **Only the top three categories** are broken out, and that is fixed in the
+   API rather than a display preference.
+3. **No month-over-month comparison** — the comparison window is always
+   length-based.
+4. **No caching.** Every dashboard load recomputes from scratch. Fine at
+   personal-finance scale; something to revisit as histories grow.
+5. **Day boundaries are UTC**, so a transaction near midnight can land on a
+   neighbouring day relative to the user's local date.
+
+## Related
+
+- [Technical reference](../api/summary.md)
+- [Transactions — product behavior](transactions.md) — the filters, milliunits,
+  and sign conventions this builds on
+- `post-migration-improvements/claude-backend-improvements/0017-...` — the
+  uncategorized-spending gap

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -570,14 +570,5 @@
   "568": "Q: last comment address if you have anything more to say label it for a future improvement post migration and name it Codex-{title}",
   "569": "EmailNotVerifiedErrorJSONResponse",
   "570": "RequiredHeaderError",
-  "571": "BulkDeleteAccounts200JSONResponse",
-  "572": "BulkDeleteCategories200JSONResponse",
-  "573": "DeleteTransaction200JSONResponse",
-  "574": "GetSummary200JSONResponse",
-  "575": "GetTransaction200JSONResponse",
-  "576": "ListAccounts200JSONResponse",
-  "577": "ListTransactions200JSONResponse",
-  "578": "UpdateAccount200JSONResponse",
-  "579": "UpdateTransaction200JSONResponse",
-  "580": "UpdateTransaction404JSONResponse"
+  "571": "BulkDeleteAccounts200JSONResponse"
 }

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -570,5 +570,6 @@
   "568": "Q: last comment address if you have anything more to say label it for a future improvement post migration and name it Codex-{title}",
   "569": "EmailNotVerifiedErrorJSONResponse",
   "570": "RequiredHeaderError",
-  "571": "BulkDeleteAccounts200JSONResponse"
+  "571": "BulkDeleteAccounts200JSONResponse",
+  "572": "CreateCategory200JSONResponse"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - wt-48  (2026-08-08)
 
 ## Corpus Check
-- 324 files · ~179,954 words
+- 325 files · ~180,856 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3135 nodes · 5573 edges · 572 communities (177 shown, 395 thin omitted)
-- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 469 edges (avg confidence: 0.8)
+- 3147 nodes · 5605 edges · 573 communities (175 shown, 398 thin omitted)
+- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 474 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `79548587`
+- Built from commit: `780a6ce1`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -545,6 +545,7 @@
 - [[_COMMUNITY_NewPool|NewPool]]
 - [[_COMMUNITY_TestFinanceBaseSchema_LiveDatabase|TestFinanceBaseSchema_LiveDatabase]]
 - [[_COMMUNITY_GetTransaction200JSONResponse|GetTransaction200JSONResponse]]
+- [[_COMMUNITY_New|New]]
 - [[_COMMUNITY_ListTransactions200JSONResponse|ListTransactions200JSONResponse]]
 - [[_COMMUNITY_UpdateCategory200JSONResponse|UpdateCategory200JSONResponse]]
 - [[_COMMUNITY_VerifyEmail200JSONResponse|VerifyEmail200JSONResponse]]
@@ -567,6 +568,7 @@
 - [[_COMMUNITY_EmailNotVerifiedErrorJSONResponse|EmailNotVerifiedErrorJSONResponse]]
 - [[_COMMUNITY_RequiredHeaderError|RequiredHeaderError]]
 - [[_COMMUNITY_BulkDeleteAccounts200JSONResponse|BulkDeleteAccounts200JSONResponse]]
+- [[_COMMUNITY_CreateCategory200JSONResponse|CreateCategory200JSONResponse]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `cn()` - 95 edges
@@ -578,24 +580,24 @@
 7. `strictHandler` - 32 edges
 8. `Unimplemented` - 29 edges
 9. `newAccountsTestEnv()` - 27 edges
-10. `Button()` - 26 edges
+10. `NewPool()` - 26 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `Generated Go Output` --semantically_similar_to--> `generated.gen.go`  [INFERRED] [semantically similar]
   openapi/oapi-codegen.yaml → backend/internal/openapi/README.md
-- `SheetOverlay()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/sheet.tsx → lib/utils.ts
-- `SheetFooter()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/sheet.tsx → lib/utils.ts
-- `AccountsPage()` --calls--> `useNewAccount`  [EXTRACTED]
-  app/(dashboard)/accounts/page.tsx → features/accounts/hooks/use-new-account.ts
-- `CategoriesPage()` --calls--> `useNewCategory`  [EXTRACTED]
-  app/(dashboard)/categories/page.tsx → features/categories/hooks/use-new-category.ts
+- `CardAction()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/card.tsx → lib/utils.ts
+- `CardFooter()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/card.tsx → lib/utils.ts
+- `SelectLabel()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/select.tsx → lib/utils.ts
+- `SelectSeparator()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/select.tsx → lib/utils.ts
 
 ## Import Cycles
 - None detected.
 
-## Communities (572 total, 395 thin omitted)
+## Communities (573 total, 398 thin omitted)
 
 ### Community 0 - "Transaction Form Tsx"
 Cohesion: 0.12
@@ -606,8 +608,8 @@ Cohesion: 0.05
 Nodes (43): dependencies, class-variance-authority, @clerk/backend, @clerk/nextjs, clsx, date-fns, drizzle-orm, drizzle-zod (+35 more)
 
 ### Community 2 - "Cn Button Tsx"
-Cohesion: 0.50
-Nodes (4): 1. Unified Import Inbox, Product impact, What this feature should achieve, Why this matters
+Cohesion: 0.14
+Nodes (20): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), Props, DataTableProps, Table() (+12 more)
 
 ### Community 3 - "Page Tsx"
 Cohesion: 0.14
@@ -622,8 +624,8 @@ Cohesion: 0.06
 Nodes (31): 1. Frontend - Data/State (Next.js, React hooks, mutation hooks), 2. Frontend - UI Components (Shadcn/Radix UI, table rendering), 3. State Management (Custom hooks, promise-based dialog flow), 4. Developer Experience & Configuration (Dependency and repo hygiene), API, Automated Testing Needs, Breaking Changes, Business Value (+23 more)
 
 ### Community 9 - "0004 Snapshot Json"
-Cohesion: 0.08
-Nodes (28): AmountInput(), Props, AreaVariant(), Props, BarVariant(), Props, CategoryTooltip(), CategoryTooltipPayload (+20 more)
+Cohesion: 0.06
+Nodes (46): ImportableTransactionField, isImportableTransactionField(), options, Props, TableHeadSelect(), AreaVariant(), Props, BarVariant() (+38 more)
 
 ### Community 10 - "Data Card Tsx"
 Cohesion: 0.33
@@ -647,23 +649,23 @@ Nodes (9): Follow-Up Memory, Implemented Scope, Last Verified, Local Database, M
 
 ### Community 17 - "Transactions Ts"
 Cohesion: 0.01
-Nodes (145): ResourceId, Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody (+137 more)
+Nodes (142): ResourceId, Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody (+134 more)
 
 ### Community 18 - "0001 Snapshot Json"
-Cohesion: 0.19
-Nodes (8): Props, AccountFilter(), DateFilter(), Filters(), Header(), HeaderLogo(), Navigation(), WelcomeMsg()
+Cohesion: 0.27
+Nodes (5): Props, Header(), HeaderLogo(), Navigation(), WelcomeMsg()
 
 ### Community 19 - "Json Editor Code Actions"
-Cohesion: 0.14
-Nodes (17): app, app, app, db, pool, accounts, accountsRelations, categories (+9 more)
+Cohesion: 0.05
+Nodes (55): app, app, app, AppType, DELETE, GET, OPTIONS, PATCH (+47 more)
 
 ### Community 20 - "0000 Snapshot Json"
 Cohesion: 0.21
 Nodes (16): accountNotFoundError(), constraintName(), duplicateAccountNameError(), Account, ResourceServer, Request, ResourceId, ResponseWriter (+8 more)
 
 ### Community 23 - "Nuchi Project Context"
-Cohesion: 0.09
-Nodes (29): Props, Select(), FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem() (+21 more)
+Cohesion: 0.08
+Nodes (34): AmountInput(), Props, DatePicker(), FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue (+26 more)
 
 ### Community 24 - "Transactions API"
 Cohesion: 0.08
@@ -671,7 +673,7 @@ Nodes (23): Accounts, Accounts, API Shape, Canonical Architecture, Categories, C
 
 ### Community 28 - "Components Json"
 Cohesion: 0.07
-Nodes (69): decodeAPIError(), Cookie, Duration, Handler, authTestEnv, Pool, ResponseRecorder, T (+61 more)
+Nodes (74): decodeAPIError(), Cookie, Duration, Handler, authTestEnv, Pool, ResponseRecorder, T (+66 more)
 
 ### Community 29 - "Schema Ts"
 Cohesion: 0.10
@@ -682,12 +684,12 @@ Cohesion: 0.11
 Nodes (18): aliases, components, hooks, lib, ui, utils, iconLibrary, registries (+10 more)
 
 ### Community 31 - "Scripts Build"
-Cohesion: 0.16
-Nodes (12): app, enforceJsonBodyLimit(), OwnedReferencesResult, checkTransactionMutationRateLimit(), cleanupMutationRateLimit(), DateRangeQueryOptions, DateRangeQueryResult, isContentLengthTooLarge() (+4 more)
+Cohesion: 0.22
+Nodes (10): enforceJsonBodyLimit(), checkTransactionMutationRateLimit(), cleanupMutationRateLimit(), DateRangeQueryOptions, DateRangeQueryResult, isContentLengthTooLarge(), mutationRequestsByKey, parseDateRangeQuery() (+2 more)
 
 ### Community 32 - "Current API Parity Fixtures"
-Cohesion: 0.31
-Nodes (16): adminDatabaseURL(), T, liveDatabaseURL(), createRLSTestAccount(), createRLSTestUser(), deleteRLSTestUsers(), Context, Pool (+8 more)
+Cohesion: 0.30
+Nodes (17): adminDatabaseURL(), T, liveDatabaseURL(), createRLSTestAccount(), createRLSTestUser(), deleteRLSTestUsers(), Context, Pool (+9 more)
 
 ### Community 33 - "Dev Dependencies"
 Cohesion: 0.04
@@ -699,7 +701,7 @@ Nodes (17): devDependencies, dotenv, drizzle-kit, eslint, eslint-config-next, es
 
 ### Community 35 - "Seed Ts"
 Cohesion: 0.19
-Nodes (12): Chart(), ChartLoading(), DataCardLoading(), DataCharts(), DataGrid(), SpendingPie(), SpendingPieLoading(), useGetSummary() (+4 more)
+Nodes (10): geistMono, geistSans, metadata, Toaster(), sonner, getQueryClient(), makeQueryClient(), Props (+2 more)
 
 ### Community 37 - "Nuchi Application"
 Cohesion: 0.10
@@ -722,16 +724,16 @@ Cohesion: 0.08
 Nodes (95): assertAccountNotFound(), assertValidationError(), createTestAccount(), decodeAccountsAPIError(), Handler, Pool, ResponseRecorder, T (+87 more)
 
 ### Community 42 - "Api Error"
-Cohesion: 0.29
-Nodes (12): categoryNotFoundError(), duplicateCategoryNameError(), Category, ResourceServer, Request, ResourceId, ResponseWriter, toCategory() (+4 more)
+Cohesion: 0.27
+Nodes (13): categoryNotFoundError(), duplicateCategoryNameError(), Category, ResourceServer, Request, ResourceId, ResponseWriter, toCategory() (+5 more)
 
 ### Community 43 - "Edit Account Sheet Tsx"
 Cohesion: 0.18
 Nodes (10): Commands, Current Risk Areas, Env, graphify, Nuchi Codex Guide, Pull Requests Hard Rules, Reference, Repo Rules (+2 more)
 
 ### Community 45 - "Indexes Columns"
-Cohesion: 0.19
-Nodes (13): assertSeedAllowed(), databaseUrl, db, defaultFrom, defaultTo, generateRandomAmount(), generateTransactions(), generateTransactionsForDay() (+5 more)
+Cohesion: 0.52
+Nodes (6): T, UUID, newPgUUID(), TestConsumeRefreshToken_Concurrent(), TestSqlcQueries_LiveDatabase(), uniqueTestEmail()
 
 ### Community 47 - "Plaid Id"
 Cohesion: 0.15
@@ -763,7 +765,7 @@ Nodes (11): Account, Context, Queries, Text, UUID, BulkDeleteAccountsParams, Cre
 
 ### Community 55 - "Nuchi Go Backend"
 Cohesion: 0.05
-Nodes (22): BulkCreateTransactions401JSONResponse, BulkDeleteAccounts401JSONResponse, BulkDeleteCategories401JSONResponse, BulkDeleteTransactions401JSONResponse, CreateAccount401JSONResponse, CreateCategory401JSONResponse, CreateTransaction401JSONResponse, DeleteAccount401JSONResponse (+14 more)
+Nodes (23): invalidCredentialsError(), BulkCreateTransactions401JSONResponse, BulkDeleteAccounts401JSONResponse, BulkDeleteCategories401JSONResponse, BulkDeleteTransactions401JSONResponse, CreateAccount401JSONResponse, CreateCategory401JSONResponse, CreateTransaction401JSONResponse (+15 more)
 
 ### Community 58 - "Context"
 Cohesion: 0.22
@@ -822,12 +824,12 @@ Cohesion: 0.33
 Nodes (5): 0011 — No resend endpoint; email delivery is fire-and-forget, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 260 - "name"
-Cohesion: 0.07
-Nodes (42): Actions(), Props, columns, ResponseType, Actions(), Props, columns, ResponseType (+34 more)
+Cohesion: 0.08
+Nodes (32): Actions(), columns, ResponseType, Actions(), Props, columns, ResponseType, AccountColumn() (+24 more)
 
 ### Community 293 - "name"
-Cohesion: 0.08
-Nodes (49): argonParams, decodeHash(), DummyVerify(), HashPassword(), mustHashPassword(), T, TestDecodeHash_OperationalBounds(), TestDummyVerify_DoesNotPanicOrLeak() (+41 more)
+Cohesion: 0.06
+Nodes (58): argonParams, decodeHash(), DummyVerify(), HashPassword(), mustHashPassword(), T, TestDecodeHash_OperationalBounds(), TestDummyVerify_DoesNotPanicOrLeak() (+50 more)
 
 ### Community 301 - "name"
 Cohesion: 0.33
@@ -843,11 +845,11 @@ Nodes (8): Auth Redirects And API Auth Errors, CSV Import To Bulk Create, Curren
 
 ### Community 315 - "name"
 Cohesion: 0.15
-Nodes (22): buildLink(), URL, passwordResetEmailBody(), T, URL, mustParseURL(), startFakeSMTPServer(), TestBuildLink_EscapesTokenQueryParam() (+14 more)
+Nodes (23): buildLink(), URL, passwordResetEmailBody(), T, URL, mustParseURL(), startFakeSMTPServer(), TestBuildLink_EscapesTokenQueryParam() (+15 more)
 
 ### Community 316 - "name"
-Cohesion: 0.05
-Nodes (21): BulkCreateTransactions500JSONResponse, BulkDeleteAccounts500JSONResponse, BulkDeleteCategories500JSONResponse, BulkDeleteTransactions500JSONResponse, CreateAccount500JSONResponse, CreateCategory500JSONResponse, CreateTransaction500JSONResponse, DatabaseErrorJSONResponse (+13 more)
+Cohesion: 0.06
+Nodes (18): BulkCreateTransactions500JSONResponse, BulkDeleteTransactions500JSONResponse, CreateAccount500JSONResponse, CreateCategory500JSONResponse, CreateTransaction500JSONResponse, DatabaseErrorJSONResponse, DeleteAccount500JSONResponse, DeleteCategory500JSONResponse (+10 more)
 
 ### Community 317 - "notNull"
 Cohesion: 0.11
@@ -858,24 +860,24 @@ Cohesion: 0.25
 Nodes (8): `DELETE /api/transactions/:id`, `GET /api/transactions`, `GET /api/transactions/:id`, `PATCH /api/transactions/:id`, `POST /api/transactions`, `POST /api/transactions/bulk-create`, `POST /api/transactions/bulk-delete`, Transactions
 
 ### Community 323 - "name"
-Cohesion: 0.27
-Nodes (12): Handler(), HandlerFromMux(), HandlerFromMuxWithBaseURL(), HandlerWithOptions(), NewStrictHandler(), NewStrictHandlerWithOptions(), ChiServerOptions, MiddlewareFunc (+4 more)
+Cohesion: 0.48
+Nodes (4): Props, Select(), mergeCreatedSelectOption(), SelectOption
 
 ### Community 332 - "Nuchi — Claude Code Guide"
 Cohesion: 0.20
 Nodes (9): Commands, Graphify, Hard Invariants, Legacy Code, Model Orchestration, Nuchi — Claude Code Guide, Post-Migration Improvements, Project (+1 more)
 
 ### Community 338 - "primaryKey"
-Cohesion: 0.07
-Nodes (8): Handler, Request, ResponseWriter, GetHealth200JSONResponse, ServerInterfaceWrapper, strictHandler, StrictHTTPServerOptions, Unimplemented
+Cohesion: 0.05
+Nodes (23): Handler, Request, ResponseWriter, Handler(), HandlerFromMux(), HandlerFromMuxWithBaseURL(), HandlerWithOptions(), NewStrictHandler() (+15 more)
 
 ### Community 347 - "name"
 Cohesion: 0.33
 Nodes (5): 0005 — Category duplicate update returns 500, create returns 409, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 348 - "type"
-Cohesion: 0.07
-Nodes (41): Props, isImportableTransactionField(), TableHeadSelect(), DataTableProps, Preset, PresetKey, PRESETS, DatePicker() (+33 more)
+Cohesion: 0.08
+Nodes (40): Props, Props, AccountFilter(), DateFilter(), Preset, PresetKey, PRESETS, Props (+32 more)
 
 ### Community 353 - "0006 — transactions.amount is 32-bit, capping a single transaction near ±2.1M ARS"
 Cohesion: 0.29
@@ -922,16 +924,16 @@ Cohesion: 0.33
 Nodes (5): 0010 — Auth operations do not declare 500 responses in the contract, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 378 - "api-base-url.ts"
-Cohesion: 0.26
-Nodes (13): validateCategoryName(), validateResourceName(), validateBulkTransactionInputs(), Text, Timestamp, parseAmount(), textPointer(), toTransactionListItem() (+5 more)
+Cohesion: 0.36
+Nodes (9): validateBulkTransactionInputs(), Text, Timestamp, parseAmount(), validateTransactionInput(), apiFieldError, transactionInput, transactionInputBody (+1 more)
 
 ### Community 379 - "name"
 Cohesion: 0.22
 Nodes (9): Alternatives and tradeoffs, Codex — Atomic Multi-Chunk Transaction Imports, Contract and compatibility, Decision record, Invariants, Problem and evidence, Proposed design, Risks (+1 more)
 
 ### Community 388 - ".UpdateCategory"
-Cohesion: 0.20
-Nodes (9): app, AppType, DELETE, GET, OPTIONS, PATCH, POST, PUT (+1 more)
+Cohesion: 0.50
+Nodes (4): 2. Import Review, Normalization, and Deduplication, Product impact, What this feature should achieve, Why this matters
 
 ### Community 395 - "PR Review Cycle"
 Cohesion: 0.29
@@ -942,8 +944,8 @@ Cohesion: 0.33
 Nodes (5): Code review: what NOT to comment on, Code review: what to focus on, Comment format, Copilot Instructions — nuchi, Repo conventions reviews should assume
 
 ### Community 408 - "notNull"
-Cohesion: 0.13
-Nodes (12): UUID, Email, AuthSessionResponse, AuthSessionResponseTokenType, AuthUser, LoginRequest, LoginUser200JSONResponse, LoginUser200ResponseHeaders (+4 more)
+Cohesion: 0.22
+Nodes (6): AuthSessionResponse, AuthSessionResponseTokenType, LoginUser200JSONResponse, LoginUser200ResponseHeaders, RefreshSession200JSONResponse, RefreshSession200ResponseHeaders
 
 ### Community 409 - "TransactionMutationRateLimitErrorJSONResponse"
 Cohesion: 0.40
@@ -958,16 +960,16 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: recheck the fixes and give another pass for reviews, Source Nodes
 
 ### Community 428 - "import-card.tsx"
-Cohesion: 0.28
-Nodes (8): accountIDFilter(), Text, ResourceServer, Request, ResponseWriter, invalidDateQueryError(), invalidQueryError(), InvalidQueryErrorJSONResponse
+Cohesion: 0.21
+Nodes (10): accountIDFilter(), Text, ResourceServer, Request, ResponseWriter, ListTransactionsParams, Time, invalidDateQueryError() (+2 more)
 
 ### Community 429 - "columns"
 Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: give it a last review of all the files changend in the pr the comments and all that is in place right now in the pr leave comments for medim-high and high issues mid-low and low forget it we mande 3 iterations so far. if something is too big then addres it consitently here so it so i can anlyze it, Source Nodes
 
 ### Community 432 - "GetSummary200JSONResponse"
-Cohesion: 0.05
-Nodes (57): AccountsPage(), CategoriesPage(), Actions(), TransactionsPage(), RequestType, ResponseType, useBulkDeleteAccounts(), RequestType (+49 more)
+Cohesion: 0.07
+Nodes (44): AccountsPage(), CategoriesPage(), RequestType, ResponseType, useBulkDeleteAccounts(), RequestType, ResponseType, useCreateAccount() (+36 more)
 
 ### Community 435 - "name"
 Cohesion: 0.38
@@ -978,8 +980,8 @@ Cohesion: 0.29
 Nodes (4): AccountNotFoundErrorJSONResponse, DeleteAccount404JSONResponse, GetAccount404JSONResponse, UpdateAccount404JSONResponse
 
 ### Community 503 - "TransactionReferenceNotFoundErrorJSONResponse"
-Cohesion: 0.20
-Nodes (15): accountReferenceNotFoundError(), categoryReferenceNotFoundError(), ResourceServer, ListTransactionsParams, Queries, Request, ResourceId, ResponseWriter (+7 more)
+Cohesion: 0.18
+Nodes (20): UUID, UserIDFromContext(), accountReferenceNotFoundError(), categoryReferenceNotFoundError(), ResourceServer, Queries, Request, ResourceId (+12 more)
 
 ### Community 504 - "CategoryNotFoundErrorJSONResponse"
 Cohesion: 0.29
@@ -1002,12 +1004,12 @@ Cohesion: 0.40
 Nodes (3): DeleteTransaction404JSONResponse, GetTransaction404JSONResponse, TransactionNotFoundErrorJSONResponse
 
 ### Community 509 - "GetSummary400JSONResponse"
-Cohesion: 0.22
-Nodes (11): Queries, Queries, Tx, New(), T, UUID, newPgUUID(), TestConsumeRefreshToken_Concurrent() (+3 more)
+Cohesion: 0.32
+Nodes (6): Queries, Queries, Tx, New(), DBTX, dbHandle
 
 ### Community 510 - "data-card.tsx"
-Cohesion: 0.11
-Nodes (27): T, TestHealthEndpoint(), decodeBulkBody(), decodeResourceBody(), HandlerFunc, ResourceServer, ListTransactionsParams, Pool (+19 more)
+Cohesion: 0.15
+Nodes (24): decodeBulkBody(), decodeResourceBody(), HandlerFunc, ResourceServer, ListTransactionsParams, Pool, Queries, Request (+16 more)
 
 ### Community 511 - "BulkDeleteTransactions200JSONResponse"
 Cohesion: 0.33
@@ -1026,8 +1028,8 @@ Cohesion: 0.33
 Nodes (9): init(), mustRandomInt(), New(), randomBase36(), randomUint64(), strconv36(), T, TestNew_IsUnique() (+1 more)
 
 ### Community 515 - "query-provider.tsx"
-Cohesion: 0.07
-Nodes (44): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), INITIAL_IMPORT_RESULTS, VARIANTS, ImportableTransactionField (+36 more)
+Cohesion: 0.09
+Nodes (30): INITIAL_IMPORT_RESULTS, TransactionsPage(), VARIANTS, CSVReaderRenderProps, CSVUploadResults, Props, UploadButton(), boxVariant (+22 more)
 
 ### Community 516 - "api-base-url.ts"
 Cohesion: 0.33
@@ -1038,8 +1040,8 @@ Cohesion: 0.22
 Nodes (8): graphify reference: extra exports and benchmark, Step 6b - Wiki (only if --wiki flag), Step 7 - Neo4j export (only if --neo4j or --neo4j-push flag), Step 7a - FalkorDB export (only if --falkordb or --falkordb-push flag), Step 7b - SVG export (only if --svg flag), Step 7c - GraphML export (only if --graphml flag), Step 7d - MCP server (only if --mcp flag), Step 8 - Token reduction benchmark (only if total_words > 5000)
 
 ### Community 518 - "graphify reference: query, path, explain"
-Cohesion: 0.07
-Nodes (33): geistMono, geistSans, metadata, NavButton(), Props, routes, Sheet(), SheetContent() (+25 more)
+Cohesion: 0.11
+Nodes (24): routes, Sheet(), SheetContent(), SheetDescription(), SheetFooter(), SheetHeader(), SheetOverlay(), SheetTitle() (+16 more)
 
 ### Community 519 - "README.md"
 Cohesion: 0.25
@@ -1094,8 +1096,8 @@ Cohesion: 0.25
 Nodes (7): Index program, Performance acceptance gate, Performance and Query Engineering, Pool and runtime tuning, Query rules, Service objectives and budgets, Summary strategy
 
 ### Community 532 - "InvalidParamFormatError"
-Cohesion: 0.21
-Nodes (11): buildPoolConfig(), createPool(), DatabasePoolCache, getDatabaseUrl(), getOrCreateCachedPool(), isLocalDatabaseUrl(), LOCAL_HOSTS, shouldAllowInsecureTls() (+3 more)
+Cohesion: 0.50
+Nodes (4): 3. Transfers, Balances, and Net Worth, Product impact, What this feature should achieve, Why this matters
 
 ### Community 533 - "Robustness and Transaction Semantics"
 Cohesion: 0.29
@@ -1106,8 +1108,8 @@ Cohesion: 0.17
 Nodes (12): Categories are optional, and must be yours, Currency, Editing replaces the whole transaction, Importing many at once, Messages a user can encounter, Money is stored exactly, never as a decimal, Rate limiting, Related (+4 more)
 
 ### Community 535 - "GetAccount200JSONResponse"
-Cohesion: 0.26
-Nodes (12): ApiError, bearerToken(), Context, Handler, ResponseWriter, UUID, RequireAuth(), UserIDFromContext() (+4 more)
+Cohesion: 0.31
+Nodes (10): ApiError, bearerToken(), Context, Handler, ResponseWriter, RequireAuth(), writeAccessTokenExpiredError(), writeAPIError() (+2 more)
 
 ### Community 536 - "GetCategory200JSONResponse"
 Cohesion: 0.08
@@ -1142,16 +1144,16 @@ Cohesion: 0.40
 Nodes (5): Default view, Filtering by an account that isn't yours, Filters, Ordering, The transaction list
 
 ### Community 544 - "WithUserTx"
-Cohesion: 0.29
-Nodes (9): databaseHost(), main(), connectionRoleAttributes(), Context, Pool, Queries, UUID, VerifyRLSActive() (+1 more)
+Cohesion: 0.42
+Nodes (9): connectionRoleAttributes(), Context, Pool, Queries, TxOptions, UUID, VerifyRLSActive(), WithUserTx() (+1 more)
 
 ### Community 545 - "UnmarshalingParamError"
 Cohesion: 0.14
-Nodes (14): 2. Import Review, Normalization, and Deduplication, 3. Transfers, Balances, and Net Worth, Current roadmap principle, Nuchi Roadmap Features List, Open banking readiness, Parser service alignment, Product impact, Product impact (+6 more)
+Nodes (14): 1. Unified Import Inbox, 4. Budgets and Monthly Planning, Current roadmap principle, Nuchi Roadmap Features List, Open banking readiness, Parser service alignment, Product impact, Product impact (+6 more)
 
 ### Community 546 - "NewPool"
-Cohesion: 0.33
-Nodes (7): Context, Pool, NewPool(), T, TestNewPool_InvalidURL(), TestNewPool_LiveDatabase(), TestNewPool_UnreachableServer()
+Cohesion: 0.24
+Nodes (9): databaseHost(), main(), Context, Pool, NewPool(), T, TestNewPool_InvalidURL(), TestNewPool_LiveDatabase() (+1 more)
 
 ### Community 547 - "TestFinanceBaseSchema_LiveDatabase"
 Cohesion: 0.61
@@ -1160,6 +1162,10 @@ Nodes (7): assertFK(), assertIndexDefinition(), assertUniqueIndexColumns(), Cont
 ### Community 548 - "GetTransaction200JSONResponse"
 Cohesion: 0.57
 Nodes (6): assertCascadingUserFK(), assertUniqueColumn(), Context, Pool, T, TestAuthBaseSchema_LiveDatabase()
+
+### Community 549 - "New"
+Cohesion: 0.18
+Nodes (5): Codex — Summary Aggregate Contract Range, Decision record, Problem and evidence, Required decision, Verification
 
 ### Community 550 - "ListTransactions200JSONResponse"
 Cohesion: 0.50
@@ -1181,13 +1187,9 @@ Nodes (3): Answer, Q: Should Nuchi create shared Claude and Codex skills around 
 Cohesion: 0.50
 Nodes (3): For git commit hook, For native CLAUDE.md integration, graphify reference: commit hook and native CLAUDE.md integration
 
-### Community 555 - "UpdateTransaction404JSONResponse"
-Cohesion: 0.50
-Nodes (4): 4. Budgets and Monthly Planning, Product impact, What this feature should achieve, Why this matters
-
 ### Community 556 - "api-base-url.ts"
-Cohesion: 0.12
-Nodes (20): bulkCreateValidationError(), bulkDeleteValidationError(), ResourceServer, Queries, Request, ResponseWriter, Transaction, UUID (+12 more)
+Cohesion: 0.13
+Nodes (16): validationError(), bulkCreateValidationError(), bulkDeleteValidationError(), ResourceServer, Queries, Request, ResponseWriter, Transaction (+8 more)
 
 ### Community 557 - "BulkDeleteTransactions200JSONResponse"
 Cohesion: 0.25
@@ -1209,10 +1211,6 @@ Nodes (3): For --cluster-only, For --update (incremental re-extraction), graphif
 Cohesion: 0.33
 Nodes (5): 0016 — Bulk body limits are enforced against the stream, not just Content-Length, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
-### Community 562 - "UpdateTransaction200JSONResponse"
-Cohesion: 0.40
-Nodes (3): InvalidRefreshTokenErrorJSONResponse, LogoutUser401JSONResponse, RefreshSession401JSONResponse
-
 ### Community 563 - "VerifyEmail200JSONResponse"
 Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: check the tickets going foward, what we shall continue with after this pr merges ?, Source Nodes
@@ -1226,23 +1224,23 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: last comment address if you have anything more to say label it for a future improvement post migration and name it Codex-{title}, Source Nodes
 
 ## Knowledge Gaps
-- **1189 isolated node(s):** `Props`, `ResponseType`, `Props`, `ResponseType`, `Props` (+1184 more)
+- **1193 isolated node(s):** `Props`, `ResponseType`, `Props`, `ResponseType`, `Props` (+1188 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **395 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **398 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `ApiErrorResponse` connect `amount-input.tsx` to `New Router`, `Page Tsx`, `Components Json`, `Transactions Ts`?**
-  _High betweenness centrality (0.031) - this node is a cross-community bridge._
-- **Why does `NewPool()` connect `NewPool` to `WithUserTx`, `Current API Parity Fixtures`, `.CreateCategory`, `TestFinanceBaseSchema_LiveDatabase`, `GetTransaction200JSONResponse`, `New Router`, `select.tsx`, `liveDatabaseURL`, `Components Json`, `GetSummary400JSONResponse`?**
-  _High betweenness centrality (0.026) - this node is a cross-community bridge._
-- **Why does `toAuthUser()` connect `name` to `notNull`, `Route Ts`?**
-  _High betweenness centrality (0.023) - this node is a cross-community bridge._
+  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+- **Why does `NewPool()` connect `NewPool` to `Current API Parity Fixtures`, `.CreateCategory`, `TestFinanceBaseSchema_LiveDatabase`, `GetTransaction200JSONResponse`, `New Router`, `Indexes Columns`, `select.tsx`, `liveDatabaseURL`, `Components Json`?**
+  _High betweenness centrality (0.027) - this node is a cross-community bridge._
+- **Why does `toAuthUser()` connect `name` to `Route Ts`?**
+  _High betweenness centrality (0.021) - this node is a cross-community bridge._
 - **Are the 29 inferred relationships involving `newTransactionsTestEnv()` (e.g. with `TestSummaryLive_AccountFilter()` and `TestSummaryLive_CategoryBreakdown()`) actually correct?**
   _`newTransactionsTestEnv()` has 29 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Props`, `ResponseType`, `Props` to the rest of the system?**
-  _1214 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1218 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Transaction Form Tsx` be split into smaller, more focused modules?**
   _Cohesion score 0.11764705882352941 - nodes in this community are weakly interconnected._
 - **Should `Dependencies Class Variance Authority` be split into smaller, more focused modules?**

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - nuchi  (2026-08-08)
+# Graph Report - wt-48  (2026-08-08)
 
 ## Corpus Check
-- 309 files · ~164,496 words
+- 324 files · ~179,954 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3008 nodes · 5369 edges · 581 communities (177 shown, 404 thin omitted)
-- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 429 edges (avg confidence: 0.8)
+- 3135 nodes · 5573 edges · 572 communities (177 shown, 395 thin omitted)
+- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 469 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `0e66a419`
+- Built from commit: `79548587`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -545,7 +545,6 @@
 - [[_COMMUNITY_NewPool|NewPool]]
 - [[_COMMUNITY_TestFinanceBaseSchema_LiveDatabase|TestFinanceBaseSchema_LiveDatabase]]
 - [[_COMMUNITY_GetTransaction200JSONResponse|GetTransaction200JSONResponse]]
-- [[_COMMUNITY_New|New]]
 - [[_COMMUNITY_ListTransactions200JSONResponse|ListTransactions200JSONResponse]]
 - [[_COMMUNITY_UpdateCategory200JSONResponse|UpdateCategory200JSONResponse]]
 - [[_COMMUNITY_VerifyEmail200JSONResponse|VerifyEmail200JSONResponse]]
@@ -568,44 +567,35 @@
 - [[_COMMUNITY_EmailNotVerifiedErrorJSONResponse|EmailNotVerifiedErrorJSONResponse]]
 - [[_COMMUNITY_RequiredHeaderError|RequiredHeaderError]]
 - [[_COMMUNITY_BulkDeleteAccounts200JSONResponse|BulkDeleteAccounts200JSONResponse]]
-- [[_COMMUNITY_BulkDeleteCategories200JSONResponse|BulkDeleteCategories200JSONResponse]]
-- [[_COMMUNITY_DeleteTransaction200JSONResponse|DeleteTransaction200JSONResponse]]
-- [[_COMMUNITY_GetSummary200JSONResponse|GetSummary200JSONResponse]]
-- [[_COMMUNITY_GetTransaction200JSONResponse|GetTransaction200JSONResponse]]
-- [[_COMMUNITY_ListAccounts200JSONResponse|ListAccounts200JSONResponse]]
-- [[_COMMUNITY_ListTransactions200JSONResponse|ListTransactions200JSONResponse]]
-- [[_COMMUNITY_UpdateAccount200JSONResponse|UpdateAccount200JSONResponse]]
-- [[_COMMUNITY_UpdateTransaction200JSONResponse|UpdateTransaction200JSONResponse]]
-- [[_COMMUNITY_UpdateTransaction404JSONResponse|UpdateTransaction404JSONResponse]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `cn()` - 95 edges
-2. `newAuthTestEnv()` - 42 edges
-3. `createApiError()` - 41 edges
-4. `newTransactionsTestEnv()` - 35 edges
-5. `ServerInterfaceWrapper` - 33 edges
-6. `strictHandler` - 32 edges
-7. `Unimplemented` - 29 edges
-8. `newAccountsTestEnv()` - 27 edges
-9. `createTestAccount()` - 27 edges
+2. `newTransactionsTestEnv()` - 45 edges
+3. `newAuthTestEnv()` - 42 edges
+4. `createApiError()` - 41 edges
+5. `createTestAccount()` - 34 edges
+6. `ServerInterfaceWrapper` - 33 edges
+7. `strictHandler` - 32 edges
+8. `Unimplemented` - 29 edges
+9. `newAccountsTestEnv()` - 27 edges
 10. `Button()` - 26 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `Generated Go Output` --semantically_similar_to--> `generated.gen.go`  [INFERRED] [semantically similar]
   openapi/oapi-codegen.yaml → backend/internal/openapi/README.md
-- `DialogOverlay()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/dialog.tsx → lib/utils.ts
-- `PopoverHeader()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/popover.tsx → lib/utils.ts
-- `PopoverTitle()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/popover.tsx → lib/utils.ts
-- `PopoverDescription()` --calls--> `cn()`  [EXTRACTED]
-  components/ui/popover.tsx → lib/utils.ts
+- `SheetOverlay()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/sheet.tsx → lib/utils.ts
+- `SheetFooter()` --calls--> `cn()`  [EXTRACTED]
+  components/ui/sheet.tsx → lib/utils.ts
+- `AccountsPage()` --calls--> `useNewAccount`  [EXTRACTED]
+  app/(dashboard)/accounts/page.tsx → features/accounts/hooks/use-new-account.ts
+- `CategoriesPage()` --calls--> `useNewCategory`  [EXTRACTED]
+  app/(dashboard)/categories/page.tsx → features/categories/hooks/use-new-category.ts
 
 ## Import Cycles
 - None detected.
 
-## Communities (581 total, 404 thin omitted)
+## Communities (572 total, 395 thin omitted)
 
 ### Community 0 - "Transaction Form Tsx"
 Cohesion: 0.12
@@ -632,8 +622,8 @@ Cohesion: 0.06
 Nodes (31): 1. Frontend - Data/State (Next.js, React hooks, mutation hooks), 2. Frontend - UI Components (Shadcn/Radix UI, table rendering), 3. State Management (Custom hooks, promise-based dialog flow), 4. Developer Experience & Configuration (Dependency and repo hygiene), API, Automated Testing Needs, Breaking Changes, Business Value (+23 more)
 
 ### Community 9 - "0004 Snapshot Json"
-Cohesion: 0.09
-Nodes (25): CategoryTooltip(), CategoryTooltipPayload, CategoryTooltipProps, Chart(), ChartLoading(), DataCardLoading(), DataCharts(), DataGrid() (+17 more)
+Cohesion: 0.08
+Nodes (28): AmountInput(), Props, AreaVariant(), Props, BarVariant(), Props, CategoryTooltip(), CategoryTooltipPayload (+20 more)
 
 ### Community 10 - "Data Card Tsx"
 Cohesion: 0.33
@@ -648,32 +638,32 @@ Cohesion: 0.17
 Nodes (20): Duration, Mutex, Time, New(), Duration, Mutex, T, Time (+12 more)
 
 ### Community 14 - "0002 Snapshot Json"
-Cohesion: 0.12
-Nodes (21): DateFilter(), Preset, PresetKey, PRESETS, DatePicker(), Props, NavButton(), Props (+13 more)
+Cohesion: 0.08
+Nodes (24): For /graphify add and --watch, For /graphify query, For the commit hook and native CLAUDE.md integration, For --update and --cluster-only, /graphify, Honesty Rules, Interpreter guard for subcommands, Part A - Structural extraction for code files (+16 more)
 
 ### Community 16 - "Project Polish Pr Summary"
 Cohesion: 0.20
 Nodes (9): Follow-Up Memory, Implemented Scope, Last Verified, Local Database, Memory Index, ProjectPolish Context, Restart Point, Safety Rules (+1 more)
 
 ### Community 17 - "Transactions Ts"
-Cohesion: 0.02
-Nodes (131): ResourceId, Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody (+123 more)
+Cohesion: 0.01
+Nodes (145): ResourceId, Time, BulkCreateTransactionsJSONRequestBody, BulkDeleteAccountsJSONRequestBody, BulkDeleteCategoriesJSONRequestBody, BulkDeleteTransactionsJSONRequestBody, ConfirmPasswordResetJSONRequestBody, CreateAccountJSONRequestBody (+137 more)
 
 ### Community 18 - "0001 Snapshot Json"
-Cohesion: 0.27
-Nodes (5): Props, Header(), HeaderLogo(), Navigation(), WelcomeMsg()
+Cohesion: 0.19
+Nodes (8): Props, AccountFilter(), DateFilter(), Filters(), Header(), HeaderLogo(), Navigation(), WelcomeMsg()
 
 ### Community 19 - "Json Editor Code Actions"
-Cohesion: 0.07
-Nodes (37): app, app, app, AppType, DELETE, GET, OPTIONS, PATCH (+29 more)
+Cohesion: 0.14
+Nodes (17): app, app, app, db, pool, accounts, accountsRelations, categories (+9 more)
 
 ### Community 20 - "0000 Snapshot Json"
-Cohesion: 0.25
-Nodes (14): accountNotFoundError(), constraintName(), duplicateAccountNameError(), Account, ResourceServer, Request, ResourceId, ResponseWriter (+6 more)
+Cohesion: 0.21
+Nodes (16): accountNotFoundError(), constraintName(), duplicateAccountNameError(), Account, ResourceServer, Request, ResourceId, ResponseWriter (+8 more)
 
 ### Community 23 - "Nuchi Project Context"
-Cohesion: 0.12
-Nodes (25): FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem(), FormItemContext, FormItemContextValue (+17 more)
+Cohesion: 0.09
+Nodes (29): Props, Select(), FormControl(), FormDescription(), FormField(), FormFieldContext, FormFieldContextValue, FormItem() (+21 more)
 
 ### Community 24 - "Transactions API"
 Cohesion: 0.08
@@ -681,7 +671,7 @@ Nodes (23): Accounts, Accounts, API Shape, Canonical Architecture, Categories, C
 
 ### Community 28 - "Components Json"
 Cohesion: 0.07
-Nodes (74): decodeAPIError(), Cookie, Duration, Handler, authTestEnv, Pool, ResponseRecorder, T (+66 more)
+Nodes (69): decodeAPIError(), Cookie, Duration, Handler, authTestEnv, Pool, ResponseRecorder, T (+61 more)
 
 ### Community 29 - "Schema Ts"
 Cohesion: 0.10
@@ -692,8 +682,8 @@ Cohesion: 0.11
 Nodes (18): aliases, components, hooks, lib, ui, utils, iconLibrary, registries (+10 more)
 
 ### Community 31 - "Scripts Build"
-Cohesion: 0.19
-Nodes (10): geistMono, geistSans, metadata, Toaster(), sonner, getQueryClient(), makeQueryClient(), Props (+2 more)
+Cohesion: 0.16
+Nodes (12): app, enforceJsonBodyLimit(), OwnedReferencesResult, checkTransactionMutationRateLimit(), cleanupMutationRateLimit(), DateRangeQueryOptions, DateRangeQueryResult, isContentLengthTooLarge() (+4 more)
 
 ### Community 32 - "Current API Parity Fixtures"
 Cohesion: 0.31
@@ -709,7 +699,7 @@ Nodes (17): devDependencies, dotenv, drizzle-kit, eslint, eslint-config-next, es
 
 ### Community 35 - "Seed Ts"
 Cohesion: 0.19
-Nodes (11): Props, Select(), Dialog(), DialogContent(), DialogDescription(), DialogFooter(), DialogHeader(), DialogOverlay() (+3 more)
+Nodes (12): Chart(), ChartLoading(), DataCardLoading(), DataCharts(), DataGrid(), SpendingPie(), SpendingPieLoading(), useGetSummary() (+4 more)
 
 ### Community 37 - "Nuchi Application"
 Cohesion: 0.10
@@ -728,20 +718,20 @@ Cohesion: 0.46
 Nodes (14): connect(), execUpgrade(), Context, T, gooseBinary(), insertUpgradeUser(), pgIdent(), runGoose() (+6 more)
 
 ### Community 41 - "New Router"
-Cohesion: 0.09
-Nodes (82): assertAccountNotFound(), assertValidationError(), createTestAccount(), decodeAccountsAPIError(), Handler, Pool, ResponseRecorder, T (+74 more)
+Cohesion: 0.08
+Nodes (95): assertAccountNotFound(), assertValidationError(), createTestAccount(), decodeAccountsAPIError(), Handler, Pool, ResponseRecorder, T (+87 more)
 
 ### Community 42 - "Api Error"
-Cohesion: 0.25
-Nodes (13): isUniqueViolation(), categoryNotFoundError(), duplicateCategoryNameError(), Category, ResourceServer, Request, ResourceId, ResponseWriter (+5 more)
+Cohesion: 0.29
+Nodes (12): categoryNotFoundError(), duplicateCategoryNameError(), Category, ResourceServer, Request, ResourceId, ResponseWriter, toCategory() (+4 more)
 
 ### Community 43 - "Edit Account Sheet Tsx"
 Cohesion: 0.18
 Nodes (10): Commands, Current Risk Areas, Env, graphify, Nuchi Codex Guide, Pull Requests Hard Rules, Reference, Repo Rules (+2 more)
 
 ### Community 45 - "Indexes Columns"
-Cohesion: 0.10
-Nodes (9): RequestType, ResponseType, RequestType, ResponseType, RequestType, ResponseType, useEditTransaction(), ApiError (+1 more)
+Cohesion: 0.19
+Nodes (13): assertSeedAllowed(), databaseUrl, db, defaultFrom, defaultTo, generateRandomAmount(), generateTransactions(), generateTransactionsForDay() (+5 more)
 
 ### Community 47 - "Plaid Id"
 Cohesion: 0.15
@@ -752,8 +742,8 @@ Cohesion: 0.09
 Nodes (26): Context, Queries, Timestamptz, UUID, Text, Timestamp, Timestamptz, UUID (+18 more)
 
 ### Community 49 - "Clerk Auth"
-Cohesion: 0.15
-Nodes (16): ImportableTransactionField, isImportableTransactionField(), options, Props, TableHeadSelect(), AccountFilter(), Filters(), Select() (+8 more)
+Cohesion: 0.17
+Nodes (12): Category breakdown, Daily series, Date handling is shared, not reimplemented, Divergences and gaps, Empty state, Four queries, one transaction, Percentage change, Summary API — Technical Reference (+4 more)
 
 ### Community 50 - "Columns Plaid Id"
 Cohesion: 0.33
@@ -824,16 +814,16 @@ Cohesion: 0.05
 Nodes (20): BulkDeleteAccounts400JSONResponse, BulkDeleteCategories400JSONResponse, ConfirmPasswordReset400JSONResponse, CreateAccount400JSONResponse, CreateCategory400JSONResponse, CreateTransaction400JSONResponse, DeleteAccount400JSONResponse, DeleteCategory400JSONResponse (+12 more)
 
 ### Community 229 - "name"
-Cohesion: 0.23
-Nodes (12): Context, Queries, Text, Timestamp, UUID, Date, GetCategorySpendingParams, GetCategorySpendingRow (+4 more)
+Cohesion: 0.18
+Nodes (11): "Compared to previous period" means the period immediately before, Filtering by one account, "Other", Related, Summary — Product Behavior, The category chart does not add up to the expenses total, The daily chart always covers every day, The period (+3 more)
 
 ### Community 259 - "name"
 Cohesion: 0.33
 Nodes (5): 0011 — No resend endpoint; email delivery is fire-and-forget, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 260 - "name"
-Cohesion: 0.09
-Nodes (30): Actions(), Props, columns, ResponseType, Actions(), Props, columns, ResponseType (+22 more)
+Cohesion: 0.07
+Nodes (42): Actions(), Props, columns, ResponseType, Actions(), Props, columns, ResponseType (+34 more)
 
 ### Community 293 - "name"
 Cohesion: 0.08
@@ -860,8 +850,8 @@ Cohesion: 0.05
 Nodes (21): BulkCreateTransactions500JSONResponse, BulkDeleteAccounts500JSONResponse, BulkDeleteCategories500JSONResponse, BulkDeleteTransactions500JSONResponse, CreateAccount500JSONResponse, CreateCategory500JSONResponse, CreateTransaction500JSONResponse, DatabaseErrorJSONResponse (+13 more)
 
 ### Community 317 - "notNull"
-Cohesion: 0.13
-Nodes (15): Amounts, `categoryId` states, Currency, Deliberate divergences from legacy, Endpoints, Error taxonomy and precedence, Known gaps, Non-negotiables when changing this code (+7 more)
+Cohesion: 0.11
+Nodes (18): Amounts, `categoryId` states, Currency, Date filtering, Deliberate divergences from legacy, Endpoints, Error taxonomy and precedence, Known gaps (+10 more)
 
 ### Community 320 - "name"
 Cohesion: 0.25
@@ -884,8 +874,8 @@ Cohesion: 0.33
 Nodes (5): 0005 — Category duplicate update returns 500, create returns 409, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 348 - "type"
-Cohesion: 0.13
-Nodes (22): Props, DataTableProps, CardAction(), CardFooter(), DropdownMenuCheckboxItem(), DropdownMenuLabel(), DropdownMenuRadioItem(), DropdownMenuSeparator() (+14 more)
+Cohesion: 0.07
+Nodes (41): Props, isImportableTransactionField(), TableHeadSelect(), DataTableProps, Preset, PresetKey, PRESETS, DatePicker() (+33 more)
 
 ### Community 353 - "0006 — transactions.amount is 32-bit, capping a single transaction near ±2.1M ARS"
 Cohesion: 0.29
@@ -933,15 +923,15 @@ Nodes (5): 0010 — Auth operations do not declare 500 responses in the contract
 
 ### Community 378 - "api-base-url.ts"
 Cohesion: 0.26
-Nodes (12): validateAccountName(), validateBulkDeleteIds(), validateResourceName(), validateBulkTransactionInputs(), Text, Timestamp, parseAmount(), validateTransactionInput() (+4 more)
+Nodes (13): validateCategoryName(), validateResourceName(), validateBulkTransactionInputs(), Text, Timestamp, parseAmount(), textPointer(), toTransactionListItem() (+5 more)
 
 ### Community 379 - "name"
 Cohesion: 0.22
 Nodes (9): Alternatives and tradeoffs, Codex — Atomic Multi-Chunk Transaction Imports, Contract and compatibility, Decision record, Invariants, Problem and evidence, Proposed design, Risks (+1 more)
 
 ### Community 388 - ".UpdateCategory"
-Cohesion: 0.50
-Nodes (4): 2. Import Review, Normalization, and Deduplication, Product impact, What this feature should achieve, Why this matters
+Cohesion: 0.20
+Nodes (9): app, AppType, DELETE, GET, OPTIONS, PATCH, POST, PUT (+1 more)
 
 ### Community 395 - "PR Review Cycle"
 Cohesion: 0.29
@@ -968,16 +958,16 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: recheck the fixes and give another pass for reviews, Source Nodes
 
 ### Community 428 - "import-card.tsx"
-Cohesion: 0.19
-Nodes (14): CategoriesPage(), TransactionsPage(), useCreateAccount(), useGetAccounts(), useSelectAccount(), useBulkDeleteCategories(), useGetCategories(), useCreateTransaction() (+6 more)
+Cohesion: 0.28
+Nodes (8): accountIDFilter(), Text, ResourceServer, Request, ResponseWriter, invalidDateQueryError(), invalidQueryError(), InvalidQueryErrorJSONResponse
 
 ### Community 429 - "columns"
 Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: give it a last review of all the files changend in the pr the comments and all that is in place right now in the pr leave comments for medim-high and high issues mid-low and low forget it we mande 3 iterations so far. if something is too big then addres it consitently here so it so i can anlyze it, Source Nodes
 
 ### Community 432 - "GetSummary200JSONResponse"
-Cohesion: 0.10
-Nodes (28): ResponseType, useDeleteAccount(), RequestType, ResponseType, useEditAccount(), useGetAccount(), AccountForm(), EditAccountSheet() (+20 more)
+Cohesion: 0.05
+Nodes (57): AccountsPage(), CategoriesPage(), Actions(), TransactionsPage(), RequestType, ResponseType, useBulkDeleteAccounts(), RequestType (+49 more)
 
 ### Community 435 - "name"
 Cohesion: 0.38
@@ -988,8 +978,8 @@ Cohesion: 0.29
 Nodes (4): AccountNotFoundErrorJSONResponse, DeleteAccount404JSONResponse, GetAccount404JSONResponse, UpdateAccount404JSONResponse
 
 ### Community 503 - "TransactionReferenceNotFoundErrorJSONResponse"
-Cohesion: 0.14
-Nodes (25): accountReferenceNotFoundError(), categoryReferenceNotFoundError(), ResourceServer, ListTransactionsParams, Queries, Request, ResourceId, ResponseWriter (+17 more)
+Cohesion: 0.20
+Nodes (15): accountReferenceNotFoundError(), categoryReferenceNotFoundError(), ResourceServer, ListTransactionsParams, Queries, Request, ResourceId, ResponseWriter (+7 more)
 
 ### Community 504 - "CategoryNotFoundErrorJSONResponse"
 Cohesion: 0.29
@@ -1016,8 +1006,8 @@ Cohesion: 0.22
 Nodes (11): Queries, Queries, Tx, New(), T, UUID, newPgUUID(), TestConsumeRefreshToken_Concurrent() (+3 more)
 
 ### Community 510 - "data-card.tsx"
-Cohesion: 0.15
-Nodes (21): decodeBulkBody(), decodeResourceBody(), HandlerFunc, ResourceServer, ListTransactionsParams, Pool, Queries, Request (+13 more)
+Cohesion: 0.11
+Nodes (27): T, TestHealthEndpoint(), decodeBulkBody(), decodeResourceBody(), HandlerFunc, ResourceServer, ListTransactionsParams, Pool (+19 more)
 
 ### Community 511 - "BulkDeleteTransactions200JSONResponse"
 Cohesion: 0.33
@@ -1036,20 +1026,20 @@ Cohesion: 0.33
 Nodes (9): init(), mustRandomInt(), New(), randomBase36(), randomUint64(), strconv36(), T, TestNew_IsUnique() (+1 more)
 
 ### Community 515 - "query-provider.tsx"
-Cohesion: 0.13
-Nodes (22): INITIAL_IMPORT_RESULTS, VARIANTS, CSVReaderRenderProps, CSVUploadResults, Props, UploadButton(), ChartEnum, Props (+14 more)
+Cohesion: 0.07
+Nodes (44): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), INITIAL_IMPORT_RESULTS, VARIANTS, ImportableTransactionField (+36 more)
 
 ### Community 516 - "api-base-url.ts"
 Cohesion: 0.33
 Nodes (5): 0013 — Resource endpoints accept unbounded request bodies, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 517 - "RegisterUser201JSONResponse"
-Cohesion: 0.23
-Nodes (11): ImportCard(), Props, requiredOptions, SelectedColumnsState, ImportTable(), ImportedTransactionRow, ImportedTransactionRowError, parseImportedTransactionRows() (+3 more)
+Cohesion: 0.22
+Nodes (8): graphify reference: extra exports and benchmark, Step 6b - Wiki (only if --wiki flag), Step 7 - Neo4j export (only if --neo4j or --neo4j-push flag), Step 7a - FalkorDB export (only if --falkordb or --falkordb-push flag), Step 7b - SVG export (only if --svg flag), Step 7c - GraphML export (only if --graphml flag), Step 7d - MCP server (only if --mcp flag), Step 8 - Token reduction benchmark (only if total_words > 5000)
 
 ### Community 518 - "graphify reference: query, path, explain"
-Cohesion: 0.14
-Nodes (20): Sheet(), SheetContent(), SheetDescription(), SheetHeader(), SheetTitle(), InsertCategorySchema, FormValues, NewAccountSheet() (+12 more)
+Cohesion: 0.07
+Nodes (33): geistMono, geistSans, metadata, NavButton(), Props, routes, Sheet(), SheetContent() (+25 more)
 
 ### Community 519 - "README.md"
 Cohesion: 0.25
@@ -1104,8 +1094,8 @@ Cohesion: 0.25
 Nodes (7): Index program, Performance acceptance gate, Performance and Query Engineering, Pool and runtime tuning, Query rules, Service objectives and budgets, Summary strategy
 
 ### Community 532 - "InvalidParamFormatError"
-Cohesion: 0.11
-Nodes (24): buildPoolConfig(), createPool(), DatabasePoolCache, getDatabaseUrl(), getOrCreateCachedPool(), isLocalDatabaseUrl(), LOCAL_HOSTS, shouldAllowInsecureTls() (+16 more)
+Cohesion: 0.21
+Nodes (11): buildPoolConfig(), createPool(), DatabasePoolCache, getDatabaseUrl(), getOrCreateCachedPool(), isLocalDatabaseUrl(), LOCAL_HOSTS, shouldAllowInsecureTls() (+3 more)
 
 ### Community 533 - "Robustness and Transaction Semantics"
 Cohesion: 0.29
@@ -1120,12 +1110,16 @@ Cohesion: 0.26
 Nodes (12): ApiError, bearerToken(), Context, Handler, ResponseWriter, UUID, RequireAuth(), UserIDFromContext() (+4 more)
 
 ### Community 536 - "GetCategory200JSONResponse"
-Cohesion: 0.27
-Nodes (15): calendarDaysBetween(), endOfDay(), Time, parseCalendarDate(), parseDateRange(), T, present(), TestParseDateRange_BoundariesAreWholeDays() (+7 more)
+Cohesion: 0.08
+Nodes (41): Context, Queries, Text, Timestamp, UUID, calendarDaysBetween(), endOfDay(), Time (+33 more)
 
 ### Community 537 - "scripts"
 Cohesion: 0.12
 Nodes (17): scripts, build, db:generate, db:migrate, db:seed, db:studio, dev, dev:neon (+9 more)
+
+### Community 538 - "pgUserID"
+Cohesion: 0.33
+Nodes (5): For /graphify explain, For /graphify path, graphify reference: query, path, explain, Step 0 — Constrained query expansion (REQUIRED before traversal), Step 1 — Traversal
 
 ### Community 539 - "GetTransaction200JSONResponse"
 Cohesion: 0.40
@@ -1136,8 +1130,8 @@ Cohesion: 0.29
 Nodes (6): API Contract and Documentation Standard, Contract workflow, Documentation acceptance gate, Internal documentation, Operational documentation, Required operation documentation
 
 ### Community 541 - "UnescapedCookieParamError"
-Cohesion: 0.19
-Nodes (9): AreaVariant(), Props, BarVariant(), Props, CustomTooltip(), CustomTooltipProps, TooltipPayloadItem, LineVariant() (+1 more)
+Cohesion: 0.33
+Nodes (5): 0017 — The summary category chart silently excludes uncategorized spending, How it was migrated, Proposed improvement, The concern, Why it was done this way
 
 ### Community 542 - "edit-category-sheet.tsx"
 Cohesion: 0.40
@@ -1152,8 +1146,8 @@ Cohesion: 0.29
 Nodes (9): databaseHost(), main(), connectionRoleAttributes(), Context, Pool, Queries, UUID, VerifyRLSActive() (+1 more)
 
 ### Community 545 - "UnmarshalingParamError"
-Cohesion: 0.22
-Nodes (6): 3. Transfers, Balances, and Net Worth, Nuchi Roadmap Features List, Product impact, Roadmap Context, What this feature should achieve, Why this matters
+Cohesion: 0.14
+Nodes (14): 2. Import Review, Normalization, and Deduplication, 3. Transfers, Balances, and Net Worth, Current roadmap principle, Nuchi Roadmap Features List, Open banking readiness, Parser service alignment, Product impact, Product impact (+6 more)
 
 ### Community 546 - "NewPool"
 Cohesion: 0.33
@@ -1167,9 +1161,9 @@ Nodes (7): assertFK(), assertIndexDefinition(), assertUniqueIndexColumns(), Cont
 Cohesion: 0.57
 Nodes (6): assertCascadingUserFK(), assertUniqueColumn(), Context, Pool, T, TestAuthBaseSchema_LiveDatabase()
 
-### Community 549 - "New"
-Cohesion: 0.22
-Nodes (7): ResponseType, useDeleteCategory(), RequestType, ResponseType, useEditCategory(), useGetCategory(), EditCategorySheet()
+### Community 550 - "ListTransactions200JSONResponse"
+Cohesion: 0.50
+Nodes (3): For /graphify add, For --watch, graphify reference: add a URL and watch a folder
 
 ### Community 551 - "UpdateCategory200JSONResponse"
 Cohesion: 0.33
@@ -1183,13 +1177,17 @@ Nodes (4): Answer, Outcome, Q: would it be a good complement or suplement adding
 Cohesion: 0.50
 Nodes (3): Answer, Q: Should Nuchi create shared Claude and Codex skills around Graphify and CodeGraph after the Go migration?, Source Nodes
 
+### Community 554 - "UpdateAccount200JSONResponse"
+Cohesion: 0.50
+Nodes (3): For git commit hook, For native CLAUDE.md integration, graphify reference: commit hook and native CLAUDE.md integration
+
 ### Community 555 - "UpdateTransaction404JSONResponse"
 Cohesion: 0.50
 Nodes (4): 4. Budgets and Monthly Planning, Product impact, What this feature should achieve, Why this matters
 
 ### Community 556 - "api-base-url.ts"
 Cohesion: 0.12
-Nodes (17): bulkCreateValidationError(), bulkDeleteValidationError(), ResourceServer, Queries, Request, ResponseWriter, Transaction, UUID (+9 more)
+Nodes (20): bulkCreateValidationError(), bulkDeleteValidationError(), ResourceServer, Queries, Request, ResponseWriter, Transaction, UUID (+12 more)
 
 ### Community 557 - "BulkDeleteTransactions200JSONResponse"
 Cohesion: 0.25
@@ -1204,8 +1202,8 @@ Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: recheck the changes and doanother review, Source Nodes
 
 ### Community 560 - "ListAccounts200JSONResponse"
-Cohesion: 0.67
-Nodes (3): Date filtering, Presence vs emptiness, The three date errors
+Cohesion: 0.50
+Nodes (3): For --cluster-only, For --update (incremental re-extraction), graphify reference: incremental update and cluster-only
 
 ### Community 561 - "ListCategories200JSONResponse"
 Cohesion: 0.33
@@ -1219,58 +1217,32 @@ Nodes (3): InvalidRefreshTokenErrorJSONResponse, LogoutUser401JSONResponse, Refr
 Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: check the tickets going foward, what we shall continue with after this pr merges ?, Source Nodes
 
-### Community 564 - "Strategic Notes"
-Cohesion: 0.50
-Nodes (4): Current roadmap principle, Open banking readiness, Parser service alignment, Strategic Notes
-
-### Community 565 - "InvalidParamFormatError"
-Cohesion: 0.39
-Nodes (6): AmountInput(), Props, Tooltip(), TooltipContent(), TooltipProvider(), TooltipTrigger()
-
 ### Community 566 - "liveDatabaseURL"
 Cohesion: 0.33
 Nodes (5): T, liveDatabaseURL(), T, TestForeignKeyConstraintNamesMatchTheSchema_LiveDatabase(), TestReferenceErrorFromForeignKeyViolation()
-
-### Community 567 - "UnmarshalingParamError"
-Cohesion: 0.40
-Nodes (4): AccountsPage(), RequestType, ResponseType, useBulkDeleteAccounts()
 
 ### Community 568 - "Q: last comment address if you have anything more to say label it for a future improvement post migration and name it Codex-{title}"
 Cohesion: 0.40
 Nodes (4): Answer, Outcome, Q: last comment address if you have anything more to say label it for a future improvement post migration and name it Codex-{title}, Source Nodes
 
 ## Knowledge Gaps
-- **1125 isolated node(s):** `Props`, `ResponseType`, `Props`, `ResponseType`, `Props` (+1120 more)
+- **1189 isolated node(s):** `Props`, `ResponseType`, `Props`, `ResponseType`, `Props` (+1184 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **404 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
-
-## Work-memory lessons
-
-**Preferred sources** — corroborated by past sessions; start here.
-- `Config` (3× useful, score=1.830176442)
-- `JWT Access Tokens` (3× useful, score=1.687658685)
-- `RefreshToken` (3× useful, score=1.687658685)
-- `AuthSessionResponse` (3× useful, score=1.687658685)
-- `Authentication and sessions` (3× useful, score=1.687658685)
-- `Contract` (2× useful, score=1.59704832)
-- `transactions.ts` (2× useful, score=1.56932953)
-- `schema.ts` (2× useful, score=1.56932953)
-- `use-create-transaction.ts` (2× useful, score=1.56932953)
-- `Architecture` (2× useful, score=1.56932953)
+- **395 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `ApiErrorResponse` connect `amount-input.tsx` to `New Router`, `Page Tsx`, `Components Json`, `Transactions Ts`?**
-  _High betweenness centrality (0.038) - this node is a cross-community bridge._
+  _High betweenness centrality (0.031) - this node is a cross-community bridge._
 - **Why does `NewPool()` connect `NewPool` to `WithUserTx`, `Current API Parity Fixtures`, `.CreateCategory`, `TestFinanceBaseSchema_LiveDatabase`, `GetTransaction200JSONResponse`, `New Router`, `select.tsx`, `liveDatabaseURL`, `Components Json`, `GetSummary400JSONResponse`?**
   _High betweenness centrality (0.026) - this node is a cross-community bridge._
 - **Why does `toAuthUser()` connect `name` to `notNull`, `Route Ts`?**
-  _High betweenness centrality (0.024) - this node is a cross-community bridge._
-- **Are the 21 inferred relationships involving `newAuthTestEnv()` (e.g. with `NewPool()` and `NewAuthServer()`) actually correct?**
-  _`newAuthTestEnv()` has 21 INFERRED edges - model-reasoned connections that need verification._
+  _High betweenness centrality (0.023) - this node is a cross-community bridge._
+- **Are the 29 inferred relationships involving `newTransactionsTestEnv()` (e.g. with `TestSummaryLive_AccountFilter()` and `TestSummaryLive_CategoryBreakdown()`) actually correct?**
+  _`newTransactionsTestEnv()` has 29 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Props`, `ResponseType`, `Props` to the rest of the system?**
-  _1150 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1214 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Transaction Form Tsx` be split into smaller, more focused modules?**
   _Cohesion score 0.11764705882352941 - nodes in this community are weakly interconnected._
 - **Should `Dependencies Class Variance Authority` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -50,7 +50,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions",
-      "community": 260,
+      "community": 348,
       "norm_label": "actions.tsx"
     },
     {
@@ -60,7 +60,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "app_dashboard_accounts_actions_props",
-      "community": 260,
+      "community": 348,
       "norm_label": "props"
     },
     {
@@ -240,7 +240,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_page",
-      "community": 35,
+      "community": 515,
       "norm_label": "page.tsx"
     },
     {
@@ -250,7 +250,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "app_dashboard_page_dashboardpage",
-      "community": 35,
+      "community": 515,
       "norm_label": "dashboardpage()"
     },
     {
@@ -290,7 +290,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_actions",
-      "community": 260,
+      "community": 348,
       "norm_label": "actions.tsx"
     },
     {
@@ -300,7 +300,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "app_dashboard_transactions_actions_props",
-      "community": 260,
+      "community": 348,
       "norm_label": "props"
     },
     {
@@ -310,7 +310,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_dashboard_transactions_actions_actions",
-      "community": 432,
+      "community": 260,
       "norm_label": "actions()"
     },
     {
@@ -380,7 +380,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card",
-      "community": 515,
+      "community": 2,
       "norm_label": "import-card.tsx"
     },
     {
@@ -390,7 +390,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_requiredoptions",
-      "community": 515,
+      "community": 2,
       "norm_label": "requiredoptions"
     },
     {
@@ -400,7 +400,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_selectedcolumnsstate",
-      "community": 515,
+      "community": 2,
       "norm_label": "selectedcolumnsstate"
     },
     {
@@ -410,7 +410,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_props",
-      "community": 515,
+      "community": 2,
       "norm_label": "props"
     },
     {
@@ -420,7 +420,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_importcard",
-      "community": 515,
+      "community": 2,
       "norm_label": "importcard()"
     },
     {
@@ -430,7 +430,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table",
-      "community": 348,
+      "community": 2,
       "norm_label": "import-table.tsx"
     },
     {
@@ -440,7 +440,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table_props",
-      "community": 348,
+      "community": 2,
       "norm_label": "props"
     },
     {
@@ -450,7 +450,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table_importtable",
-      "community": 515,
+      "community": 2,
       "norm_label": "importtable()"
     },
     {
@@ -490,7 +490,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_transactionspage",
-      "community": 432,
+      "community": 515,
       "norm_label": "transactionspage()"
     },
     {
@@ -510,7 +510,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select",
-      "community": 515,
+      "community": 9,
       "norm_label": "table-head-select.tsx"
     },
     {
@@ -520,7 +520,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_props",
-      "community": 515,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -530,7 +530,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_options",
-      "community": 515,
+      "community": 9,
       "norm_label": "options"
     },
     {
@@ -540,7 +540,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_importabletransactionfield",
-      "community": 515,
+      "community": 9,
       "norm_label": "importabletransactionfield"
     },
     {
@@ -550,7 +550,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_isimportabletransactionfield",
-      "community": 348,
+      "community": 9,
       "norm_label": "isimportabletransactionfield()"
     },
     {
@@ -560,7 +560,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_tableheadselect",
-      "community": 348,
+      "community": 9,
       "norm_label": "tableheadselect()"
     },
     {
@@ -660,7 +660,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_api_route_route",
-      "community": 388,
+      "community": 19,
       "norm_label": "route.ts"
     },
     {
@@ -670,7 +670,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_api_route_route_app",
-      "community": 388,
+      "community": 19,
       "norm_label": "app"
     },
     {
@@ -680,7 +680,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "app_api_route_route_routes",
-      "community": 388,
+      "community": 19,
       "norm_label": "routes"
     },
     {
@@ -690,7 +690,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "app_api_route_route_get",
-      "community": 388,
+      "community": 19,
       "norm_label": "get"
     },
     {
@@ -700,7 +700,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_api_route_route_post",
-      "community": 388,
+      "community": 19,
       "norm_label": "post"
     },
     {
@@ -710,7 +710,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "app_api_route_route_patch",
-      "community": 388,
+      "community": 19,
       "norm_label": "patch"
     },
     {
@@ -720,7 +720,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "app_api_route_route_delete",
-      "community": 388,
+      "community": 19,
       "norm_label": "delete"
     },
     {
@@ -730,7 +730,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "app_api_route_route_put",
-      "community": 388,
+      "community": 19,
       "norm_label": "put"
     },
     {
@@ -740,7 +740,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "app_api_route_route_options",
-      "community": 388,
+      "community": 19,
       "norm_label": "options"
     },
     {
@@ -750,7 +750,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "app_api_route_route_apptype",
-      "community": 388,
+      "community": 19,
       "norm_label": "apptype"
     },
     {
@@ -780,7 +780,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_api_route_transactions",
-      "community": 31,
+      "community": 19,
       "norm_label": "transactions.ts"
     },
     {
@@ -790,7 +790,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "app_api_route_transactions_ownedreferencesresult",
-      "community": 31,
+      "community": 19,
       "norm_label": "ownedreferencesresult"
     },
     {
@@ -800,7 +800,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "app_api_route_transactions_validatetransactionreferences",
-      "community": 31,
+      "community": 19,
       "norm_label": "validatetransactionreferences()"
     },
     {
@@ -810,7 +810,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "app_api_route_transactions_validatebulktransactionreferences",
-      "community": 31,
+      "community": 19,
       "norm_label": "validatebulktransactionreferences()"
     },
     {
@@ -820,7 +820,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "app_api_route_transactions_sendratelimited",
-      "community": 31,
+      "community": 19,
       "norm_label": "sendratelimited()"
     },
     {
@@ -840,7 +840,7 @@
       "source_location": "L182",
       "_origin": "ast",
       "id": "app_api_route_transactions_app",
-      "community": 31,
+      "community": 19,
       "norm_label": "app"
     },
     {
@@ -850,7 +850,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_layout",
-      "community": 518,
+      "community": 35,
       "norm_label": "layout.tsx"
     },
     {
@@ -860,7 +860,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "app_layout_geistsans",
-      "community": 518,
+      "community": 35,
       "norm_label": "geistsans"
     },
     {
@@ -870,7 +870,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_layout_geistmono",
-      "community": 518,
+      "community": 35,
       "norm_label": "geistmono"
     },
     {
@@ -880,7 +880,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_layout_metadata",
-      "community": 518,
+      "community": 35,
       "norm_label": "metadata"
     },
     {
@@ -890,7 +890,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_layout_rootlayout",
-      "community": 518,
+      "community": 35,
       "norm_label": "rootlayout()"
     },
     {
@@ -900,7 +900,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_cmd_api_main",
-      "community": 544,
+      "community": 546,
       "norm_label": "main.go"
     },
     {
@@ -910,7 +910,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "backend_cmd_api_main_main",
-      "community": 544,
+      "community": 546,
       "norm_label": "main()"
     },
     {
@@ -920,7 +920,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "backend_cmd_api_main_databasehost",
-      "community": 544,
+      "community": 546,
       "norm_label": "databasehost()"
     },
     {
@@ -3542,7 +3542,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_db_queries_live_test",
-      "community": 509,
+      "community": 45,
       "norm_label": "queries_live_test.go"
     },
     {
@@ -3552,7 +3552,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "backend_internal_db_queries_live_test_testsqlcqueries_livedatabase",
-      "community": 509,
+      "community": 45,
       "norm_label": "testsqlcqueries_livedatabase()"
     },
     {
@@ -3562,7 +3562,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_db_queries_live_test_go_t",
-      "community": 509,
+      "community": 45,
       "norm_label": "t"
     },
     {
@@ -3572,7 +3572,7 @@
       "source_location": "L469",
       "_origin": "ast",
       "id": "backend_internal_db_queries_live_test_newpguuid",
-      "community": 509,
+      "community": 45,
       "norm_label": "newpguuid()"
     },
     {
@@ -3582,7 +3582,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_db_queries_live_test_go_uuid",
-      "community": 509,
+      "community": 45,
       "norm_label": "uuid"
     },
     {
@@ -3592,7 +3592,7 @@
       "source_location": "L476",
       "_origin": "ast",
       "id": "backend_internal_db_queries_live_test_uniquetestemail",
-      "community": 509,
+      "community": 45,
       "norm_label": "uniquetestemail()"
     },
     {
@@ -3602,7 +3602,7 @@
       "source_location": "L488",
       "_origin": "ast",
       "id": "backend_internal_db_queries_live_test_testconsumerefreshtoken_concurrent",
-      "community": 509,
+      "community": 45,
       "norm_label": "testconsumerefreshtoken_concurrent()"
     },
     {
@@ -3619,7 +3619,7 @@
       "label": "WithUserTx()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "_origin": "ast",
       "id": "backend_internal_db_rls_withusertx",
       "community": 544,
@@ -3666,10 +3666,30 @@
       "norm_label": "queries"
     },
     {
+      "label": "WithUserTxOptions()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L46",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_withusertxoptions",
+      "community": 544,
+      "norm_label": "withusertxoptions()"
+    },
+    {
+      "label": "TxOptions",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_go_txoptions",
+      "community": 544,
+      "norm_label": "txoptions"
+    },
+    {
       "label": "VerifyRLSActive()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L92",
+      "source_location": "L107",
       "_origin": "ast",
       "id": "backend_internal_db_rls_verifyrlsactive",
       "community": 544,
@@ -3679,7 +3699,7 @@
       "label": "connectionRoleAttributes()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L113",
+      "source_location": "L128",
       "_origin": "ast",
       "id": "backend_internal_db_rls_connectionroleattributes",
       "community": 544,
@@ -3806,10 +3826,20 @@
       "norm_label": "testwithusertx_rollsbackonerror_livedatabase()"
     },
     {
+      "label": "TestWithUserTxOptions_RepeatableReadUsesOneSnapshot_LiveDatabase()",
+      "file_type": "code",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L274",
+      "_origin": "ast",
+      "id": "backend_internal_db_rls_test_testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase",
+      "community": 32,
+      "norm_label": "testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase()"
+    },
+    {
       "label": "TestVerifyRLSActive_PassesForOrdinaryRole_LiveDatabase()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L273",
+      "source_location": "L343",
       "_origin": "ast",
       "id": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
       "community": 32,
@@ -3819,7 +3849,7 @@
       "label": "TestVerifyRLSActive_RejectsBypassingRole_LiveDatabase()",
       "file_type": "code",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L294",
+      "source_location": "L364",
       "_origin": "ast",
       "id": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
       "community": 32,
@@ -4402,7 +4432,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "http_dbhandle",
-      "community": 293,
+      "community": 509,
       "norm_label": "dbhandle"
     },
     {
@@ -4672,7 +4702,7 @@
       "source_location": "L937",
       "_origin": "ast",
       "id": "backend_internal_http_auth_validationerror",
-      "community": 293,
+      "community": 556,
       "norm_label": "validationerror()"
     },
     {
@@ -4692,7 +4722,7 @@
       "source_location": "L960",
       "_origin": "ast",
       "id": "backend_internal_http_auth_invalidcredentialserror",
-      "community": 293,
+      "community": 55,
       "norm_label": "invalidcredentialserror()"
     },
     {
@@ -5192,7 +5222,7 @@
       "source_location": "L296",
       "_origin": "ast",
       "id": "backend_internal_http_categories_validatecategoryname",
-      "community": 378,
+      "community": 42,
       "norm_label": "validatecategoryname()"
     },
     {
@@ -6062,7 +6092,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_health_test",
-      "community": 510,
+      "community": 28,
       "norm_label": "health_test.go"
     },
     {
@@ -6072,7 +6102,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "backend_internal_http_health_test_testhealthendpoint",
-      "community": 510,
+      "community": 28,
       "norm_label": "testhealthendpoint()"
     },
     {
@@ -6082,7 +6112,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_health_test_go_t",
-      "community": 510,
+      "community": 28,
       "norm_label": "t"
     },
     {
@@ -6142,7 +6172,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_useridfromcontext",
-      "community": 535,
+      "community": 503,
       "norm_label": "useridfromcontext()"
     },
     {
@@ -6162,7 +6192,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_middleware_go_uuid",
-      "community": 535,
+      "community": 503,
       "norm_label": "uuid"
     },
     {
@@ -6569,7 +6599,7 @@
       "label": "decodeResourceBody()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L39",
+      "source_location": "L40",
       "_origin": "ast",
       "id": "backend_internal_http_resources_decoderesourcebody",
       "community": 510,
@@ -6609,7 +6639,7 @@
       "label": "bodyDecodeOutcome",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L48",
+      "source_location": "L49",
       "_origin": "ast",
       "id": "http_bodydecodeoutcome",
       "community": 510,
@@ -6619,7 +6649,7 @@
       "label": "decodeBulkBody()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L69",
+      "source_location": "L70",
       "_origin": "ast",
       "id": "backend_internal_http_resources_decodebulkbody",
       "community": 510,
@@ -6629,7 +6659,7 @@
       "label": "ResourceServer",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L102",
+      "source_location": "L103",
       "_origin": "ast",
       "id": "backend_internal_http_resources_go_http_resourceserver",
       "community": 510,
@@ -6659,7 +6689,7 @@
       "label": "NewResourceServer()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L118",
+      "source_location": "L119",
       "_origin": "ast",
       "id": "backend_internal_http_resources_newresourceserver",
       "community": 510,
@@ -6669,7 +6699,7 @@
       "label": "newResourceServerWithClock()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L125",
+      "source_location": "L126",
       "_origin": "ast",
       "id": "backend_internal_http_resources_newresourceserverwithclock",
       "community": 510,
@@ -6679,7 +6709,7 @@
       "label": "resourceServerMethods",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L134",
+      "source_location": "L135",
       "_origin": "ast",
       "id": "http_resourceservermethods",
       "community": 510,
@@ -6689,7 +6719,7 @@
       "label": "withResourceID()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L165",
+      "source_location": "L166",
       "_origin": "ast",
       "id": "backend_internal_http_resources_withresourceid",
       "community": 510,
@@ -6719,7 +6749,7 @@
       "label": "withListTransactionsParams()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L180",
+      "source_location": "L181",
       "_origin": "ast",
       "id": "backend_internal_http_resources_withlisttransactionsparams",
       "community": 510,
@@ -6739,7 +6769,7 @@
       "label": "optionalQueryParam()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L199",
+      "source_location": "L200",
       "_origin": "ast",
       "id": "backend_internal_http_resources_optionalqueryparam",
       "community": 510,
@@ -6759,7 +6789,7 @@
       "label": "accountIDFilter()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L215",
+      "source_location": "L216",
       "_origin": "ast",
       "id": "backend_internal_http_resources_accountidfilter",
       "community": 428,
@@ -6779,7 +6809,7 @@
       "label": "withSummaryParams()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L229",
+      "source_location": "L234",
       "_origin": "ast",
       "id": "backend_internal_http_resources_withsummaryparams",
       "community": 510,
@@ -6789,7 +6819,7 @@
       "label": ".withUser()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L252",
+      "source_location": "L257",
       "_origin": "ast",
       "id": "http_resourceserver_withuser",
       "community": 510,
@@ -6816,10 +6846,30 @@
       "norm_label": "queries"
     },
     {
+      "label": ".withUserTxOptions()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L265",
+      "_origin": "ast",
+      "id": "http_resourceserver_withusertxoptions",
+      "community": 510,
+      "norm_label": ".withusertxoptions()"
+    },
+    {
+      "label": "TxOptions",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_resources_go_txoptions",
+      "community": 510,
+      "norm_label": "txoptions"
+    },
+    {
       "label": "pgUserID()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L267",
+      "source_location": "L285",
       "_origin": "ast",
       "id": "backend_internal_http_resources_pguserid",
       "community": 42,
@@ -6829,30 +6879,30 @@
       "label": "validateResourceName()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L276",
+      "source_location": "L294",
       "_origin": "ast",
       "id": "backend_internal_http_resources_validateresourcename",
-      "community": 378,
+      "community": 510,
       "norm_label": "validateresourcename()"
     },
     {
       "label": "logResourceError()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L287",
+      "source_location": "L305",
       "_origin": "ast",
       "id": "backend_internal_http_resources_logresourceerror",
-      "community": 20,
+      "community": 42,
       "norm_label": "logresourceerror()"
     },
     {
       "label": "dbError()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L294",
+      "source_location": "L312",
       "_origin": "ast",
       "id": "backend_internal_http_resources_dberror",
-      "community": 42,
+      "community": 20,
       "norm_label": "dberror()"
     },
     {
@@ -6862,7 +6912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_router",
-      "community": 510,
+      "community": 28,
       "norm_label": "router.go"
     },
     {
@@ -6872,7 +6922,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "backend_internal_http_router_newrouter",
-      "community": 510,
+      "community": 28,
       "norm_label": "newrouter()"
     },
     {
@@ -6882,7 +6932,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "resourceserver",
-      "community": 510,
+      "community": 28,
       "norm_label": "resourceserver"
     },
     {
@@ -6892,7 +6942,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_router_go_handler",
-      "community": 510,
+      "community": 28,
       "norm_label": "handler"
     },
     {
@@ -6909,7 +6959,7 @@
       "label": "ResourceServer",
       "file_type": "code",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L35",
+      "source_location": "L37",
       "_origin": "ast",
       "id": "backend_internal_http_summary_go_http_resourceserver",
       "community": 428,
@@ -6919,7 +6969,7 @@
       "label": ".GetSummary()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L35",
+      "source_location": "L37",
       "_origin": "ast",
       "id": "http_resourceserver_getsummary",
       "community": 428,
@@ -6949,7 +6999,7 @@
       "label": "percentageChange()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L140",
+      "source_location": "L142",
       "_origin": "ast",
       "id": "backend_internal_http_summary_percentagechange",
       "community": 536,
@@ -6959,7 +7009,7 @@
       "label": "bucketCategories()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L162",
+      "source_location": "L166",
       "_origin": "ast",
       "id": "backend_internal_http_summary_bucketcategories",
       "community": 536,
@@ -6969,7 +7019,7 @@
       "label": "fillMissingDays()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L194",
+      "source_location": "L198",
       "_origin": "ast",
       "id": "backend_internal_http_summary_fillmissingdays",
       "community": 536,
@@ -6989,7 +7039,7 @@
       "label": "pgTimestamp()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L220",
+      "source_location": "L224",
       "_origin": "ast",
       "id": "backend_internal_http_summary_pgtimestamp",
       "community": 536,
@@ -7159,7 +7209,7 @@
       "label": "TestPercentageChange()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L15",
+      "source_location": "L16",
       "_origin": "ast",
       "id": "backend_internal_http_summary_test_testpercentagechange",
       "community": 536,
@@ -7179,17 +7229,27 @@
       "label": "TestPercentageChange_UsesFloatDivision()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L44",
+      "source_location": "L45",
       "_origin": "ast",
       "id": "backend_internal_http_summary_test_testpercentagechange_usesfloatdivision",
       "community": 536,
       "norm_label": "testpercentagechange_usesfloatdivision()"
     },
     {
+      "label": "TestPercentageChange_WidensBeforeSubtracting()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L52",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_test_testpercentagechange_widensbeforesubtracting",
+      "community": 536,
+      "norm_label": "testpercentagechange_widensbeforesubtracting()"
+    },
+    {
       "label": "categoryRow()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L51",
+      "source_location": "L63",
       "_origin": "ast",
       "id": "backend_internal_http_summary_test_categoryrow",
       "community": 536,
@@ -7199,7 +7259,7 @@
       "label": "TestBucketCategories()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L55",
+      "source_location": "L67",
       "_origin": "ast",
       "id": "backend_internal_http_summary_test_testbucketcategories",
       "community": 536,
@@ -7209,7 +7269,7 @@
       "label": "dailyRow()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L120",
+      "source_location": "L132",
       "_origin": "ast",
       "id": "backend_internal_http_summary_test_dailyrow",
       "community": 536,
@@ -7219,7 +7279,7 @@
       "label": "TestFillMissingDays()",
       "file_type": "code",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L129",
+      "source_location": "L141",
       "_origin": "ast",
       "id": "backend_internal_http_summary_test_testfillmissingdays",
       "community": 536,
@@ -7232,7 +7292,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_transactions",
-      "community": 378,
+      "community": 503,
       "norm_label": "transactions.go"
     },
     {
@@ -7302,7 +7362,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "http_resourceserver_listtransactions",
-      "community": 503,
+      "community": 428,
       "norm_label": ".listtransactions()"
     },
     {
@@ -7332,7 +7392,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_go_listtransactionsparams",
-      "community": 503,
+      "community": 428,
       "norm_label": "listtransactionsparams"
     },
     {
@@ -7422,7 +7482,7 @@
       "source_location": "L422",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_referenceerrorfromforeignkeyviolation",
-      "community": 556,
+      "community": 503,
       "norm_label": "referenceerrorfromforeignkeyviolation()"
     },
     {
@@ -7462,7 +7522,7 @@
       "source_location": "L538",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_totransactionlistitem",
-      "community": 378,
+      "community": 503,
       "norm_label": "totransactionlistitem()"
     },
     {
@@ -7492,7 +7552,7 @@
       "source_location": "L570",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_textpointer",
-      "community": 378,
+      "community": 503,
       "norm_label": "textpointer()"
     },
     {
@@ -7552,7 +7612,7 @@
       "source_location": "L614",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_ratelimitederror",
-      "community": 556,
+      "community": 503,
       "norm_label": "ratelimitederror()"
     },
     {
@@ -7562,7 +7622,7 @@
       "source_location": "L628",
       "_origin": "ast",
       "id": "http_resourceserver_now",
-      "community": 503,
+      "community": 428,
       "norm_label": ".now()"
     },
     {
@@ -7572,7 +7632,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_go_time",
-      "community": 503,
+      "community": 428,
       "norm_label": "time"
     },
     {
@@ -7612,7 +7672,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "http_resourceserver_bulkcreatetransactions",
-      "community": 556,
+      "community": 503,
       "norm_label": ".bulkcreatetransactions()"
     },
     {
@@ -8502,7 +8562,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "mail_mailer",
-      "community": 293,
+      "community": 315,
       "norm_label": "mailer"
     },
     {
@@ -8812,7 +8872,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "openapi_currencycode",
-      "community": 17,
+      "community": 503,
       "norm_label": "currencycode"
     },
     {
@@ -8822,7 +8882,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "openapi_currencycode_valid",
-      "community": 17,
+      "community": 503,
       "norm_label": ".valid()"
     },
     {
@@ -8942,7 +9002,7 @@
       "source_location": "L130",
       "_origin": "ast",
       "id": "openapi_authuser",
-      "community": 408,
+      "community": 293,
       "norm_label": "authuser"
     },
     {
@@ -8952,7 +9012,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "email",
-      "community": 408,
+      "community": 293,
       "norm_label": "email"
     },
     {
@@ -8962,7 +9022,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_openapi_generated_gen_go_uuid",
-      "community": 408,
+      "community": 293,
       "norm_label": "uuid"
     },
     {
@@ -9092,7 +9152,7 @@
       "source_location": "L209",
       "_origin": "ast",
       "id": "openapi_loginrequest",
-      "community": 408,
+      "community": 293,
       "norm_label": "loginrequest"
     },
     {
@@ -9112,7 +9172,7 @@
       "source_location": "L221",
       "_origin": "ast",
       "id": "openapi_passwordresetrequest",
-      "community": 408,
+      "community": 293,
       "norm_label": "passwordresetrequest"
     },
     {
@@ -9122,7 +9182,7 @@
       "source_location": "L226",
       "_origin": "ast",
       "id": "openapi_registerrequest",
-      "community": 408,
+      "community": 293,
       "norm_label": "registerrequest"
     },
     {
@@ -9142,7 +9202,7 @@
       "source_location": "L262",
       "_origin": "ast",
       "id": "openapi_summarycategory",
-      "community": 536,
+      "community": 17,
       "norm_label": "summarycategory"
     },
     {
@@ -9332,7 +9392,7 @@
       "source_location": "L509",
       "_origin": "ast",
       "id": "openapi_serverinterface",
-      "community": 323,
+      "community": 338,
       "norm_label": "serverinterface"
     },
     {
@@ -9662,7 +9722,7 @@
       "source_location": "L775",
       "_origin": "ast",
       "id": "openapi_middlewarefunc",
-      "community": 323,
+      "community": 338,
       "norm_label": "middlewarefunc"
     },
     {
@@ -9952,7 +10012,7 @@
       "source_location": "L1499",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror",
-      "community": 17,
+      "community": 562,
       "norm_label": "unescapedcookieparamerror"
     },
     {
@@ -9962,7 +10022,7 @@
       "source_location": "L1504",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_error",
-      "community": 17,
+      "community": 562,
       "norm_label": ".error()"
     },
     {
@@ -9972,7 +10032,7 @@
       "source_location": "L1508",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_unwrap",
-      "community": 17,
+      "community": 562,
       "norm_label": ".unwrap()"
     },
     {
@@ -10112,7 +10172,7 @@
       "source_location": "L1569",
       "_origin": "ast",
       "id": "backend_internal_openapi_generated_gen_handler",
-      "community": 323,
+      "community": 338,
       "norm_label": "handler()"
     },
     {
@@ -10132,7 +10192,7 @@
       "source_location": "L1573",
       "_origin": "ast",
       "id": "openapi_chiserveroptions",
-      "community": 323,
+      "community": 338,
       "norm_label": "chiserveroptions"
     },
     {
@@ -10142,7 +10202,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "router",
-      "community": 323,
+      "community": 338,
       "norm_label": "router"
     },
     {
@@ -10152,7 +10212,7 @@
       "source_location": "L1581",
       "_origin": "ast",
       "id": "backend_internal_openapi_generated_gen_handlerfrommux",
-      "community": 323,
+      "community": 338,
       "norm_label": "handlerfrommux()"
     },
     {
@@ -10162,7 +10222,7 @@
       "source_location": "L1587",
       "_origin": "ast",
       "id": "backend_internal_openapi_generated_gen_handlerfrommuxwithbaseurl",
-      "community": 323,
+      "community": 338,
       "norm_label": "handlerfrommuxwithbaseurl()"
     },
     {
@@ -10172,7 +10232,7 @@
       "source_location": "L1595",
       "_origin": "ast",
       "id": "backend_internal_openapi_generated_gen_handlerwithoptions",
-      "community": 323,
+      "community": 338,
       "norm_label": "handlerwithoptions()"
     },
     {
@@ -10192,7 +10252,7 @@
       "source_location": "L1702",
       "_origin": "ast",
       "id": "openapi_bulkcreatevalidationerrorjsonresponse",
-      "community": 556,
+      "community": 17,
       "norm_label": "bulkcreatevalidationerrorjsonresponse"
     },
     {
@@ -10202,7 +10262,7 @@
       "source_location": "L1704",
       "_origin": "ast",
       "id": "openapi_bulkdeletevalidationerrorjsonresponse",
-      "community": 556,
+      "community": 17,
       "norm_label": "bulkdeletevalidationerrorjsonresponse"
     },
     {
@@ -10222,7 +10282,7 @@
       "source_location": "L1708",
       "_origin": "ast",
       "id": "openapi_conflicterrorjsonresponse",
-      "community": 17,
+      "community": 293,
       "norm_label": "conflicterrorjsonresponse"
     },
     {
@@ -10262,7 +10322,7 @@
       "source_location": "L1716",
       "_origin": "ast",
       "id": "openapi_emailnotverifiederrorjsonresponse",
-      "community": 17,
+      "community": 293,
       "norm_label": "emailnotverifiederrorjsonresponse"
     },
     {
@@ -10282,7 +10342,7 @@
       "source_location": "L1720",
       "_origin": "ast",
       "id": "openapi_invalidrefreshtokenerrorjsonresponse",
-      "community": 562,
+      "community": 293,
       "norm_label": "invalidrefreshtokenerrorjsonresponse"
     },
     {
@@ -10672,7 +10732,7 @@
       "source_location": "L1922",
       "_origin": "ast",
       "id": "openapi_bulkdeleteaccounts500jsonresponse",
-      "community": 316,
+      "community": 338,
       "norm_label": "bulkdeleteaccounts500jsonresponse"
     },
     {
@@ -10682,7 +10742,7 @@
       "source_location": "L1924",
       "_origin": "ast",
       "id": "openapi_bulkdeleteaccounts500jsonresponse_visitbulkdeleteaccountsresponse",
-      "community": 316,
+      "community": 338,
       "norm_label": ".visitbulkdeleteaccountsresponse()"
     },
     {
@@ -11062,7 +11122,7 @@
       "source_location": "L2179",
       "_origin": "ast",
       "id": "openapi_updateaccount500jsonresponse",
-      "community": 316,
+      "community": 338,
       "norm_label": "updateaccount500jsonresponse"
     },
     {
@@ -11072,7 +11132,7 @@
       "source_location": "L2181",
       "_origin": "ast",
       "id": "openapi_updateaccount500jsonresponse_visitupdateaccountresponse",
-      "community": 316,
+      "community": 338,
       "norm_label": ".visitupdateaccountresponse()"
     },
     {
@@ -11182,7 +11242,7 @@
       "source_location": "L2253",
       "_origin": "ast",
       "id": "openapi_loginuser403jsonresponse",
-      "community": 17,
+      "community": 293,
       "norm_label": "loginuser403jsonresponse"
     },
     {
@@ -11192,7 +11252,7 @@
       "source_location": "L2257",
       "_origin": "ast",
       "id": "openapi_loginuser403jsonresponse_visitloginuserresponse",
-      "community": 17,
+      "community": 338,
       "norm_label": ".visitloginuserresponse()"
     },
     {
@@ -11252,7 +11312,7 @@
       "source_location": "L2300",
       "_origin": "ast",
       "id": "openapi_logoutuser401jsonresponse",
-      "community": 562,
+      "community": 293,
       "norm_label": "logoutuser401jsonresponse"
     },
     {
@@ -11262,7 +11322,7 @@
       "source_location": "L2304",
       "_origin": "ast",
       "id": "openapi_logoutuser401jsonresponse_visitlogoutuserresponse",
-      "community": 562,
+      "community": 338,
       "norm_label": ".visitlogoutuserresponse()"
     },
     {
@@ -11482,7 +11542,7 @@
       "source_location": "L2433",
       "_origin": "ast",
       "id": "openapi_refreshsession401jsonresponse",
-      "community": 562,
+      "community": 293,
       "norm_label": "refreshsession401jsonresponse"
     },
     {
@@ -11492,7 +11552,7 @@
       "source_location": "L2437",
       "_origin": "ast",
       "id": "openapi_refreshsession401jsonresponse_visitrefreshsessionresponse",
-      "community": 562,
+      "community": 338,
       "norm_label": ".visitrefreshsessionresponse()"
     },
     {
@@ -11572,7 +11632,7 @@
       "source_location": "L2485",
       "_origin": "ast",
       "id": "openapi_registeruser409jsonresponse",
-      "community": 17,
+      "community": 293,
       "norm_label": "registeruser409jsonresponse"
     },
     {
@@ -11582,7 +11642,7 @@
       "source_location": "L2487",
       "_origin": "ast",
       "id": "openapi_registeruser409jsonresponse_visitregisteruserresponse",
-      "community": 17,
+      "community": 338,
       "norm_label": ".visitregisteruserresponse()"
     },
     {
@@ -11792,7 +11852,7 @@
       "source_location": "L2606",
       "_origin": "ast",
       "id": "openapi_createcategory200jsonresponse",
-      "community": 17,
+      "community": 572,
       "norm_label": "createcategory200jsonresponse"
     },
     {
@@ -11802,7 +11862,7 @@
       "source_location": "L2608",
       "_origin": "ast",
       "id": "openapi_createcategory200jsonresponse_visitcreatecategoryresponse",
-      "community": 17,
+      "community": 572,
       "norm_label": ".visitcreatecategoryresponse()"
     },
     {
@@ -11982,7 +12042,7 @@
       "source_location": "L2728",
       "_origin": "ast",
       "id": "openapi_bulkdeletecategories500jsonresponse",
-      "community": 316,
+      "community": 338,
       "norm_label": "bulkdeletecategories500jsonresponse"
     },
     {
@@ -11992,7 +12052,7 @@
       "source_location": "L2730",
       "_origin": "ast",
       "id": "openapi_bulkdeletecategories500jsonresponse_visitbulkdeletecategoriesresponse",
-      "community": 316,
+      "community": 338,
       "norm_label": ".visitbulkdeletecategoriesresponse()"
     },
     {
@@ -12112,7 +12172,7 @@
       "source_location": "L2810",
       "_origin": "ast",
       "id": "openapi_deletecategory500jsonresponse_visitdeletecategoryresponse",
-      "community": 316,
+      "community": 338,
       "norm_label": ".visitdeletecategoryresponse()"
     },
     {
@@ -12832,7 +12892,7 @@
       "source_location": "L3269",
       "_origin": "ast",
       "id": "openapi_bulkcreatetransactions400jsonresponse",
-      "community": 556,
+      "community": 17,
       "norm_label": "bulkcreatetransactions400jsonresponse"
     },
     {
@@ -12842,7 +12902,7 @@
       "source_location": "L3273",
       "_origin": "ast",
       "id": "openapi_bulkcreatetransactions400jsonresponse_visitbulkcreatetransactionsresponse",
-      "community": 556,
+      "community": 17,
       "norm_label": ".visitbulkcreatetransactionsresponse()"
     },
     {
@@ -12942,7 +13002,7 @@
       "source_location": "L3352",
       "_origin": "ast",
       "id": "openapi_bulkcreatetransactions500jsonresponse_visitbulkcreatetransactionsresponse",
-      "community": 316,
+      "community": 338,
       "norm_label": ".visitbulkcreatetransactionsresponse()"
     },
     {
@@ -13512,7 +13572,7 @@
       "source_location": "L3745",
       "_origin": "ast",
       "id": "openapi_strictserverinterface",
-      "community": 323,
+      "community": 338,
       "norm_label": "strictserverinterface"
     },
     {
@@ -13532,7 +13592,7 @@
       "source_location": "L3833",
       "_origin": "ast",
       "id": "openapi_strictmiddlewarefunc",
-      "community": 323,
+      "community": 338,
       "norm_label": "strictmiddlewarefunc"
     },
     {
@@ -13552,7 +13612,7 @@
       "source_location": "L3840",
       "_origin": "ast",
       "id": "backend_internal_openapi_generated_gen_newstricthandler",
-      "community": 323,
+      "community": 338,
       "norm_label": "newstricthandler()"
     },
     {
@@ -13562,7 +13622,7 @@
       "source_location": "L3851",
       "_origin": "ast",
       "id": "backend_internal_openapi_generated_gen_newstricthandlerwithoptions",
-      "community": 323,
+      "community": 338,
       "norm_label": "newstricthandlerwithoptions()"
     },
     {
@@ -14322,7 +14382,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_account_filter",
-      "community": 515,
+      "community": 9,
       "norm_label": "account-filter.tsx"
     },
     {
@@ -14332,7 +14392,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_account_filter_accountfilter",
-      "community": 18,
+      "community": 348,
       "norm_label": "accountfilter()"
     },
     {
@@ -14342,7 +14402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_amount_input",
-      "community": 9,
+      "community": 23,
       "norm_label": "amount-input.tsx"
     },
     {
@@ -14352,7 +14412,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_amount_input_props",
-      "community": 9,
+      "community": 23,
       "norm_label": "props"
     },
     {
@@ -14362,7 +14422,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "components_amount_input_amountinput",
-      "community": 9,
+      "community": 23,
       "norm_label": "amountinput()"
     },
     {
@@ -14472,7 +14532,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_chart",
-      "community": 515,
+      "community": 9,
       "norm_label": "chart.tsx"
     },
     {
@@ -14482,7 +14542,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_chart_props",
-      "community": 515,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -14492,7 +14552,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "components_chart_chartenum",
-      "community": 515,
+      "community": 9,
       "norm_label": "chartenum"
     },
     {
@@ -14502,7 +14562,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "components_chart_chart",
-      "community": 35,
+      "community": 9,
       "norm_label": "chart()"
     },
     {
@@ -14512,7 +14572,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "components_chart_chartloading",
-      "community": 35,
+      "community": 9,
       "norm_label": "chartloading()"
     },
     {
@@ -14642,7 +14702,7 @@
       "source_location": "L100",
       "_origin": "ast",
       "id": "components_data_card_datacardloading",
-      "community": 35,
+      "community": 515,
       "norm_label": "datacardloading()"
     },
     {
@@ -14652,7 +14712,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_charts",
-      "community": 35,
+      "community": 9,
       "norm_label": "data-charts.tsx"
     },
     {
@@ -14662,7 +14722,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_data_charts_datacharts",
-      "community": 35,
+      "community": 515,
       "norm_label": "datacharts()"
     },
     {
@@ -14672,7 +14732,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_grid",
-      "community": 35,
+      "community": 515,
       "norm_label": "data-grid.tsx"
     },
     {
@@ -14682,7 +14742,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_data_grid_datagrid",
-      "community": 35,
+      "community": 515,
       "norm_label": "datagrid()"
     },
     {
@@ -14692,7 +14752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_table",
-      "community": 348,
+      "community": 2,
       "norm_label": "data-table.tsx"
     },
     {
@@ -14702,7 +14762,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "components_data_table_datatableprops",
-      "community": 348,
+      "community": 2,
       "norm_label": "datatableprops"
     },
     {
@@ -14762,7 +14822,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "components_date_filter_datefilter",
-      "community": 18,
+      "community": 348,
       "norm_label": "datefilter()"
     },
     {
@@ -14792,7 +14852,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_date_picker_datepicker",
-      "community": 348,
+      "community": 23,
       "norm_label": "datepicker()"
     },
     {
@@ -14802,7 +14862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_filters",
-      "community": 18,
+      "community": 348,
       "norm_label": "filters.tsx"
     },
     {
@@ -14812,7 +14872,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "components_filters_filters",
-      "community": 18,
+      "community": 348,
       "norm_label": "filters()"
     },
     {
@@ -14892,7 +14952,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_nav_button",
-      "community": 518,
+      "community": 348,
       "norm_label": "nav-button.tsx"
     },
     {
@@ -14902,7 +14962,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_nav_button_props",
-      "community": 518,
+      "community": 348,
       "norm_label": "props"
     },
     {
@@ -14912,7 +14972,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "components_nav_button_navbutton",
-      "community": 518,
+      "community": 348,
       "norm_label": "navbutton()"
     },
     {
@@ -15002,7 +15062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_radar_variant",
-      "community": 515,
+      "community": 9,
       "norm_label": "radar-variant.tsx"
     },
     {
@@ -15012,7 +15072,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_radar_variant_props",
-      "community": 515,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -15022,7 +15082,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_radar_variant_radarvariant",
-      "community": 515,
+      "community": 9,
       "norm_label": "radarvariant()"
     },
     {
@@ -15072,7 +15132,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_select",
-      "community": 23,
+      "community": 323,
       "norm_label": "select.tsx"
     },
     {
@@ -15082,7 +15142,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "components_select_props",
-      "community": 23,
+      "community": 323,
       "norm_label": "props"
     },
     {
@@ -15092,7 +15152,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "components_select_select",
-      "community": 23,
+      "community": 323,
       "norm_label": "select()"
     },
     {
@@ -15102,7 +15162,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_spending_pie",
-      "community": 515,
+      "community": 9,
       "norm_label": "spending-pie.tsx"
     },
     {
@@ -15112,7 +15172,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_spending_pie_props",
-      "community": 515,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -15122,7 +15182,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieenum",
-      "community": 515,
+      "community": 9,
       "norm_label": "spendingpieenum"
     },
     {
@@ -15132,7 +15192,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpie",
-      "community": 35,
+      "community": 9,
       "norm_label": "spendingpie()"
     },
     {
@@ -15142,7 +15202,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieloading",
-      "community": 35,
+      "community": 9,
       "norm_label": "spendingpieloading()"
     },
     {
@@ -15182,7 +15242,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_button",
-      "community": 260,
+      "community": 348,
       "norm_label": "button.tsx"
     },
     {
@@ -15202,7 +15262,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "components_ui_button_button",
-      "community": 260,
+      "community": 348,
       "norm_label": "button()"
     },
     {
@@ -15292,7 +15352,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "components_ui_card_cardaction",
-      "community": 348,
+      "community": 515,
       "norm_label": "cardaction()"
     },
     {
@@ -15302,7 +15362,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "components_ui_card_cardcontent",
-      "community": 515,
+      "community": 9,
       "norm_label": "cardcontent()"
     },
     {
@@ -15312,7 +15372,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "components_ui_card_cardfooter",
-      "community": 348,
+      "community": 515,
       "norm_label": "cardfooter()"
     },
     {
@@ -15342,7 +15402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_dialog",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialog.tsx"
     },
     {
@@ -15352,7 +15412,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_ui_dialog_dialog",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialog()"
     },
     {
@@ -15362,7 +15422,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtrigger",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialogtrigger()"
     },
     {
@@ -15372,7 +15432,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogportal",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialogportal()"
     },
     {
@@ -15382,7 +15442,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogclose",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialogclose()"
     },
     {
@@ -15402,7 +15462,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogcontent",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialogcontent()"
     },
     {
@@ -15412,7 +15472,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogheader",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialogheader()"
     },
     {
@@ -15422,7 +15482,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogfooter",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialogfooter()"
     },
     {
@@ -15432,7 +15492,7 @@
       "source_location": "L121",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtitle",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialogtitle()"
     },
     {
@@ -15442,7 +15502,7 @@
       "source_location": "L134",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogdescription",
-      "community": 260,
+      "community": 348,
       "norm_label": "dialogdescription()"
     },
     {
@@ -15462,7 +15522,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenu",
-      "community": 260,
+      "community": 348,
       "norm_label": "dropdownmenu()"
     },
     {
@@ -15482,7 +15542,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenutrigger",
-      "community": 260,
+      "community": 348,
       "norm_label": "dropdownmenutrigger()"
     },
     {
@@ -15492,7 +15552,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenucontent",
-      "community": 260,
+      "community": 348,
       "norm_label": "dropdownmenucontent()"
     },
     {
@@ -15512,7 +15572,7 @@
       "source_location": "L62",
       "_origin": "ast",
       "id": "components_ui_dropdown_menu_dropdownmenuitem",
-      "community": 260,
+      "community": 348,
       "norm_label": "dropdownmenuitem()"
     },
     {
@@ -15852,7 +15912,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_select",
-      "community": 515,
+      "community": 9,
       "norm_label": "select.tsx"
     },
     {
@@ -15862,7 +15922,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "components_ui_select_select",
-      "community": 515,
+      "community": 9,
       "norm_label": "select()"
     },
     {
@@ -15872,7 +15932,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "components_ui_select_selectgroup",
-      "community": 515,
+      "community": 9,
       "norm_label": "selectgroup()"
     },
     {
@@ -15882,7 +15942,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_ui_select_selectvalue",
-      "community": 515,
+      "community": 9,
       "norm_label": "selectvalue()"
     },
     {
@@ -15892,7 +15952,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "components_ui_select_selecttrigger",
-      "community": 515,
+      "community": 9,
       "norm_label": "selecttrigger()"
     },
     {
@@ -15902,7 +15962,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "components_ui_select_selectcontent",
-      "community": 515,
+      "community": 9,
       "norm_label": "selectcontent()"
     },
     {
@@ -15912,7 +15972,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "components_ui_select_selectlabel",
-      "community": 348,
+      "community": 9,
       "norm_label": "selectlabel()"
     },
     {
@@ -15922,7 +15982,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "components_ui_select_selectitem",
-      "community": 515,
+      "community": 9,
       "norm_label": "selectitem()"
     },
     {
@@ -15932,7 +15992,7 @@
       "source_location": "L130",
       "_origin": "ast",
       "id": "components_ui_select_selectseparator",
-      "community": 348,
+      "community": 9,
       "norm_label": "selectseparator()"
     },
     {
@@ -15942,7 +16002,7 @@
       "source_location": "L143",
       "_origin": "ast",
       "id": "components_ui_select_selectscrollupbutton",
-      "community": 348,
+      "community": 9,
       "norm_label": "selectscrollupbutton()"
     },
     {
@@ -15952,7 +16012,7 @@
       "source_location": "L161",
       "_origin": "ast",
       "id": "components_ui_select_selectscrolldownbutton",
-      "community": 348,
+      "community": 9,
       "norm_label": "selectscrolldownbutton()"
     },
     {
@@ -16112,7 +16172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_sonner",
-      "community": 518,
+      "community": 35,
       "norm_label": "sonner.tsx"
     },
     {
@@ -16122,7 +16182,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_ui_sonner_toaster",
-      "community": 518,
+      "community": 35,
       "norm_label": "toaster()"
     },
     {
@@ -16132,7 +16192,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_table",
-      "community": 348,
+      "community": 2,
       "norm_label": "table.tsx"
     },
     {
@@ -16142,7 +16202,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "components_ui_table_table",
-      "community": 348,
+      "community": 2,
       "norm_label": "table()"
     },
     {
@@ -16152,7 +16212,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_ui_table_tableheader",
-      "community": 348,
+      "community": 2,
       "norm_label": "tableheader()"
     },
     {
@@ -16162,7 +16222,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "components_ui_table_tablebody",
-      "community": 348,
+      "community": 2,
       "norm_label": "tablebody()"
     },
     {
@@ -16172,7 +16232,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "components_ui_table_tablefooter",
-      "community": 348,
+      "community": 2,
       "norm_label": "tablefooter()"
     },
     {
@@ -16182,7 +16242,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "components_ui_table_tablerow",
-      "community": 348,
+      "community": 2,
       "norm_label": "tablerow()"
     },
     {
@@ -16192,7 +16252,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "components_ui_table_tablehead",
-      "community": 348,
+      "community": 2,
       "norm_label": "tablehead()"
     },
     {
@@ -16202,7 +16262,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "components_ui_table_tablecell",
-      "community": 348,
+      "community": 2,
       "norm_label": "tablecell()"
     },
     {
@@ -16212,7 +16272,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_table_tablecaption",
-      "community": 348,
+      "community": 2,
       "norm_label": "tablecaption()"
     },
     {
@@ -16242,7 +16302,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_tooltip",
-      "community": 9,
+      "community": 23,
       "norm_label": "tooltip.tsx"
     },
     {
@@ -16252,7 +16312,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltipprovider",
-      "community": 9,
+      "community": 23,
       "norm_label": "tooltipprovider()"
     },
     {
@@ -16262,7 +16322,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltip",
-      "community": 9,
+      "community": 23,
       "norm_label": "tooltip()"
     },
     {
@@ -16272,7 +16332,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltiptrigger",
-      "community": 9,
+      "community": 23,
       "norm_label": "tooltiptrigger()"
     },
     {
@@ -16282,7 +16342,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltipcontent",
-      "community": 9,
+      "community": 23,
       "norm_label": "tooltipcontent()"
     },
     {
@@ -16332,7 +16392,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "db_connection_test",
-      "community": 532,
+      "community": 19,
       "norm_label": "connection.test.ts"
     },
     {
@@ -16342,7 +16402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "db_connection",
-      "community": 532,
+      "community": 19,
       "norm_label": "connection.ts"
     },
     {
@@ -16352,7 +16412,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "db_connection_local_hosts",
-      "community": 532,
+      "community": 19,
       "norm_label": "local_hosts"
     },
     {
@@ -16362,7 +16422,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "db_connection_databasepoolcache",
-      "community": 532,
+      "community": 19,
       "norm_label": "databasepoolcache"
     },
     {
@@ -16372,7 +16432,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "db_connection_getdatabaseurl",
-      "community": 532,
+      "community": 19,
       "norm_label": "getdatabaseurl()"
     },
     {
@@ -16382,7 +16442,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "db_connection_islocaldatabaseurl",
-      "community": 532,
+      "community": 19,
       "norm_label": "islocaldatabaseurl()"
     },
     {
@@ -16392,7 +16452,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "db_connection_shouldusessl",
-      "community": 532,
+      "community": 19,
       "norm_label": "shouldusessl()"
     },
     {
@@ -16402,7 +16462,7 @@
       "source_location": "L54",
       "_origin": "ast",
       "id": "db_connection_shouldallowinsecuretls",
-      "community": 532,
+      "community": 19,
       "norm_label": "shouldallowinsecuretls()"
     },
     {
@@ -16412,7 +16472,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "db_connection_buildpoolconfig",
-      "community": 532,
+      "community": 19,
       "norm_label": "buildpoolconfig()"
     },
     {
@@ -16422,7 +16482,7 @@
       "source_location": "L75",
       "_origin": "ast",
       "id": "db_connection_createpool",
-      "community": 532,
+      "community": 19,
       "norm_label": "createpool()"
     },
     {
@@ -16432,7 +16492,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "db_connection_getorcreatecachedpool",
-      "community": 532,
+      "community": 19,
       "norm_label": "getorcreatecachedpool()"
     },
     {
@@ -16692,7 +16752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_delete_account",
-      "community": 432,
+      "community": 518,
       "norm_label": "use-delete-account.ts"
     },
     {
@@ -16702,7 +16762,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_delete_account_responsetype",
-      "community": 432,
+      "community": 518,
       "norm_label": "responsetype"
     },
     {
@@ -16712,7 +16772,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "features_accounts_api_use_delete_account_usedeleteaccount",
-      "community": 260,
+      "community": 518,
       "norm_label": "usedeleteaccount()"
     },
     {
@@ -16752,7 +16812,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_accounts_api_use_edit_account_useeditaccount",
-      "community": 432,
+      "community": 518,
       "norm_label": "useeditaccount()"
     },
     {
@@ -16772,7 +16832,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_account_usegetaccount",
-      "community": 432,
+      "community": 518,
       "norm_label": "usegetaccount()"
     },
     {
@@ -16842,7 +16902,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_accounts_components_account_form_accountform",
-      "community": 518,
+      "community": 23,
       "norm_label": "accountform()"
     },
     {
@@ -16872,7 +16932,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "features_accounts_components_edit_account_sheet_editaccountsheet",
-      "community": 260,
+      "community": 518,
       "norm_label": "editaccountsheet()"
     },
     {
@@ -16972,7 +17032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account",
-      "community": 260,
+      "community": 348,
       "norm_label": "use-select-account.tsx"
     },
     {
@@ -16982,7 +17042,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account_useselectaccount",
-      "community": 432,
+      "community": 515,
       "norm_label": "useselectaccount()"
     },
     {
@@ -17102,7 +17162,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category",
-      "community": 432,
+      "community": 260,
       "norm_label": "use-edit-category.ts"
     },
     {
@@ -17112,7 +17172,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category_responsetype",
-      "community": 432,
+      "community": 260,
       "norm_label": "responsetype"
     },
     {
@@ -17122,7 +17182,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category_requesttype",
-      "community": 432,
+      "community": 260,
       "norm_label": "requesttype"
     },
     {
@@ -17222,7 +17282,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_categories_components_category_form_categoryform",
-      "community": 518,
+      "community": 23,
       "norm_label": "categoryform()"
     },
     {
@@ -17352,7 +17412,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_summary_use_get_summary",
-      "community": 35,
+      "community": 432,
       "norm_label": "use-get-summary.ts"
     },
     {
@@ -17362,7 +17422,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_summary_use_get_summary_usegetsummary",
-      "community": 35,
+      "community": 515,
       "norm_label": "usegetsummary()"
     },
     {
@@ -17402,7 +17462,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_create_transactions_usebulkcreatetransactions",
-      "community": 432,
+      "community": 515,
       "norm_label": "usebulkcreatetransactions()"
     },
     {
@@ -17442,7 +17502,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_transactions_api_use_bulk_delete_transactions_usebulkdeletetransactions",
-      "community": 432,
+      "community": 515,
       "norm_label": "usebulkdeletetransactions()"
     },
     {
@@ -17582,7 +17642,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transactions",
-      "community": 35,
+      "community": 432,
       "norm_label": "use-get-transactions.ts"
     },
     {
@@ -17592,7 +17652,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transactions_usegettransactions",
-      "community": 35,
+      "community": 432,
       "norm_label": "usegettransactions()"
     },
     {
@@ -17712,7 +17772,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "features_transactions_components_transaction_form_transactionform",
-      "community": 432,
+      "community": 19,
       "norm_label": "transactionform()"
     },
     {
@@ -17752,7 +17812,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_open_transaction",
-      "community": 432,
+      "community": 260,
       "norm_label": "use-open-transaction.ts"
     },
     {
@@ -17762,7 +17822,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_open_transaction_opentransactionstate",
-      "community": 432,
+      "community": 260,
       "norm_label": "opentransactionstate"
     },
     {
@@ -17772,7 +17832,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_open_transaction_useopentransaction",
-      "community": 432,
+      "community": 260,
       "norm_label": "useopentransaction"
     },
     {
@@ -17782,7 +17842,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "hooks_use_confirm",
-      "community": 260,
+      "community": 348,
       "norm_label": "use-confirm.tsx"
     },
     {
@@ -17802,7 +17862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_base_url_test",
-      "community": 432,
+      "community": 555,
       "norm_label": "api-base-url.test.ts"
     },
     {
@@ -17812,7 +17872,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_base_url",
-      "community": 432,
+      "community": 555,
       "norm_label": "api-base-url.ts"
     },
     {
@@ -17822,7 +17882,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_base_url_resolveapibaseurloptions",
-      "community": 432,
+      "community": 555,
       "norm_label": "resolveapibaseurloptions"
     },
     {
@@ -17832,7 +17892,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "lib_api_base_url_resolveapibaseurl",
-      "community": 432,
+      "community": 555,
       "norm_label": "resolveapibaseurl()"
     },
     {
@@ -18032,7 +18092,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items_test",
-      "community": 432,
+      "community": 515,
       "norm_label": "chunk-items.test.ts"
     },
     {
@@ -18042,7 +18102,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items",
-      "community": 432,
+      "community": 515,
       "norm_label": "chunk-items.ts"
     },
     {
@@ -18052,7 +18112,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items_chunkitems",
-      "community": 432,
+      "community": 515,
       "norm_label": "chunkitems()"
     },
     {
@@ -18082,7 +18142,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_query_params",
-      "community": 35,
+      "community": 432,
       "norm_label": "query-params.ts"
     },
     {
@@ -18092,7 +18152,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "lib_query_params_omitemptyqueryparams",
-      "community": 35,
+      "community": 432,
       "norm_label": "omitemptyqueryparams()"
     },
     {
@@ -18102,7 +18162,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options_test",
-      "community": 23,
+      "community": 323,
       "norm_label": "select-options.test.ts"
     },
     {
@@ -18112,7 +18172,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options",
-      "community": 23,
+      "community": 323,
       "norm_label": "select-options.ts"
     },
     {
@@ -18122,7 +18182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options_selectoption",
-      "community": 23,
+      "community": 323,
       "norm_label": "selectoption"
     },
     {
@@ -18132,7 +18192,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "lib_select_options_mergecreatedselectoption",
-      "community": 23,
+      "community": 323,
       "norm_label": "mergecreatedselectoption()"
     },
     {
@@ -18142,7 +18202,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_import_test",
-      "community": 515,
+      "community": 2,
       "norm_label": "transaction-import.test.ts"
     },
     {
@@ -18152,7 +18212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_import",
-      "community": 515,
+      "community": 2,
       "norm_label": "transaction-import.ts"
     },
     {
@@ -18162,7 +18222,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "lib_transaction_import_importedtransactionrow",
-      "community": 515,
+      "community": 2,
       "norm_label": "importedtransactionrow"
     },
     {
@@ -18172,7 +18232,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "lib_transaction_import_rawimportedtransactionrow",
-      "community": 515,
+      "community": 2,
       "norm_label": "rawimportedtransactionrow"
     },
     {
@@ -18182,7 +18242,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "lib_transaction_import_importedtransactionrowerror",
-      "community": 515,
+      "community": 2,
       "norm_label": "importedtransactionrowerror"
     },
     {
@@ -18192,7 +18252,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "lib_transaction_import_parseimportedtransactionrows",
-      "community": 515,
+      "community": 2,
       "norm_label": "parseimportedtransactionrows()"
     },
     {
@@ -18322,7 +18382,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_utils",
-      "community": 9,
+      "community": 19,
       "norm_label": "utils.ts"
     },
     {
@@ -18342,7 +18402,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "lib_utils_convertamountfrommiliunits",
-      "community": 35,
+      "community": 432,
       "norm_label": "convertamountfrommiliunits()"
     },
     {
@@ -18352,7 +18412,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "lib_utils_convertamounttomiliunits",
-      "community": 515,
+      "community": 19,
       "norm_label": "convertamounttomiliunits()"
     },
     {
@@ -18362,7 +18422,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "lib_utils_issafemiliunitamount",
-      "community": 515,
+      "community": 2,
       "norm_label": "issafemiliunitamount()"
     },
     {
@@ -18402,7 +18462,7 @@
       "source_location": "L95",
       "_origin": "ast",
       "id": "lib_utils_period",
-      "community": 9,
+      "community": 19,
       "norm_label": "period"
     },
     {
@@ -18412,7 +18472,7 @@
       "source_location": "L100",
       "_origin": "ast",
       "id": "lib_utils_formatdaterange",
-      "community": 35,
+      "community": 515,
       "norm_label": "formatdaterange()"
     },
     {
@@ -19062,7 +19122,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "package_dependencies_sonner",
-      "community": 518,
+      "community": 35,
       "norm_label": "sonner"
     },
     {
@@ -19322,7 +19382,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "providers_query_provider",
-      "community": 518,
+      "community": 35,
       "norm_label": "query-provider.tsx"
     },
     {
@@ -19332,7 +19392,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "providers_query_provider_makequeryclient",
-      "community": 518,
+      "community": 35,
       "norm_label": "makequeryclient()"
     },
     {
@@ -19342,7 +19402,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "providers_query_provider_getqueryclient",
-      "community": 518,
+      "community": 35,
       "norm_label": "getqueryclient()"
     },
     {
@@ -19352,7 +19412,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "providers_query_provider_props",
-      "community": 518,
+      "community": 35,
       "norm_label": "props"
     },
     {
@@ -19362,7 +19422,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "providers_query_provider_queryprovider",
-      "community": 518,
+      "community": 35,
       "norm_label": "queryprovider()"
     },
     {
@@ -19382,7 +19442,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "providers_sheet_provider_sheetprovider",
-      "community": 518,
+      "community": 35,
       "norm_label": "sheetprovider()"
     },
     {
@@ -19492,7 +19552,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "scripts_migrate",
-      "community": 532,
+      "community": 19,
       "norm_label": "migrate.ts"
     },
     {
@@ -19502,7 +19562,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "scripts_migrate_pool",
-      "community": 532,
+      "community": 19,
       "norm_label": "pool"
     },
     {
@@ -19512,7 +19572,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "scripts_migrate_db",
-      "community": 532,
+      "community": 19,
       "norm_label": "db"
     },
     {
@@ -19522,7 +19582,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "scripts_migrate_main",
-      "community": 532,
+      "community": 19,
       "norm_label": "main()"
     },
     {
@@ -19532,7 +19592,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "scripts_seed",
-      "community": 45,
+      "community": 19,
       "norm_label": "seed.ts"
     },
     {
@@ -19542,7 +19602,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "scripts_seed_databaseurl",
-      "community": 45,
+      "community": 19,
       "norm_label": "databaseurl"
     },
     {
@@ -19552,7 +19612,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "scripts_seed_pool",
-      "community": 45,
+      "community": 19,
       "norm_label": "pool"
     },
     {
@@ -19562,7 +19622,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "scripts_seed_db",
-      "community": 45,
+      "community": 19,
       "norm_label": "db"
     },
     {
@@ -19572,7 +19632,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "scripts_seed_assertseedallowed",
-      "community": 45,
+      "community": 19,
       "norm_label": "assertseedallowed()"
     },
     {
@@ -19582,7 +19642,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "scripts_seed_seed_categories",
-      "community": 45,
+      "community": 19,
       "norm_label": "seed_categories"
     },
     {
@@ -19592,7 +19652,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "scripts_seed_seed_accounts",
-      "community": 45,
+      "community": 19,
       "norm_label": "seed_accounts"
     },
     {
@@ -19602,7 +19662,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "scripts_seed_defaultto",
-      "community": 45,
+      "community": 19,
       "norm_label": "defaultto"
     },
     {
@@ -19612,7 +19672,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "scripts_seed_defaultfrom",
-      "community": 45,
+      "community": 19,
       "norm_label": "defaultfrom"
     },
     {
@@ -19622,7 +19682,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "scripts_seed_seed_transactions",
-      "community": 45,
+      "community": 19,
       "norm_label": "seed_transactions"
     },
     {
@@ -19632,7 +19692,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "scripts_seed_generaterandomamount",
-      "community": 45,
+      "community": 19,
       "norm_label": "generaterandomamount()"
     },
     {
@@ -19642,7 +19702,7 @@
       "source_location": "L80",
       "_origin": "ast",
       "id": "scripts_seed_generatetransactionsforday",
-      "community": 45,
+      "community": 19,
       "norm_label": "generatetransactionsforday()"
     },
     {
@@ -19652,7 +19712,7 @@
       "source_location": "L104",
       "_origin": "ast",
       "id": "scripts_seed_generatetransactions",
-      "community": 45,
+      "community": 19,
       "norm_label": "generatetransactions()"
     },
     {
@@ -19662,7 +19722,7 @@
       "source_location": "L110",
       "_origin": "ast",
       "id": "scripts_seed_main",
-      "community": 45,
+      "community": 19,
       "norm_label": "main()"
     },
     {
@@ -22449,7 +22509,7 @@
       "label": "The comparison period",
       "file_type": "document",
       "source_file": "docs/api/summary.md",
-      "source_location": "L48",
+      "source_location": "L49",
       "_origin": "ast",
       "id": "docs_api_summary_the_comparison_period",
       "community": 49,
@@ -22459,7 +22519,7 @@
       "label": "Percentage change",
       "file_type": "document",
       "source_file": "docs/api/summary.md",
-      "source_location": "L63",
+      "source_location": "L64",
       "_origin": "ast",
       "id": "docs_api_summary_percentage_change",
       "community": 49,
@@ -22469,7 +22529,7 @@
       "label": "Category breakdown",
       "file_type": "document",
       "source_file": "docs/api/summary.md",
-      "source_location": "L81",
+      "source_location": "L82",
       "_origin": "ast",
       "id": "docs_api_summary_category_breakdown",
       "community": 49,
@@ -22479,7 +22539,7 @@
       "label": "What the breakdown excludes",
       "file_type": "document",
       "source_file": "docs/api/summary.md",
-      "source_location": "L91",
+      "source_location": "L92",
       "_origin": "ast",
       "id": "docs_api_summary_what_the_breakdown_excludes",
       "community": 49,
@@ -22489,7 +22549,7 @@
       "label": "Daily series",
       "file_type": "document",
       "source_file": "docs/api/summary.md",
-      "source_location": "L103",
+      "source_location": "L104",
       "_origin": "ast",
       "id": "docs_api_summary_daily_series",
       "community": 49,
@@ -22499,7 +22559,7 @@
       "label": "Empty state",
       "file_type": "document",
       "source_file": "docs/api/summary.md",
-      "source_location": "L118",
+      "source_location": "L119",
       "_origin": "ast",
       "id": "docs_api_summary_empty_state",
       "community": 49,
@@ -22509,7 +22569,7 @@
       "label": "Where the code lives",
       "file_type": "document",
       "source_file": "docs/api/summary.md",
-      "source_location": "L129",
+      "source_location": "L130",
       "_origin": "ast",
       "id": "docs_api_summary_where_the_code_lives",
       "community": 49,
@@ -22519,7 +22579,7 @@
       "label": "Divergences and gaps",
       "file_type": "document",
       "source_file": "docs/api/summary.md",
-      "source_location": "L138",
+      "source_location": "L139",
       "_origin": "ast",
       "id": "docs_api_summary_divergences_and_gaps",
       "community": 49,
@@ -22832,7 +22892,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_1_unified_import_inbox",
-      "community": 2,
+      "community": 545,
       "norm_label": "1. unified import inbox"
     },
     {
@@ -22842,7 +22902,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_why_this_matters",
-      "community": 2,
+      "community": 545,
       "norm_label": "why this matters"
     },
     {
@@ -22852,7 +22912,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_what_this_feature_should_achieve",
-      "community": 2,
+      "community": 545,
       "norm_label": "what this feature should achieve"
     },
     {
@@ -22862,7 +22922,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_product_impact",
-      "community": 2,
+      "community": 545,
       "norm_label": "product impact"
     },
     {
@@ -22872,7 +22932,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_2_import_review_normalization_and_deduplication",
-      "community": 545,
+      "community": 388,
       "norm_label": "2. import review, normalization, and deduplication"
     },
     {
@@ -22882,7 +22942,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_why_this_matters_33",
-      "community": 545,
+      "community": 388,
       "norm_label": "why this matters"
     },
     {
@@ -22892,7 +22952,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_what_this_feature_should_achieve_37",
-      "community": 545,
+      "community": 388,
       "norm_label": "what this feature should achieve"
     },
     {
@@ -22902,7 +22962,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_product_impact_45",
-      "community": 545,
+      "community": 388,
       "norm_label": "product impact"
     },
     {
@@ -22912,7 +22972,7 @@
       "source_location": "L49",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_3_transfers_balances_and_net_worth",
-      "community": 545,
+      "community": 532,
       "norm_label": "3. transfers, balances, and net worth"
     },
     {
@@ -22922,7 +22982,7 @@
       "source_location": "L51",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_why_this_matters_51",
-      "community": 545,
+      "community": 532,
       "norm_label": "why this matters"
     },
     {
@@ -22932,7 +22992,7 @@
       "source_location": "L55",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_what_this_feature_should_achieve_55",
-      "community": 545,
+      "community": 532,
       "norm_label": "what this feature should achieve"
     },
     {
@@ -22942,7 +23002,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_product_impact_63",
-      "community": 545,
+      "community": 532,
       "norm_label": "product impact"
     },
     {
@@ -22952,7 +23012,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_4_budgets_and_monthly_planning",
-      "community": 555,
+      "community": 545,
       "norm_label": "4. budgets and monthly planning"
     },
     {
@@ -22962,7 +23022,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_why_this_matters_69",
-      "community": 555,
+      "community": 545,
       "norm_label": "why this matters"
     },
     {
@@ -22972,7 +23032,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_what_this_feature_should_achieve_73",
-      "community": 555,
+      "community": 545,
       "norm_label": "what this feature should achieve"
     },
     {
@@ -22982,7 +23042,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_product_impact_81",
-      "community": 555,
+      "community": 545,
       "norm_label": "product impact"
     },
     {
@@ -26716,6 +26776,66 @@
       "norm_label": "decision record"
     },
     {
+      "label": "Codex-summary-aggregate-contract-range.md",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range",
+      "community": 549,
+      "norm_label": "codex-summary-aggregate-contract-range.md"
+    },
+    {
+      "label": "Codex \u2014 Summary Aggregate Contract Range",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_codex_summary_aggregate_contract_range",
+      "community": 549,
+      "norm_label": "codex \u2014 summary aggregate contract range"
+    },
+    {
+      "label": "Problem and evidence",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_problem_and_evidence",
+      "community": 549,
+      "norm_label": "problem and evidence"
+    },
+    {
+      "label": "Required decision",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_required_decision",
+      "community": 549,
+      "norm_label": "required decision"
+    },
+    {
+      "label": "Verification",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L37",
+      "_origin": "ast",
+      "id": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_verification",
+      "community": 549,
+      "norm_label": "verification"
+    },
+    {
+      "label": "Decision record",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L47",
+      "_origin": "ast",
+      "id": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_decision_record",
+      "community": 549,
+      "norm_label": "decision record"
+    },
+    {
       "label": "README.md",
       "file_type": "document",
       "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
@@ -26749,7 +26869,7 @@
       "label": "Decision hierarchy",
       "file_type": "document",
       "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
-      "source_location": "L41",
+      "source_location": "L43",
       "_origin": "ast",
       "id": "post_migration_improvements_codex_backend_improvements_readme_decision_hierarchy",
       "community": 519,
@@ -26759,7 +26879,7 @@
       "label": "Definition of done for an endpoint",
       "file_type": "document",
       "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
-      "source_location": "L56",
+      "source_location": "L58",
       "_origin": "ast",
       "id": "post_migration_improvements_codex_backend_improvements_readme_definition_of_done_for_an_endpoint",
       "community": 519,
@@ -26769,7 +26889,7 @@
       "label": "Source set",
       "file_type": "document",
       "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
-      "source_location": "L64",
+      "source_location": "L66",
       "_origin": "ast",
       "id": "post_migration_improvements_codex_backend_improvements_readme_source_set",
       "community": 519,
@@ -37680,7 +37800,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L277",
+      "source_location": "L347",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
       "target": "backend_internal_db_db_newpool"
@@ -37691,7 +37811,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L298",
+      "source_location": "L368",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
       "target": "backend_internal_db_db_newpool"
@@ -37738,6 +37858,17 @@
       "source_location": "L194",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_db_newpool"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L278",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase",
       "target": "backend_internal_db_db_newpool"
     },
     {
@@ -40101,9 +40232,9 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L54",
+      "source_location": "L69",
       "weight": 1.0,
-      "source": "backend_internal_db_rls_withusertx",
+      "source": "backend_internal_db_rls_withusertxoptions",
       "target": "backend_internal_db_gen_db_new"
     },
     {
@@ -40581,7 +40712,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L162",
+      "source_location": "L166",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_summary_bucketcategories",
@@ -40592,7 +40723,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L51",
+      "source_location": "L63",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_summary_test_categoryrow",
@@ -40688,7 +40819,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L194",
+      "source_location": "L198",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_summary_fillmissingdays",
@@ -40699,7 +40830,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L120",
+      "source_location": "L132",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_summary_test_dailyrow",
@@ -41546,7 +41677,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L274",
+      "source_location": "L344",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
       "target": "backend_internal_db_livedb_test_livedatabaseurl"
@@ -41600,6 +41731,17 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L275",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase",
+      "target": "backend_internal_db_livedb_test_livedatabaseurl"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/db/transactions_category_rls_test.go",
       "source_location": "L25",
       "weight": 1.0,
@@ -41645,7 +41787,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L295",
+      "source_location": "L365",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
       "target": "backend_internal_db_livedb_test_admindatabaseurl"
@@ -42288,7 +42430,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L113",
+      "source_location": "L128",
       "weight": 1.0,
       "source": "backend_internal_db_rls",
       "target": "backend_internal_db_rls_connectionroleattributes",
@@ -42298,7 +42440,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L92",
+      "source_location": "L107",
       "weight": 1.0,
       "source": "backend_internal_db_rls",
       "target": "backend_internal_db_rls_verifyrlsactive",
@@ -42308,10 +42450,20 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "source": "backend_internal_db_rls",
       "target": "backend_internal_db_rls_withusertx",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls",
+      "target": "backend_internal_db_rls_withusertxoptions",
       "confidence_score": 1.0
     },
     {
@@ -42348,10 +42500,21 @@
       "target": "backend_internal_db_rls_withusertx"
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L301",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase",
+      "target": "backend_internal_db_rls_withusertx"
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_withusertx",
@@ -42362,7 +42525,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_withusertx",
@@ -42373,7 +42536,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_withusertx",
@@ -42384,11 +42547,22 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L37",
+      "source_location": "L38",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_withusertx",
       "target": "backend_internal_db_rls_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_withusertx",
+      "target": "backend_internal_db_rls_withusertxoptions",
       "confidence_score": 1.0
     },
     {
@@ -42458,21 +42632,10 @@
       "target": "backend_internal_db_rls_withusertx"
     },
     {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "INFERRED",
-      "confidence_score": 0.8,
-      "source_file": "backend/internal/http/resources.go",
-      "source_location": "L259",
-      "weight": 1.0,
-      "source": "http_resourceserver_withuser",
-      "target": "backend_internal_db_rls_withusertx"
-    },
-    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L113",
+      "source_location": "L128",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_connectionroleattributes",
@@ -42483,7 +42646,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L92",
+      "source_location": "L107",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_verifyrlsactive",
@@ -42494,7 +42657,18 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L113",
+      "source_location": "L46",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_withusertxoptions",
+      "target": "backend_internal_db_rls_go_context",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L128",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_connectionroleattributes",
@@ -42505,11 +42679,44 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L92",
+      "source_location": "L107",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_verifyrlsactive",
       "target": "backend_internal_db_rls_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L46",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_withusertxoptions",
+      "target": "backend_internal_db_rls_go_pool",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L46",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_withusertxoptions",
+      "target": "backend_internal_db_rls_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L46",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_withusertxoptions",
+      "target": "backend_internal_db_rls_go_queries",
       "confidence_score": 1.0
     },
     {
@@ -42518,7 +42725,40 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L283",
+      "source_location": "L290",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase",
+      "target": "backend_internal_db_rls_withusertxoptions"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls.go",
+      "source_location": "L46",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_withusertxoptions",
+      "target": "backend_internal_db_rls_go_txoptions",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L277",
+      "weight": 1.0,
+      "source": "http_resourceserver_withusertxoptions",
+      "target": "backend_internal_db_rls_withusertxoptions"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L353",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
       "target": "backend_internal_db_rls_verifyrlsactive"
@@ -42529,7 +42769,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L304",
+      "source_location": "L374",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
       "target": "backend_internal_db_rls_verifyrlsactive"
@@ -42539,7 +42779,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls.go",
-      "source_location": "L99",
+      "source_location": "L114",
       "weight": 1.0,
       "source": "backend_internal_db_rls_verifyrlsactive",
       "target": "backend_internal_db_rls_connectionroleattributes",
@@ -42579,7 +42819,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L273",
+      "source_location": "L343",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
@@ -42589,7 +42829,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L294",
+      "source_location": "L364",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
@@ -42633,6 +42873,16 @@
       "weight": 1.0,
       "source": "backend_internal_db_rls_test",
       "target": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L274",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test",
+      "target": "backend_internal_db_rls_test_testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase",
       "confidence_score": 1.0
     },
     {
@@ -42724,6 +42974,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L284",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase",
+      "target": "backend_internal_db_rls_test_createrlstestuser",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
@@ -42771,7 +43032,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L273",
+      "source_location": "L343",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_testverifyrlsactive_passesforordinaryrole_livedatabase",
@@ -42782,7 +43043,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/rls_test.go",
-      "source_location": "L294",
+      "source_location": "L364",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_testverifyrlsactive_rejectsbypassingrole_livedatabase",
@@ -42830,6 +43091,17 @@
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_rls_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L274",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_db_rls_test_testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase",
       "target": "backend_internal_db_rls_test_go_t",
       "confidence_score": 1.0
     },
@@ -42907,6 +43179,17 @@
       "source_location": "L201",
       "weight": 1.0,
       "source": "backend_internal_db_rls_test_testwithusertx_unboundtransactionfailsclosed_livedatabase",
+      "target": "backend_internal_db_rls_test_deleterlstestusers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/db/rls_test.go",
+      "source_location": "L285",
+      "weight": 1.0,
+      "source": "backend_internal_db_rls_test_testwithusertxoptions_repeatablereadusesonesnapshot_livedatabase",
       "target": "backend_internal_db_rls_test_deleterlstestusers",
       "confidence_score": 1.0
     },
@@ -45949,7 +46232,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L40",
+      "source_location": "L41",
       "weight": 1.0,
       "source": "backend_internal_http_resources_decoderesourcebody",
       "target": "backend_internal_http_auth_decodejsonbody"
@@ -46199,7 +46482,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L276",
+      "source_location": "L294",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_validateresourcename",
@@ -50181,7 +50464,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L37",
+      "source_location": "L39",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_daterange_parsedaterange"
@@ -50247,7 +50530,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L205",
+      "source_location": "L209",
       "weight": 1.0,
       "source": "backend_internal_http_summary_fillmissingdays",
       "target": "backend_internal_http_daterange_calendardaysbetween"
@@ -50258,7 +50541,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L59",
+      "source_location": "L61",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_daterange_calendardaysbetween"
@@ -51706,9 +51989,9 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L253",
+      "source_location": "L271",
       "weight": 1.0,
-      "source": "http_resourceserver_withuser",
+      "source": "http_resourceserver_withusertxoptions",
       "target": "backend_internal_http_middleware_useridfromcontext"
     },
     {
@@ -51926,9 +52209,9 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L255",
+      "source_location": "L273",
       "weight": 1.0,
-      "source": "http_resourceserver_withuser",
+      "source": "http_resourceserver_withusertxoptions",
       "target": "backend_internal_http_middleware_writeunauthorizederror"
     },
     {
@@ -52699,7 +52982,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L215",
+      "source_location": "L216",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_accountidfilter",
@@ -52709,7 +52992,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L294",
+      "source_location": "L312",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_dberror",
@@ -52719,7 +53002,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L69",
+      "source_location": "L70",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_decodebulkbody",
@@ -52729,7 +53012,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_decoderesourcebody",
@@ -52739,7 +53022,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L102",
+      "source_location": "L103",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_go_http_resourceserver",
@@ -52749,7 +53032,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L287",
+      "source_location": "L305",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_logresourceerror",
@@ -52759,7 +53042,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L118",
+      "source_location": "L119",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_newresourceserver",
@@ -52769,7 +53052,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L125",
+      "source_location": "L126",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_newresourceserverwithclock",
@@ -52779,7 +53062,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L199",
+      "source_location": "L200",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_optionalqueryparam",
@@ -52789,7 +53072,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L267",
+      "source_location": "L285",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_pguserid",
@@ -52799,7 +53082,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L276",
+      "source_location": "L294",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_validateresourcename",
@@ -52809,7 +53092,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L180",
+      "source_location": "L181",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_withlisttransactionsparams",
@@ -52819,7 +53102,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L165",
+      "source_location": "L166",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_withresourceid",
@@ -52829,7 +53112,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L229",
+      "source_location": "L234",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_withsummaryparams",
@@ -52839,7 +53122,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L48",
+      "source_location": "L49",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "http_bodydecodeoutcome",
@@ -52849,7 +53132,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L134",
+      "source_location": "L135",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "http_resourceservermethods",
@@ -52859,7 +53142,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_decoderesourcebody",
@@ -52870,7 +53153,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_decoderesourcebody",
@@ -52881,7 +53164,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_decoderesourcebody",
@@ -52914,7 +53197,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L69",
+      "source_location": "L70",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_decodebulkbody",
@@ -52925,7 +53208,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L180",
+      "source_location": "L181",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withlisttransactionsparams",
@@ -52936,7 +53219,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L165",
+      "source_location": "L166",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -52947,7 +53230,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L229",
+      "source_location": "L234",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withsummaryparams",
@@ -52958,7 +53241,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L252",
+      "source_location": "L257",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -52969,7 +53252,18 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L69",
+      "source_location": "L265",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_withusertxoptions",
+      "target": "backend_internal_http_resources_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L70",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_decodebulkbody",
@@ -52980,7 +53274,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L287",
+      "source_location": "L305",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_logresourceerror",
@@ -52991,7 +53285,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L180",
+      "source_location": "L181",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withlisttransactionsparams",
@@ -53002,7 +53296,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L165",
+      "source_location": "L166",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -53013,7 +53307,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L229",
+      "source_location": "L234",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withsummaryparams",
@@ -53024,7 +53318,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L252",
+      "source_location": "L257",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -53035,7 +53329,18 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L69",
+      "source_location": "L265",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_withusertxoptions",
+      "target": "backend_internal_http_resources_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L70",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_decodebulkbody",
@@ -53046,7 +53351,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L69",
+      "source_location": "L70",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_decodebulkbody",
@@ -53079,7 +53384,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L103",
+      "source_location": "L104",
       "weight": 1.0,
       "context": "field",
       "source": "backend_internal_http_resources_go_http_resourceserver",
@@ -53090,7 +53395,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L113",
+      "source_location": "L114",
       "weight": 1.0,
       "context": "field",
       "source": "backend_internal_http_resources_go_http_resourceserver",
@@ -53101,17 +53406,27 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L252",
+      "source_location": "L257",
       "weight": 1.0,
       "source": "backend_internal_http_resources_go_http_resourceserver",
       "target": "http_resourceserver_withuser",
       "confidence_score": 1.0
     },
     {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L265",
+      "weight": 1.0,
+      "source": "backend_internal_http_resources_go_http_resourceserver",
+      "target": "http_resourceserver_withusertxoptions",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L108",
+      "source_location": "L109",
       "weight": 1.0,
       "context": "field",
       "source": "backend_internal_http_resources_go_http_resourceserver",
@@ -53122,7 +53437,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L118",
+      "source_location": "L119",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_newresourceserver",
@@ -53133,7 +53448,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L125",
+      "source_location": "L126",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_newresourceserverwithclock",
@@ -53144,7 +53459,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L118",
+      "source_location": "L119",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_newresourceserver",
@@ -53155,7 +53470,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L125",
+      "source_location": "L126",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_newresourceserverwithclock",
@@ -53166,7 +53481,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L125",
+      "source_location": "L126",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_newresourceserverwithclock",
@@ -53188,7 +53503,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L165",
+      "source_location": "L166",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -53199,7 +53514,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L165",
+      "source_location": "L166",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -53221,7 +53536,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L180",
+      "source_location": "L181",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_withlisttransactionsparams",
@@ -53232,7 +53547,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L229",
+      "source_location": "L234",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_withsummaryparams",
@@ -53243,7 +53558,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L180",
+      "source_location": "L181",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withlisttransactionsparams",
@@ -53255,7 +53570,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L186",
+      "source_location": "L187",
       "weight": 1.0,
       "source": "backend_internal_http_resources_withlisttransactionsparams",
       "target": "backend_internal_http_resources_optionalqueryparam",
@@ -53276,7 +53591,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L199",
+      "source_location": "L200",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_optionalqueryparam",
@@ -53288,7 +53603,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L232",
+      "source_location": "L237",
       "weight": 1.0,
       "source": "backend_internal_http_resources_withsummaryparams",
       "target": "backend_internal_http_resources_optionalqueryparam",
@@ -53300,7 +53615,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L38",
+      "source_location": "L40",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_resources_optionalqueryparam"
@@ -53320,7 +53635,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L215",
+      "source_location": "L216",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_accountidfilter",
@@ -53333,7 +53648,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L48",
+      "source_location": "L50",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_resources_accountidfilter"
@@ -53353,7 +53668,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L229",
+      "source_location": "L234",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withsummaryparams",
@@ -53375,7 +53690,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L252",
+      "source_location": "L257",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -53386,7 +53701,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L252",
+      "source_location": "L257",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -53394,14 +53709,58 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L258",
+      "weight": 1.0,
+      "source": "http_resourceserver_withuser",
+      "target": "http_resourceserver_withusertxoptions",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L267",
+      "source_location": "L285",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_pguserid",
       "target": "backend_internal_http_resources_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L265",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_withusertxoptions",
+      "target": "backend_internal_http_resources_go_uuid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L265",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_withusertxoptions",
+      "target": "backend_internal_http_resources_go_queries",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L265",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_withusertxoptions",
+      "target": "backend_internal_http_resources_go_txoptions",
       "confidence_score": 1.0
     },
     {
@@ -53454,7 +53813,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L70",
+      "source_location": "L72",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_resources_pguserid"
@@ -53542,7 +53901,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L111",
+      "source_location": "L113",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_resources_logresourceerror"
@@ -53584,7 +53943,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L294",
+      "source_location": "L312",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_dberror",
@@ -53641,7 +54000,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L112",
+      "source_location": "L114",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_resources_dberror"
@@ -53726,7 +54085,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L162",
+      "source_location": "L166",
       "weight": 1.0,
       "source": "backend_internal_http_summary",
       "target": "backend_internal_http_summary_bucketcategories",
@@ -53736,7 +54095,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L194",
+      "source_location": "L198",
       "weight": 1.0,
       "source": "backend_internal_http_summary",
       "target": "backend_internal_http_summary_fillmissingdays",
@@ -53746,7 +54105,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L140",
+      "source_location": "L142",
       "weight": 1.0,
       "source": "backend_internal_http_summary",
       "target": "backend_internal_http_summary_percentagechange",
@@ -53756,7 +54115,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L220",
+      "source_location": "L224",
       "weight": 1.0,
       "source": "backend_internal_http_summary",
       "target": "backend_internal_http_summary_pgtimestamp",
@@ -53766,7 +54125,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L35",
+      "source_location": "L37",
       "weight": 1.0,
       "source": "backend_internal_http_summary_go_http_resourceserver",
       "target": "http_resourceserver_getsummary",
@@ -53777,7 +54136,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L124",
+      "source_location": "L126",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_summary_bucketcategories",
@@ -53788,7 +54147,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L125",
+      "source_location": "L127",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_summary_fillmissingdays",
@@ -53798,7 +54157,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L35",
+      "source_location": "L37",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_getsummary",
@@ -53809,7 +54168,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L35",
+      "source_location": "L37",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_getsummary",
@@ -53821,7 +54180,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L119",
+      "source_location": "L121",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_summary_percentagechange",
@@ -53832,7 +54191,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L71",
+      "source_location": "L73",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_summary_pgtimestamp",
@@ -53844,7 +54203,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L43",
+      "source_location": "L45",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_transactions_invaliddatequeryerror"
@@ -53855,7 +54214,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L50",
+      "source_location": "L52",
       "weight": 1.0,
       "source": "http_resourceserver_getsummary",
       "target": "backend_internal_http_transactions_invalidqueryerror"
@@ -53864,7 +54223,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L35",
+      "source_location": "L37",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_getsummary",
@@ -53877,7 +54236,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L35",
+      "source_location": "L36",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test_testpercentagechange",
       "target": "backend_internal_http_summary_percentagechange"
@@ -53888,16 +54247,27 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L46",
+      "source_location": "L47",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test_testpercentagechange_usesfloatdivision",
+      "target": "backend_internal_http_summary_percentagechange"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test_testpercentagechange_widensbeforesubtracting",
       "target": "backend_internal_http_summary_percentagechange"
     },
     {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L162",
+      "source_location": "L166",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_summary_bucketcategories",
@@ -53910,7 +54280,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L57",
+      "source_location": "L69",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test_testbucketcategories",
       "target": "backend_internal_http_summary_bucketcategories"
@@ -53919,7 +54289,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L194",
+      "source_location": "L198",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_summary_fillmissingdays",
@@ -53930,7 +54300,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L194",
+      "source_location": "L198",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_summary_fillmissingdays",
@@ -53943,7 +54313,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L134",
+      "source_location": "L146",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test_testfillmissingdays",
       "target": "backend_internal_http_summary_fillmissingdays"
@@ -53952,7 +54322,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L220",
+      "source_location": "L224",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_summary_pgtimestamp",
@@ -53963,7 +54333,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary.go",
-      "source_location": "L220",
+      "source_location": "L224",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_summary_pgtimestamp",
@@ -54556,7 +54926,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L51",
+      "source_location": "L63",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test",
       "target": "backend_internal_http_summary_test_categoryrow",
@@ -54566,7 +54936,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L120",
+      "source_location": "L132",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test",
       "target": "backend_internal_http_summary_test_dailyrow",
@@ -54576,7 +54946,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L55",
+      "source_location": "L67",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test",
       "target": "backend_internal_http_summary_test_testbucketcategories",
@@ -54586,7 +54956,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L129",
+      "source_location": "L141",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test",
       "target": "backend_internal_http_summary_test_testfillmissingdays",
@@ -54596,7 +54966,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L15",
+      "source_location": "L16",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test",
       "target": "backend_internal_http_summary_test_testpercentagechange",
@@ -54606,17 +54976,27 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L44",
+      "source_location": "L45",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test",
       "target": "backend_internal_http_summary_test_testpercentagechange_usesfloatdivision",
       "confidence_score": 1.0
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test",
+      "target": "backend_internal_http_summary_test_testpercentagechange_widensbeforesubtracting",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L15",
+      "source_location": "L16",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_summary_test_testpercentagechange",
@@ -54627,7 +55007,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L55",
+      "source_location": "L67",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_summary_test_testbucketcategories",
@@ -54638,7 +55018,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L129",
+      "source_location": "L141",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_summary_test_testfillmissingdays",
@@ -54649,10 +55029,21 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L44",
+      "source_location": "L45",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_summary_test_testpercentagechange_usesfloatdivision",
+      "target": "backend_internal_http_summary_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L52",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_test_testpercentagechange_widensbeforesubtracting",
       "target": "backend_internal_http_summary_test_go_t",
       "confidence_score": 1.0
     },
@@ -54661,7 +55052,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L58",
+      "source_location": "L70",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test_testbucketcategories",
       "target": "backend_internal_http_summary_test_categoryrow",
@@ -54672,7 +55063,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/summary_test.go",
-      "source_location": "L135",
+      "source_location": "L147",
       "weight": 1.0,
       "source": "backend_internal_http_summary_test_testfillmissingdays",
       "target": "backend_internal_http_summary_test_dailyrow",
@@ -85648,6 +86039,16 @@
     {
       "relation": "references",
       "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "docs_api_summary",
+      "target": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
       "source_file": "docs/product/summary.md",
       "source_location": "L7",
       "weight": 1.0,
@@ -85659,7 +86060,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/summary.md",
-      "source_location": "L81",
+      "source_location": "L82",
       "weight": 1.0,
       "source": "docs_api_summary_summary_api_technical_reference",
       "target": "docs_api_summary_category_breakdown",
@@ -85669,7 +86070,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/summary.md",
-      "source_location": "L103",
+      "source_location": "L104",
       "weight": 1.0,
       "source": "docs_api_summary_summary_api_technical_reference",
       "target": "docs_api_summary_daily_series",
@@ -85689,7 +86090,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/summary.md",
-      "source_location": "L138",
+      "source_location": "L139",
       "weight": 1.0,
       "source": "docs_api_summary_summary_api_technical_reference",
       "target": "docs_api_summary_divergences_and_gaps",
@@ -85699,7 +86100,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/summary.md",
-      "source_location": "L118",
+      "source_location": "L119",
       "weight": 1.0,
       "source": "docs_api_summary_summary_api_technical_reference",
       "target": "docs_api_summary_empty_state",
@@ -85719,7 +86120,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/summary.md",
-      "source_location": "L63",
+      "source_location": "L64",
       "weight": 1.0,
       "source": "docs_api_summary_summary_api_technical_reference",
       "target": "docs_api_summary_percentage_change",
@@ -85729,7 +86130,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/summary.md",
-      "source_location": "L48",
+      "source_location": "L49",
       "weight": 1.0,
       "source": "docs_api_summary_summary_api_technical_reference",
       "target": "docs_api_summary_the_comparison_period",
@@ -85749,7 +86150,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/summary.md",
-      "source_location": "L129",
+      "source_location": "L130",
       "weight": 1.0,
       "source": "docs_api_summary_summary_api_technical_reference",
       "target": "docs_api_summary_where_the_code_lives",
@@ -85759,7 +86160,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "docs/api/summary.md",
-      "source_location": "L91",
+      "source_location": "L92",
       "weight": 1.0,
       "source": "docs_api_summary_category_breakdown",
       "target": "docs_api_summary_what_the_breakdown_excludes",
@@ -89828,6 +90229,66 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range",
+      "target": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_codex_summary_aggregate_contract_range",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "post_migration_improvements_codex_backend_improvements_readme",
+      "target": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_codex_summary_aggregate_contract_range",
+      "target": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_decision_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_codex_summary_aggregate_contract_range",
+      "target": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_problem_and_evidence",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_codex_summary_aggregate_contract_range",
+      "target": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_required_decision",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_codex_summary_aggregate_contract_range",
+      "target": "post_migration_improvements_codex_backend_improvements_codex_summary_aggregate_contract_range_verification",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
       "source_location": "L1",
       "weight": 1.0,
@@ -89839,7 +90300,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
-      "source_location": "L60",
+      "source_location": "L62",
       "weight": 1.0,
       "source": "post_migration_improvements_codex_backend_improvements_readme",
       "target": "post_migration_improvements_codex_backend_improvements_templates_endpoint_review",
@@ -89849,7 +90310,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
-      "source_location": "L41",
+      "source_location": "L43",
       "weight": 1.0,
       "source": "post_migration_improvements_codex_backend_improvements_readme_codex_backend_improvements",
       "target": "post_migration_improvements_codex_backend_improvements_readme_decision_hierarchy",
@@ -89859,7 +90320,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
-      "source_location": "L56",
+      "source_location": "L58",
       "weight": 1.0,
       "source": "post_migration_improvements_codex_backend_improvements_readme_codex_backend_improvements",
       "target": "post_migration_improvements_codex_backend_improvements_readme_definition_of_done_for_an_endpoint",
@@ -89879,7 +90340,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "post-migration-improvements/codex-backend-improvements/README.md",
-      "source_location": "L64",
+      "source_location": "L66",
       "weight": 1.0,
       "source": "post_migration_improvements_codex_backend_improvements_readme_codex_backend_improvements",
       "target": "post_migration_improvements_codex_backend_improvements_readme_source_set",
@@ -90457,5 +90918,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "79548587c06aa0c5430819480fdc67a32f2a52ab"
+  "built_at_commit": "780a6ce174ff4a340769f7e8f5549b3c2ae9b59b"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -120,7 +120,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "app_dashboard_accounts_page_accountspage",
-      "community": 567,
+      "community": 432,
       "norm_label": "accountspage()"
     },
     {
@@ -200,7 +200,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "app_dashboard_categories_page_categoriespage",
-      "community": 428,
+      "community": 432,
       "norm_label": "categoriespage()"
     },
     {
@@ -240,7 +240,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_page",
-      "community": 9,
+      "community": 35,
       "norm_label": "page.tsx"
     },
     {
@@ -250,7 +250,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "app_dashboard_page_dashboardpage",
-      "community": 9,
+      "community": 35,
       "norm_label": "dashboardpage()"
     },
     {
@@ -310,7 +310,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_dashboard_transactions_actions_actions",
-      "community": 260,
+      "community": 432,
       "norm_label": "actions()"
     },
     {
@@ -380,7 +380,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card",
-      "community": 517,
+      "community": 515,
       "norm_label": "import-card.tsx"
     },
     {
@@ -390,7 +390,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_requiredoptions",
-      "community": 517,
+      "community": 515,
       "norm_label": "requiredoptions"
     },
     {
@@ -400,7 +400,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_selectedcolumnsstate",
-      "community": 517,
+      "community": 515,
       "norm_label": "selectedcolumnsstate"
     },
     {
@@ -410,7 +410,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_props",
-      "community": 517,
+      "community": 515,
       "norm_label": "props"
     },
     {
@@ -420,7 +420,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_card_importcard",
-      "community": 517,
+      "community": 515,
       "norm_label": "importcard()"
     },
     {
@@ -450,7 +450,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "app_dashboard_transactions_import_table_importtable",
-      "community": 517,
+      "community": 515,
       "norm_label": "importtable()"
     },
     {
@@ -490,7 +490,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "app_dashboard_transactions_page_transactionspage",
-      "community": 428,
+      "community": 432,
       "norm_label": "transactionspage()"
     },
     {
@@ -510,7 +510,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select",
-      "community": 49,
+      "community": 515,
       "norm_label": "table-head-select.tsx"
     },
     {
@@ -520,7 +520,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_props",
-      "community": 49,
+      "community": 515,
       "norm_label": "props"
     },
     {
@@ -530,7 +530,7 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_options",
-      "community": 49,
+      "community": 515,
       "norm_label": "options"
     },
     {
@@ -540,7 +540,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_importabletransactionfield",
-      "community": 49,
+      "community": 515,
       "norm_label": "importabletransactionfield"
     },
     {
@@ -550,7 +550,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_isimportabletransactionfield",
-      "community": 49,
+      "community": 348,
       "norm_label": "isimportabletransactionfield()"
     },
     {
@@ -560,7 +560,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "app_dashboard_transactions_table_head_select_tableheadselect",
-      "community": 49,
+      "community": 348,
       "norm_label": "tableheadselect()"
     },
     {
@@ -660,7 +660,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_api_route_route",
-      "community": 19,
+      "community": 388,
       "norm_label": "route.ts"
     },
     {
@@ -670,7 +670,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_api_route_route_app",
-      "community": 19,
+      "community": 388,
       "norm_label": "app"
     },
     {
@@ -680,7 +680,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "app_api_route_route_routes",
-      "community": 19,
+      "community": 388,
       "norm_label": "routes"
     },
     {
@@ -690,7 +690,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "app_api_route_route_get",
-      "community": 19,
+      "community": 388,
       "norm_label": "get"
     },
     {
@@ -700,7 +700,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_api_route_route_post",
-      "community": 19,
+      "community": 388,
       "norm_label": "post"
     },
     {
@@ -710,7 +710,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "app_api_route_route_patch",
-      "community": 19,
+      "community": 388,
       "norm_label": "patch"
     },
     {
@@ -720,7 +720,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "app_api_route_route_delete",
-      "community": 19,
+      "community": 388,
       "norm_label": "delete"
     },
     {
@@ -730,7 +730,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "app_api_route_route_put",
-      "community": 19,
+      "community": 388,
       "norm_label": "put"
     },
     {
@@ -740,7 +740,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "app_api_route_route_options",
-      "community": 19,
+      "community": 388,
       "norm_label": "options"
     },
     {
@@ -750,7 +750,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "app_api_route_route_apptype",
-      "community": 19,
+      "community": 388,
       "norm_label": "apptype"
     },
     {
@@ -780,7 +780,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_api_route_transactions",
-      "community": 19,
+      "community": 31,
       "norm_label": "transactions.ts"
     },
     {
@@ -790,7 +790,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "app_api_route_transactions_ownedreferencesresult",
-      "community": 19,
+      "community": 31,
       "norm_label": "ownedreferencesresult"
     },
     {
@@ -800,7 +800,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "app_api_route_transactions_validatetransactionreferences",
-      "community": 19,
+      "community": 31,
       "norm_label": "validatetransactionreferences()"
     },
     {
@@ -810,7 +810,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "app_api_route_transactions_validatebulktransactionreferences",
-      "community": 19,
+      "community": 31,
       "norm_label": "validatebulktransactionreferences()"
     },
     {
@@ -820,7 +820,7 @@
       "source_location": "L147",
       "_origin": "ast",
       "id": "app_api_route_transactions_sendratelimited",
-      "community": 19,
+      "community": 31,
       "norm_label": "sendratelimited()"
     },
     {
@@ -830,7 +830,7 @@
       "source_location": "L164",
       "_origin": "ast",
       "id": "app_api_route_transactions_enforcejsonbodylimit",
-      "community": 19,
+      "community": 31,
       "norm_label": "enforcejsonbodylimit()"
     },
     {
@@ -840,7 +840,7 @@
       "source_location": "L182",
       "_origin": "ast",
       "id": "app_api_route_transactions_app",
-      "community": 19,
+      "community": 31,
       "norm_label": "app"
     },
     {
@@ -850,7 +850,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "app_layout",
-      "community": 31,
+      "community": 518,
       "norm_label": "layout.tsx"
     },
     {
@@ -860,7 +860,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "app_layout_geistsans",
-      "community": 31,
+      "community": 518,
       "norm_label": "geistsans"
     },
     {
@@ -870,7 +870,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "app_layout_geistmono",
-      "community": 31,
+      "community": 518,
       "norm_label": "geistmono"
     },
     {
@@ -880,7 +880,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "app_layout_metadata",
-      "community": 31,
+      "community": 518,
       "norm_label": "metadata"
     },
     {
@@ -890,7 +890,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "app_layout_rootlayout",
-      "community": 31,
+      "community": 518,
       "norm_label": "rootlayout()"
     },
     {
@@ -2862,7 +2862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_db_gen_summary_sql",
-      "community": 229,
+      "community": 536,
       "norm_label": "summary.sql.go"
     },
     {
@@ -2872,7 +2872,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "gen_getcategoryspendingparams",
-      "community": 229,
+      "community": 536,
       "norm_label": "getcategoryspendingparams"
     },
     {
@@ -2882,7 +2882,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_db_gen_summary_sql_go_uuid",
-      "community": 229,
+      "community": 536,
       "norm_label": "uuid"
     },
     {
@@ -2892,7 +2892,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_db_gen_summary_sql_go_timestamp",
-      "community": 229,
+      "community": 536,
       "norm_label": "timestamp"
     },
     {
@@ -2902,7 +2902,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_db_gen_summary_sql_go_text",
-      "community": 229,
+      "community": 536,
       "norm_label": "text"
     },
     {
@@ -2912,7 +2912,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "gen_getcategoryspendingrow",
-      "community": 229,
+      "community": 536,
       "norm_label": "getcategoryspendingrow"
     },
     {
@@ -2922,7 +2922,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "backend_internal_db_gen_summary_sql_go_gen_queries",
-      "community": 229,
+      "community": 536,
       "norm_label": "queries"
     },
     {
@@ -2932,7 +2932,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "gen_queries_getcategoryspending",
-      "community": 229,
+      "community": 536,
       "norm_label": ".getcategoryspending()"
     },
     {
@@ -2942,7 +2942,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_db_gen_summary_sql_go_context",
-      "community": 229,
+      "community": 536,
       "norm_label": "context"
     },
     {
@@ -2952,7 +2952,7 @@
       "source_location": "L83",
       "_origin": "ast",
       "id": "gen_getdailytotalsparams",
-      "community": 229,
+      "community": 536,
       "norm_label": "getdailytotalsparams"
     },
     {
@@ -2962,7 +2962,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "gen_getdailytotalsrow",
-      "community": 229,
+      "community": 536,
       "norm_label": "getdailytotalsrow"
     },
     {
@@ -2972,7 +2972,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "date",
-      "community": 229,
+      "community": 536,
       "norm_label": "date"
     },
     {
@@ -2982,7 +2982,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "gen_queries_getdailytotals",
-      "community": 229,
+      "community": 536,
       "norm_label": ".getdailytotals()"
     },
     {
@@ -2992,7 +2992,7 @@
       "source_location": "L141",
       "_origin": "ast",
       "id": "gen_getperiodtotalsparams",
-      "community": 229,
+      "community": 536,
       "norm_label": "getperiodtotalsparams"
     },
     {
@@ -3002,7 +3002,7 @@
       "source_location": "L148",
       "_origin": "ast",
       "id": "gen_getperiodtotalsrow",
-      "community": 229,
+      "community": 536,
       "norm_label": "getperiodtotalsrow"
     },
     {
@@ -3012,7 +3012,7 @@
       "source_location": "L163",
       "_origin": "ast",
       "id": "gen_queries_getperiodtotals",
-      "community": 229,
+      "community": 536,
       "norm_label": ".getperiodtotals()"
     },
     {
@@ -3992,7 +3992,7 @@
       "source_location": "L300",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_validateaccountname",
-      "community": 378,
+      "community": 20,
       "norm_label": "validateaccountname()"
     },
     {
@@ -4002,7 +4002,7 @@
       "source_location": "L308",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_validatebulkdeleteids",
-      "community": 378,
+      "community": 20,
       "norm_label": "validatebulkdeleteids()"
     },
     {
@@ -4062,7 +4062,7 @@
       "source_location": "L373",
       "_origin": "ast",
       "id": "backend_internal_http_accounts_isuniqueviolation",
-      "community": 42,
+      "community": 20,
       "norm_label": "isuniqueviolation()"
     },
     {
@@ -5192,7 +5192,7 @@
       "source_location": "L296",
       "_origin": "ast",
       "id": "backend_internal_http_categories_validatecategoryname",
-      "community": 42,
+      "community": 378,
       "norm_label": "validatecategoryname()"
     },
     {
@@ -6062,7 +6062,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_health_test",
-      "community": 28,
+      "community": 510,
       "norm_label": "health_test.go"
     },
     {
@@ -6072,7 +6072,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "backend_internal_http_health_test_testhealthendpoint",
-      "community": 28,
+      "community": 510,
       "norm_label": "testhealthendpoint()"
     },
     {
@@ -6082,7 +6082,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_health_test_go_t",
-      "community": 28,
+      "community": 510,
       "norm_label": "t"
     },
     {
@@ -6689,7 +6689,7 @@
       "label": "withResourceID()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L163",
+      "source_location": "L165",
       "_origin": "ast",
       "id": "backend_internal_http_resources_withresourceid",
       "community": 510,
@@ -6719,7 +6719,7 @@
       "label": "withListTransactionsParams()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L178",
+      "source_location": "L180",
       "_origin": "ast",
       "id": "backend_internal_http_resources_withlisttransactionsparams",
       "community": 510,
@@ -6739,7 +6739,7 @@
       "label": "optionalQueryParam()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L197",
+      "source_location": "L199",
       "_origin": "ast",
       "id": "backend_internal_http_resources_optionalqueryparam",
       "community": 510,
@@ -6756,10 +6756,40 @@
       "norm_label": "values"
     },
     {
+      "label": "accountIDFilter()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L215",
+      "_origin": "ast",
+      "id": "backend_internal_http_resources_accountidfilter",
+      "community": 428,
+      "norm_label": "accountidfilter()"
+    },
+    {
+      "label": "Text",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_resources_go_text",
+      "community": 428,
+      "norm_label": "text"
+    },
+    {
+      "label": "withSummaryParams()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L229",
+      "_origin": "ast",
+      "id": "backend_internal_http_resources_withsummaryparams",
+      "community": 510,
+      "norm_label": "withsummaryparams()"
+    },
+    {
       "label": ".withUser()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L218",
+      "source_location": "L252",
       "_origin": "ast",
       "id": "http_resourceserver_withuser",
       "community": 510,
@@ -6789,17 +6819,17 @@
       "label": "pgUserID()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L233",
+      "source_location": "L267",
       "_origin": "ast",
       "id": "backend_internal_http_resources_pguserid",
-      "community": 20,
+      "community": 42,
       "norm_label": "pguserid()"
     },
     {
       "label": "validateResourceName()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L242",
+      "source_location": "L276",
       "_origin": "ast",
       "id": "backend_internal_http_resources_validateresourcename",
       "community": 378,
@@ -6809,20 +6839,20 @@
       "label": "logResourceError()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L253",
+      "source_location": "L287",
       "_origin": "ast",
       "id": "backend_internal_http_resources_logresourceerror",
-      "community": 42,
+      "community": 20,
       "norm_label": "logresourceerror()"
     },
     {
       "label": "dbError()",
       "file_type": "code",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L260",
+      "source_location": "L294",
       "_origin": "ast",
       "id": "backend_internal_http_resources_dberror",
-      "community": 20,
+      "community": 42,
       "norm_label": "dberror()"
     },
     {
@@ -6832,7 +6862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_router",
-      "community": 28,
+      "community": 510,
       "norm_label": "router.go"
     },
     {
@@ -6842,7 +6872,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "backend_internal_http_router_newrouter",
-      "community": 28,
+      "community": 510,
       "norm_label": "newrouter()"
     },
     {
@@ -6852,7 +6882,7 @@
       "source_location": "",
       "_origin": "ast",
       "id": "resourceserver",
-      "community": 28,
+      "community": 510,
       "norm_label": "resourceserver"
     },
     {
@@ -6862,8 +6892,338 @@
       "source_location": "",
       "_origin": "ast",
       "id": "backend_internal_http_router_go_handler",
-      "community": 28,
+      "community": 510,
       "norm_label": "handler"
+    },
+    {
+      "label": "summary.go",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary",
+      "community": 536,
+      "norm_label": "summary.go"
+    },
+    {
+      "label": "ResourceServer",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L35",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_go_http_resourceserver",
+      "community": 428,
+      "norm_label": "resourceserver"
+    },
+    {
+      "label": ".GetSummary()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L35",
+      "_origin": "ast",
+      "id": "http_resourceserver_getsummary",
+      "community": 428,
+      "norm_label": ".getsummary()"
+    },
+    {
+      "label": "ResponseWriter",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_go_responsewriter",
+      "community": 428,
+      "norm_label": "responsewriter"
+    },
+    {
+      "label": "Request",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_go_request",
+      "community": 428,
+      "norm_label": "request"
+    },
+    {
+      "label": "percentageChange()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L140",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_percentagechange",
+      "community": 536,
+      "norm_label": "percentagechange()"
+    },
+    {
+      "label": "bucketCategories()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L162",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_bucketcategories",
+      "community": 536,
+      "norm_label": "bucketcategories()"
+    },
+    {
+      "label": "fillMissingDays()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L194",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_fillmissingdays",
+      "community": 536,
+      "norm_label": "fillmissingdays()"
+    },
+    {
+      "label": "Time",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_go_time",
+      "community": 536,
+      "norm_label": "time"
+    },
+    {
+      "label": "pgTimestamp()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L220",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_pgtimestamp",
+      "community": 536,
+      "norm_label": "pgtimestamp()"
+    },
+    {
+      "label": "Timestamp",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_go_timestamp",
+      "community": 536,
+      "norm_label": "timestamp"
+    },
+    {
+      "label": "summary_live_test.go",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test",
+      "community": 41,
+      "norm_label": "summary_live_test.go"
+    },
+    {
+      "label": "getSummary()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L18",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_getsummary",
+      "community": 41,
+      "norm_label": "getsummary()"
+    },
+    {
+      "label": "T",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_go_t",
+      "community": 41,
+      "norm_label": "t"
+    },
+    {
+      "label": "seedSummaryTransaction()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L33",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "community": 41,
+      "norm_label": "seedsummarytransaction()"
+    },
+    {
+      "label": "TestSummaryLive_Totals()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L42",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_totals",
+      "community": 41,
+      "norm_label": "testsummarylive_totals()"
+    },
+    {
+      "label": "TestSummaryLive_EmptyStateIsZerosAndFilledDays()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L70",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_emptystateiszerosandfilleddays",
+      "community": 41,
+      "norm_label": "testsummarylive_emptystateiszerosandfilleddays()"
+    },
+    {
+      "label": "TestSummaryLive_ChangeComparesThePrecedingWindow()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L123",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_changecomparestheprecedingwindow",
+      "community": 41,
+      "norm_label": "testsummarylive_changecomparestheprecedingwindow()"
+    },
+    {
+      "label": "TestSummaryLive_ChangeIs100WhenPreviousPeriodIsEmpty()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L144",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_changeis100whenpreviousperiodisempty",
+      "community": 41,
+      "norm_label": "testsummarylive_changeis100whenpreviousperiodisempty()"
+    },
+    {
+      "label": "TestSummaryLive_CategoryBreakdown()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L163",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_categorybreakdown",
+      "community": 41,
+      "norm_label": "testsummarylive_categorybreakdown()"
+    },
+    {
+      "label": "TestSummaryLive_DailySeries()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L211",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_dailyseries",
+      "community": 41,
+      "norm_label": "testsummarylive_dailyseries()"
+    },
+    {
+      "label": "TestSummaryLive_AccountFilter()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L243",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_accountfilter",
+      "community": 41,
+      "norm_label": "testsummarylive_accountfilter()"
+    },
+    {
+      "label": "TestSummaryLive_CrossUserIsolation()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L270",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_crossuserisolation",
+      "community": 41,
+      "norm_label": "testsummarylive_crossuserisolation()"
+    },
+    {
+      "label": "TestSummaryLive_DateQueryErrors()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L302",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_datequeryerrors",
+      "community": 41,
+      "norm_label": "testsummarylive_datequeryerrors()"
+    },
+    {
+      "label": "TestSummaryLive_Unauthorized()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L336",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_live_test_testsummarylive_unauthorized",
+      "community": 41,
+      "norm_label": "testsummarylive_unauthorized()"
+    },
+    {
+      "label": "summary_test.go",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_test",
+      "community": 536,
+      "norm_label": "summary_test.go"
+    },
+    {
+      "label": "TestPercentageChange()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L15",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_test_testpercentagechange",
+      "community": 536,
+      "norm_label": "testpercentagechange()"
+    },
+    {
+      "label": "T",
+      "file_type": "code",
+      "source_file": "",
+      "source_location": "",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_test_go_t",
+      "community": 536,
+      "norm_label": "t"
+    },
+    {
+      "label": "TestPercentageChange_UsesFloatDivision()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L44",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_test_testpercentagechange_usesfloatdivision",
+      "community": 536,
+      "norm_label": "testpercentagechange_usesfloatdivision()"
+    },
+    {
+      "label": "categoryRow()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L51",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_test_categoryrow",
+      "community": 536,
+      "norm_label": "categoryrow()"
+    },
+    {
+      "label": "TestBucketCategories()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L55",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_test_testbucketcategories",
+      "community": 536,
+      "norm_label": "testbucketcategories()"
+    },
+    {
+      "label": "dailyRow()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L120",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_test_dailyrow",
+      "community": 536,
+      "norm_label": "dailyrow()"
+    },
+    {
+      "label": "TestFillMissingDays()",
+      "file_type": "code",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L129",
+      "_origin": "ast",
+      "id": "backend_internal_http_summary_test_testfillmissingdays",
+      "community": 536,
+      "norm_label": "testfillmissingdays()"
     },
     {
       "label": "transactions.go",
@@ -6872,7 +7232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "backend_internal_http_transactions",
-      "community": 503,
+      "community": 378,
       "norm_label": "transactions.go"
     },
     {
@@ -6979,7 +7339,7 @@
       "label": ".GetTransaction()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L141",
+      "source_location": "L135",
       "_origin": "ast",
       "id": "http_resourceserver_gettransaction",
       "community": 503,
@@ -6999,7 +7359,7 @@
       "label": ".CreateTransaction()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L183",
+      "source_location": "L177",
       "_origin": "ast",
       "id": "http_resourceserver_createtransaction",
       "community": 503,
@@ -7009,7 +7369,7 @@
       "label": ".UpdateTransaction()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L263",
+      "source_location": "L257",
       "_origin": "ast",
       "id": "http_resourceserver_updatetransaction",
       "community": 503,
@@ -7019,7 +7379,7 @@
       "label": ".DeleteTransaction()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L340",
+      "source_location": "L334",
       "_origin": "ast",
       "id": "http_resourceserver_deletetransaction",
       "community": 503,
@@ -7029,7 +7389,7 @@
       "label": "validateTransactionReferences()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L390",
+      "source_location": "L384",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_validatetransactionreferences",
       "community": 503,
@@ -7059,17 +7419,17 @@
       "label": "referenceErrorFromForeignKeyViolation()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L428",
+      "source_location": "L422",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_referenceerrorfromforeignkeyviolation",
-      "community": 503,
+      "community": 556,
       "norm_label": "referenceerrorfromforeignkeyviolation()"
     },
     {
       "label": ".allowMutation()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L445",
+      "source_location": "L439",
       "_origin": "ast",
       "id": "http_resourceserver_allowmutation",
       "community": 503,
@@ -7079,7 +7439,7 @@
       "label": "validateTransactionInput()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L461",
+      "source_location": "L455",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_validatetransactioninput",
       "community": 378,
@@ -7089,7 +7449,7 @@
       "label": "parseAmount()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L523",
+      "source_location": "L517",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_parseamount",
       "community": 378,
@@ -7099,17 +7459,17 @@
       "label": "toTransactionListItem()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L544",
+      "source_location": "L538",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_totransactionlistitem",
-      "community": 503,
+      "community": 378,
       "norm_label": "totransactionlistitem()"
     },
     {
       "label": "toTransaction()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L561",
+      "source_location": "L555",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_totransaction",
       "community": 503,
@@ -7129,37 +7489,37 @@
       "label": "textPointer()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L576",
+      "source_location": "L570",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_textpointer",
-      "community": 503,
+      "community": 378,
       "norm_label": "textpointer()"
     },
     {
       "label": "invalidDateQueryError()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L585",
+      "source_location": "L579",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_invaliddatequeryerror",
-      "community": 503,
+      "community": 428,
       "norm_label": "invaliddatequeryerror()"
     },
     {
       "label": "invalidQueryError()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L596",
+      "source_location": "L590",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_invalidqueryerror",
-      "community": 503,
+      "community": 428,
       "norm_label": "invalidqueryerror()"
     },
     {
       "label": "transactionNotFoundError()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L602",
+      "source_location": "L596",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_transactionnotfounderror",
       "community": 503,
@@ -7169,7 +7529,7 @@
       "label": "accountReferenceNotFoundError()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L608",
+      "source_location": "L602",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_accountreferencenotfounderror",
       "community": 503,
@@ -7179,7 +7539,7 @@
       "label": "categoryReferenceNotFoundError()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L614",
+      "source_location": "L608",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_categoryreferencenotfounderror",
       "community": 503,
@@ -7189,17 +7549,17 @@
       "label": "rateLimitedError()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L620",
+      "source_location": "L614",
       "_origin": "ast",
       "id": "backend_internal_http_transactions_ratelimitederror",
-      "community": 503,
+      "community": 556,
       "norm_label": "ratelimitederror()"
     },
     {
       "label": ".now()",
       "file_type": "code",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L634",
+      "source_location": "L628",
       "_origin": "ast",
       "id": "http_resourceserver_now",
       "community": 503,
@@ -7252,7 +7612,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "http_resourceserver_bulkcreatetransactions",
-      "community": 503,
+      "community": 556,
       "norm_label": ".bulkcreatetransactions()"
     },
     {
@@ -8452,7 +8812,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "openapi_currencycode",
-      "community": 503,
+      "community": 17,
       "norm_label": "currencycode"
     },
     {
@@ -8462,7 +8822,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "openapi_currencycode_valid",
-      "community": 503,
+      "community": 17,
       "norm_label": ".valid()"
     },
     {
@@ -8782,7 +9142,7 @@
       "source_location": "L262",
       "_origin": "ast",
       "id": "openapi_summarycategory",
-      "community": 17,
+      "community": 536,
       "norm_label": "summarycategory"
     },
     {
@@ -8872,7 +9232,7 @@
       "source_location": "L339",
       "_origin": "ast",
       "id": "openapi_transactionlistitem",
-      "community": 503,
+      "community": 17,
       "norm_label": "transactionlistitem"
     },
     {
@@ -8882,7 +9242,7 @@
       "source_location": "L361",
       "_origin": "ast",
       "id": "openapi_transactionlistresponse",
-      "community": 503,
+      "community": 17,
       "norm_label": "transactionlistresponse"
     },
     {
@@ -9592,7 +9952,7 @@
       "source_location": "L1499",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror",
-      "community": 538,
+      "community": 17,
       "norm_label": "unescapedcookieparamerror"
     },
     {
@@ -9602,7 +9962,7 @@
       "source_location": "L1504",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_error",
-      "community": 538,
+      "community": 17,
       "norm_label": ".error()"
     },
     {
@@ -9612,7 +9972,7 @@
       "source_location": "L1508",
       "_origin": "ast",
       "id": "openapi_unescapedcookieparamerror_unwrap",
-      "community": 538,
+      "community": 17,
       "norm_label": ".unwrap()"
     },
     {
@@ -9622,7 +9982,7 @@
       "source_location": "L1512",
       "_origin": "ast",
       "id": "openapi_unmarshalingparamerror",
-      "community": 17,
+      "community": 569,
       "norm_label": "unmarshalingparamerror"
     },
     {
@@ -9632,7 +9992,7 @@
       "source_location": "L1517",
       "_origin": "ast",
       "id": "openapi_unmarshalingparamerror_error",
-      "community": 17,
+      "community": 569,
       "norm_label": ".error()"
     },
     {
@@ -9642,7 +10002,7 @@
       "source_location": "L1521",
       "_origin": "ast",
       "id": "openapi_unmarshalingparamerror_unwrap",
-      "community": 17,
+      "community": 569,
       "norm_label": ".unwrap()"
     },
     {
@@ -9702,7 +10062,7 @@
       "source_location": "L1546",
       "_origin": "ast",
       "id": "openapi_invalidparamformaterror",
-      "community": 17,
+      "community": 567,
       "norm_label": "invalidparamformaterror"
     },
     {
@@ -9712,7 +10072,7 @@
       "source_location": "L1551",
       "_origin": "ast",
       "id": "openapi_invalidparamformaterror_error",
-      "community": 17,
+      "community": 567,
       "norm_label": ".error()"
     },
     {
@@ -9722,7 +10082,7 @@
       "source_location": "L1555",
       "_origin": "ast",
       "id": "openapi_invalidparamformaterror_unwrap",
-      "community": 17,
+      "community": 567,
       "norm_label": ".unwrap()"
     },
     {
@@ -9902,7 +10262,7 @@
       "source_location": "L1716",
       "_origin": "ast",
       "id": "openapi_emailnotverifiederrorjsonresponse",
-      "community": 569,
+      "community": 17,
       "norm_label": "emailnotverifiederrorjsonresponse"
     },
     {
@@ -9912,7 +10272,7 @@
       "source_location": "L1718",
       "_origin": "ast",
       "id": "openapi_invalidqueryerrorjsonresponse",
-      "community": 503,
+      "community": 428,
       "norm_label": "invalidqueryerrorjsonresponse"
     },
     {
@@ -10032,7 +10392,7 @@
       "source_location": "L1750",
       "_origin": "ast",
       "id": "openapi_listaccounts200jsonresponse",
-      "community": 576,
+      "community": 17,
       "norm_label": "listaccounts200jsonresponse"
     },
     {
@@ -10042,7 +10402,7 @@
       "source_location": "L1752",
       "_origin": "ast",
       "id": "openapi_listaccounts200jsonresponse_visitlistaccountsresponse",
-      "community": 576,
+      "community": 17,
       "norm_label": ".visitlistaccountsresponse()"
     },
     {
@@ -10252,7 +10612,7 @@
       "source_location": "L1880",
       "_origin": "ast",
       "id": "openapi_bulkdeleteaccounts200jsonresponse",
-      "community": 571,
+      "community": 17,
       "norm_label": "bulkdeleteaccounts200jsonresponse"
     },
     {
@@ -10262,7 +10622,7 @@
       "source_location": "L1882",
       "_origin": "ast",
       "id": "openapi_bulkdeleteaccounts200jsonresponse_visitbulkdeleteaccountsresponse",
-      "community": 571,
+      "community": 17,
       "norm_label": ".visitbulkdeleteaccountsresponse()"
     },
     {
@@ -10472,7 +10832,7 @@
       "source_location": "L2024",
       "_origin": "ast",
       "id": "openapi_getaccount200jsonresponse",
-      "community": 550,
+      "community": 17,
       "norm_label": "getaccount200jsonresponse"
     },
     {
@@ -10482,7 +10842,7 @@
       "source_location": "L2026",
       "_origin": "ast",
       "id": "openapi_getaccount200jsonresponse_visitgetaccountresponse",
-      "community": 550,
+      "community": 17,
       "norm_label": ".visitgetaccountresponse()"
     },
     {
@@ -10602,7 +10962,7 @@
       "source_location": "L2105",
       "_origin": "ast",
       "id": "openapi_updateaccount200jsonresponse",
-      "community": 578,
+      "community": 17,
       "norm_label": "updateaccount200jsonresponse"
     },
     {
@@ -10612,7 +10972,7 @@
       "source_location": "L2107",
       "_origin": "ast",
       "id": "openapi_updateaccount200jsonresponse_visitupdateaccountresponse",
-      "community": 578,
+      "community": 17,
       "norm_label": ".visitupdateaccountresponse()"
     },
     {
@@ -10822,7 +11182,7 @@
       "source_location": "L2253",
       "_origin": "ast",
       "id": "openapi_loginuser403jsonresponse",
-      "community": 569,
+      "community": 17,
       "norm_label": "loginuser403jsonresponse"
     },
     {
@@ -10832,7 +11192,7 @@
       "source_location": "L2257",
       "_origin": "ast",
       "id": "openapi_loginuser403jsonresponse_visitloginuserresponse",
-      "community": 569,
+      "community": 17,
       "norm_label": ".visitloginuserresponse()"
     },
     {
@@ -11562,7 +11922,7 @@
       "source_location": "L2686",
       "_origin": "ast",
       "id": "openapi_bulkdeletecategories200jsonresponse",
-      "community": 572,
+      "community": 17,
       "norm_label": "bulkdeletecategories200jsonresponse"
     },
     {
@@ -11572,7 +11932,7 @@
       "source_location": "L2688",
       "_origin": "ast",
       "id": "openapi_bulkdeletecategories200jsonresponse_visitbulkdeletecategoriesresponse",
-      "community": 572,
+      "community": 17,
       "norm_label": ".visitbulkdeletecategoriesresponse()"
     },
     {
@@ -11782,7 +12142,7 @@
       "source_location": "L2830",
       "_origin": "ast",
       "id": "openapi_getcategory200jsonresponse",
-      "community": 554,
+      "community": 17,
       "norm_label": "getcategory200jsonresponse"
     },
     {
@@ -11792,7 +12152,7 @@
       "source_location": "L2832",
       "_origin": "ast",
       "id": "openapi_getcategory200jsonresponse_visitgetcategoryresponse",
-      "community": 554,
+      "community": 17,
       "norm_label": ".visitgetcategoryresponse()"
     },
     {
@@ -12092,7 +12452,7 @@
       "source_location": "L3028",
       "_origin": "ast",
       "id": "openapi_getsummary200jsonresponse",
-      "community": 574,
+      "community": 17,
       "norm_label": "getsummary200jsonresponse"
     },
     {
@@ -12102,7 +12462,7 @@
       "source_location": "L3030",
       "_origin": "ast",
       "id": "openapi_getsummary200jsonresponse_visitgetsummaryresponse",
-      "community": 574,
+      "community": 17,
       "norm_label": ".visitgetsummaryresponse()"
     },
     {
@@ -12192,7 +12552,7 @@
       "source_location": "L3092",
       "_origin": "ast",
       "id": "openapi_listtransactions200jsonresponse",
-      "community": 577,
+      "community": 17,
       "norm_label": "listtransactions200jsonresponse"
     },
     {
@@ -12202,7 +12562,7 @@
       "source_location": "L3094",
       "_origin": "ast",
       "id": "openapi_listtransactions200jsonresponse_visitlisttransactionsresponse",
-      "community": 577,
+      "community": 17,
       "norm_label": ".visitlisttransactionsresponse()"
     },
     {
@@ -12472,7 +12832,7 @@
       "source_location": "L3269",
       "_origin": "ast",
       "id": "openapi_bulkcreatetransactions400jsonresponse",
-      "community": 17,
+      "community": 556,
       "norm_label": "bulkcreatetransactions400jsonresponse"
     },
     {
@@ -12482,7 +12842,7 @@
       "source_location": "L3273",
       "_origin": "ast",
       "id": "openapi_bulkcreatetransactions400jsonresponse_visitbulkcreatetransactionsresponse",
-      "community": 17,
+      "community": 556,
       "norm_label": ".visitbulkcreatetransactionsresponse()"
     },
     {
@@ -12762,7 +13122,7 @@
       "source_location": "L3473",
       "_origin": "ast",
       "id": "openapi_deletetransaction200jsonresponse",
-      "community": 573,
+      "community": 17,
       "norm_label": "deletetransaction200jsonresponse"
     },
     {
@@ -12772,7 +13132,7 @@
       "source_location": "L3475",
       "_origin": "ast",
       "id": "openapi_deletetransaction200jsonresponse_visitdeletetransactionresponse",
-      "community": 573,
+      "community": 17,
       "norm_label": ".visitdeletetransactionresponse()"
     },
     {
@@ -12902,7 +13262,7 @@
       "source_location": "L3572",
       "_origin": "ast",
       "id": "openapi_gettransaction200jsonresponse",
-      "community": 575,
+      "community": 17,
       "norm_label": "gettransaction200jsonresponse"
     },
     {
@@ -12912,7 +13272,7 @@
       "source_location": "L3574",
       "_origin": "ast",
       "id": "openapi_gettransaction200jsonresponse_visitgettransactionresponse",
-      "community": 575,
+      "community": 17,
       "norm_label": ".visitgettransactionresponse()"
     },
     {
@@ -13032,7 +13392,7 @@
       "source_location": "L3653",
       "_origin": "ast",
       "id": "openapi_updatetransaction200jsonresponse",
-      "community": 579,
+      "community": 17,
       "norm_label": "updatetransaction200jsonresponse"
     },
     {
@@ -13042,7 +13402,7 @@
       "source_location": "L3655",
       "_origin": "ast",
       "id": "openapi_updatetransaction200jsonresponse_visitupdatetransactionresponse",
-      "community": 579,
+      "community": 17,
       "norm_label": ".visitupdatetransactionresponse()"
     },
     {
@@ -13092,7 +13452,7 @@
       "source_location": "L3695",
       "_origin": "ast",
       "id": "openapi_updatetransaction404jsonresponse",
-      "community": 580,
+      "community": 17,
       "norm_label": "updatetransaction404jsonresponse"
     },
     {
@@ -13102,7 +13462,7 @@
       "source_location": "L3699",
       "_origin": "ast",
       "id": "openapi_updatetransaction404jsonresponse_visitupdatetransactionresponse",
-      "community": 580,
+      "community": 17,
       "norm_label": ".visitupdatetransactionresponse()"
     },
     {
@@ -13962,7 +14322,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_account_filter",
-      "community": 49,
+      "community": 515,
       "norm_label": "account-filter.tsx"
     },
     {
@@ -13972,7 +14332,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_account_filter_accountfilter",
-      "community": 49,
+      "community": 18,
       "norm_label": "accountfilter()"
     },
     {
@@ -13982,7 +14342,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_amount_input",
-      "community": 565,
+      "community": 9,
       "norm_label": "amount-input.tsx"
     },
     {
@@ -13992,7 +14352,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_amount_input_props",
-      "community": 565,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -14002,7 +14362,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "components_amount_input_amountinput",
-      "community": 565,
+      "community": 9,
       "norm_label": "amountinput()"
     },
     {
@@ -14012,7 +14372,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_area_variant",
-      "community": 541,
+      "community": 9,
       "norm_label": "area-variant.tsx"
     },
     {
@@ -14022,7 +14382,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_area_variant_props",
-      "community": 541,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -14032,7 +14392,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_area_variant_areavariant",
-      "community": 541,
+      "community": 9,
       "norm_label": "areavariant()"
     },
     {
@@ -14042,7 +14402,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_bar_variant",
-      "community": 541,
+      "community": 9,
       "norm_label": "bar-variant.tsx"
     },
     {
@@ -14052,7 +14412,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_bar_variant_props",
-      "community": 541,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -14062,7 +14422,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_bar_variant_barvariant",
-      "community": 541,
+      "community": 9,
       "norm_label": "barvariant()"
     },
     {
@@ -14142,7 +14502,7 @@
       "source_location": "L36",
       "_origin": "ast",
       "id": "components_chart_chart",
-      "community": 9,
+      "community": 35,
       "norm_label": "chart()"
     },
     {
@@ -14152,7 +14512,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "components_chart_chartloading",
-      "community": 9,
+      "community": 35,
       "norm_label": "chartloading()"
     },
     {
@@ -14172,7 +14532,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_custom_tooltip",
-      "community": 541,
+      "community": 9,
       "norm_label": "custom-tooltip.tsx"
     },
     {
@@ -14182,7 +14542,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "components_custom_tooltip_tooltippayloaditem",
-      "community": 541,
+      "community": 9,
       "norm_label": "tooltippayloaditem"
     },
     {
@@ -14192,7 +14552,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_custom_tooltip_customtooltipprops",
-      "community": 541,
+      "community": 9,
       "norm_label": "customtooltipprops"
     },
     {
@@ -14202,7 +14562,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "components_custom_tooltip_customtooltip",
-      "community": 541,
+      "community": 9,
       "norm_label": "customtooltip()"
     },
     {
@@ -14282,7 +14642,7 @@
       "source_location": "L100",
       "_origin": "ast",
       "id": "components_data_card_datacardloading",
-      "community": 9,
+      "community": 35,
       "norm_label": "datacardloading()"
     },
     {
@@ -14292,7 +14652,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_charts",
-      "community": 9,
+      "community": 35,
       "norm_label": "data-charts.tsx"
     },
     {
@@ -14302,7 +14662,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_data_charts_datacharts",
-      "community": 9,
+      "community": 35,
       "norm_label": "datacharts()"
     },
     {
@@ -14312,7 +14672,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_data_grid",
-      "community": 9,
+      "community": 35,
       "norm_label": "data-grid.tsx"
     },
     {
@@ -14322,7 +14682,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_data_grid_datagrid",
-      "community": 9,
+      "community": 35,
       "norm_label": "datagrid()"
     },
     {
@@ -14362,7 +14722,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_date_filter",
-      "community": 14,
+      "community": 348,
       "norm_label": "date-filter.tsx"
     },
     {
@@ -14372,7 +14732,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "components_date_filter_presetkey",
-      "community": 14,
+      "community": 348,
       "norm_label": "presetkey"
     },
     {
@@ -14382,7 +14742,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "components_date_filter_preset",
-      "community": 14,
+      "community": 348,
       "norm_label": "preset"
     },
     {
@@ -14392,7 +14752,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "components_date_filter_presets",
-      "community": 14,
+      "community": 348,
       "norm_label": "presets"
     },
     {
@@ -14402,7 +14762,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "components_date_filter_datefilter",
-      "community": 14,
+      "community": 18,
       "norm_label": "datefilter()"
     },
     {
@@ -14412,7 +14772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_date_picker",
-      "community": 14,
+      "community": 348,
       "norm_label": "date-picker.tsx"
     },
     {
@@ -14422,7 +14782,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "components_date_picker_props",
-      "community": 14,
+      "community": 348,
       "norm_label": "props"
     },
     {
@@ -14432,7 +14792,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_date_picker_datepicker",
-      "community": 14,
+      "community": 348,
       "norm_label": "datepicker()"
     },
     {
@@ -14442,7 +14802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_filters",
-      "community": 49,
+      "community": 18,
       "norm_label": "filters.tsx"
     },
     {
@@ -14452,7 +14812,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "components_filters_filters",
-      "community": 49,
+      "community": 18,
       "norm_label": "filters()"
     },
     {
@@ -14502,7 +14862,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_line_variant",
-      "community": 541,
+      "community": 9,
       "norm_label": "line-variant.tsx"
     },
     {
@@ -14512,7 +14872,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_line_variant_props",
-      "community": 541,
+      "community": 9,
       "norm_label": "props"
     },
     {
@@ -14522,7 +14882,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_line_variant_linevariant",
-      "community": 541,
+      "community": 9,
       "norm_label": "linevariant()"
     },
     {
@@ -14532,7 +14892,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_nav_button",
-      "community": 14,
+      "community": 518,
       "norm_label": "nav-button.tsx"
     },
     {
@@ -14542,7 +14902,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_nav_button_props",
-      "community": 14,
+      "community": 518,
       "norm_label": "props"
     },
     {
@@ -14552,7 +14912,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "components_nav_button_navbutton",
-      "community": 14,
+      "community": 518,
       "norm_label": "navbutton()"
     },
     {
@@ -14562,7 +14922,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_navigation",
-      "community": 14,
+      "community": 518,
       "norm_label": "navigation.tsx"
     },
     {
@@ -14572,7 +14932,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_navigation_routes",
-      "community": 14,
+      "community": 518,
       "norm_label": "routes"
     },
     {
@@ -14642,7 +15002,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_radar_variant",
-      "community": 9,
+      "community": 515,
       "norm_label": "radar-variant.tsx"
     },
     {
@@ -14652,7 +15012,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_radar_variant_props",
-      "community": 9,
+      "community": 515,
       "norm_label": "props"
     },
     {
@@ -14662,7 +15022,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "components_radar_variant_radarvariant",
-      "community": 9,
+      "community": 515,
       "norm_label": "radarvariant()"
     },
     {
@@ -14712,7 +15072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_select",
-      "community": 35,
+      "community": 23,
       "norm_label": "select.tsx"
     },
     {
@@ -14722,7 +15082,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "components_select_props",
-      "community": 35,
+      "community": 23,
       "norm_label": "props"
     },
     {
@@ -14732,7 +15092,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "components_select_select",
-      "community": 35,
+      "community": 23,
       "norm_label": "select()"
     },
     {
@@ -14742,7 +15102,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_spending_pie",
-      "community": 9,
+      "community": 515,
       "norm_label": "spending-pie.tsx"
     },
     {
@@ -14752,7 +15112,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_spending_pie_props",
-      "community": 9,
+      "community": 515,
       "norm_label": "props"
     },
     {
@@ -14762,7 +15122,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieenum",
-      "community": 9,
+      "community": 515,
       "norm_label": "spendingpieenum"
     },
     {
@@ -14772,7 +15132,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpie",
-      "community": 9,
+      "community": 35,
       "norm_label": "spendingpie()"
     },
     {
@@ -14782,7 +15142,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "components_spending_pie_spendingpieloading",
-      "community": 9,
+      "community": 35,
       "norm_label": "spendingpieloading()"
     },
     {
@@ -14822,7 +15182,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_button",
-      "community": 14,
+      "community": 260,
       "norm_label": "button.tsx"
     },
     {
@@ -14832,7 +15192,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "components_ui_button_buttonvariants",
-      "community": 14,
+      "community": 348,
       "norm_label": "buttonvariants"
     },
     {
@@ -14842,7 +15202,7 @@
       "source_location": "L41",
       "_origin": "ast",
       "id": "components_ui_button_button",
-      "community": 14,
+      "community": 260,
       "norm_label": "button()"
     },
     {
@@ -14852,7 +15212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_calendar",
-      "community": 14,
+      "community": 348,
       "norm_label": "calendar.tsx"
     },
     {
@@ -14862,7 +15222,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "components_ui_calendar_calendar",
-      "community": 14,
+      "community": 348,
       "norm_label": "calendar()"
     },
     {
@@ -14872,7 +15232,7 @@
       "source_location": "L182",
       "_origin": "ast",
       "id": "components_ui_calendar_calendardaybutton",
-      "community": 14,
+      "community": 348,
       "norm_label": "calendardaybutton()"
     },
     {
@@ -14982,7 +15342,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_dialog",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialog.tsx"
     },
     {
@@ -14992,7 +15352,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "components_ui_dialog_dialog",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialog()"
     },
     {
@@ -15002,7 +15362,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtrigger",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialogtrigger()"
     },
     {
@@ -15012,7 +15372,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogportal",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialogportal()"
     },
     {
@@ -15022,7 +15382,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogclose",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialogclose()"
     },
     {
@@ -15032,7 +15392,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogoverlay",
-      "community": 35,
+      "community": 348,
       "norm_label": "dialogoverlay()"
     },
     {
@@ -15042,7 +15402,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogcontent",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialogcontent()"
     },
     {
@@ -15052,7 +15412,7 @@
       "source_location": "L84",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogheader",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialogheader()"
     },
     {
@@ -15062,7 +15422,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogfooter",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialogfooter()"
     },
     {
@@ -15072,7 +15432,7 @@
       "source_location": "L121",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogtitle",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialogtitle()"
     },
     {
@@ -15082,7 +15442,7 @@
       "source_location": "L134",
       "_origin": "ast",
       "id": "components_ui_dialog_dialogdescription",
-      "community": 35,
+      "community": 260,
       "norm_label": "dialogdescription()"
     },
     {
@@ -15412,7 +15772,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_popover",
-      "community": 14,
+      "community": 348,
       "norm_label": "popover.tsx"
     },
     {
@@ -15422,7 +15782,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_ui_popover_popover",
-      "community": 14,
+      "community": 348,
       "norm_label": "popover()"
     },
     {
@@ -15432,7 +15792,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "components_ui_popover_popovertrigger",
-      "community": 14,
+      "community": 348,
       "norm_label": "popovertrigger()"
     },
     {
@@ -15442,7 +15802,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "components_ui_popover_popovercontent",
-      "community": 14,
+      "community": 348,
       "norm_label": "popovercontent()"
     },
     {
@@ -15452,7 +15812,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "components_ui_popover_popoveranchor",
-      "community": 14,
+      "community": 348,
       "norm_label": "popoveranchor()"
     },
     {
@@ -15462,7 +15822,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "components_ui_popover_popoverheader",
-      "community": 14,
+      "community": 348,
       "norm_label": "popoverheader()"
     },
     {
@@ -15472,7 +15832,7 @@
       "source_location": "L58",
       "_origin": "ast",
       "id": "components_ui_popover_popovertitle",
-      "community": 14,
+      "community": 348,
       "norm_label": "popovertitle()"
     },
     {
@@ -15482,7 +15842,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "components_ui_popover_popoverdescription",
-      "community": 14,
+      "community": 348,
       "norm_label": "popoverdescription()"
     },
     {
@@ -15492,7 +15852,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_select",
-      "community": 49,
+      "community": 515,
       "norm_label": "select.tsx"
     },
     {
@@ -15502,7 +15862,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "components_ui_select_select",
-      "community": 49,
+      "community": 515,
       "norm_label": "select()"
     },
     {
@@ -15512,7 +15872,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "components_ui_select_selectgroup",
-      "community": 49,
+      "community": 515,
       "norm_label": "selectgroup()"
     },
     {
@@ -15522,7 +15882,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_ui_select_selectvalue",
-      "community": 49,
+      "community": 515,
       "norm_label": "selectvalue()"
     },
     {
@@ -15532,7 +15892,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "components_ui_select_selecttrigger",
-      "community": 49,
+      "community": 515,
       "norm_label": "selecttrigger()"
     },
     {
@@ -15542,7 +15902,7 @@
       "source_location": "L53",
       "_origin": "ast",
       "id": "components_ui_select_selectcontent",
-      "community": 49,
+      "community": 515,
       "norm_label": "selectcontent()"
     },
     {
@@ -15552,7 +15912,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "components_ui_select_selectlabel",
-      "community": 49,
+      "community": 348,
       "norm_label": "selectlabel()"
     },
     {
@@ -15562,7 +15922,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "components_ui_select_selectitem",
-      "community": 49,
+      "community": 515,
       "norm_label": "selectitem()"
     },
     {
@@ -15572,7 +15932,7 @@
       "source_location": "L130",
       "_origin": "ast",
       "id": "components_ui_select_selectseparator",
-      "community": 49,
+      "community": 348,
       "norm_label": "selectseparator()"
     },
     {
@@ -15582,7 +15942,7 @@
       "source_location": "L143",
       "_origin": "ast",
       "id": "components_ui_select_selectscrollupbutton",
-      "community": 49,
+      "community": 348,
       "norm_label": "selectscrollupbutton()"
     },
     {
@@ -15592,7 +15952,7 @@
       "source_location": "L161",
       "_origin": "ast",
       "id": "components_ui_select_selectscrolldownbutton",
-      "community": 49,
+      "community": 348,
       "norm_label": "selectscrolldownbutton()"
     },
     {
@@ -15642,7 +16002,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_ui_sheet_sheettrigger",
-      "community": 14,
+      "community": 518,
       "norm_label": "sheettrigger()"
     },
     {
@@ -15672,7 +16032,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetoverlay",
-      "community": 348,
+      "community": 518,
       "norm_label": "sheetoverlay()"
     },
     {
@@ -15702,7 +16062,7 @@
       "source_location": "L94",
       "_origin": "ast",
       "id": "components_ui_sheet_sheetfooter",
-      "community": 348,
+      "community": 518,
       "norm_label": "sheetfooter()"
     },
     {
@@ -15752,7 +16112,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_sonner",
-      "community": 31,
+      "community": 518,
       "norm_label": "sonner.tsx"
     },
     {
@@ -15762,7 +16122,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "components_ui_sonner_toaster",
-      "community": 31,
+      "community": 518,
       "norm_label": "toaster()"
     },
     {
@@ -15882,7 +16242,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_tooltip",
-      "community": 565,
+      "community": 9,
       "norm_label": "tooltip.tsx"
     },
     {
@@ -15892,7 +16252,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltipprovider",
-      "community": 565,
+      "community": 9,
       "norm_label": "tooltipprovider()"
     },
     {
@@ -15902,7 +16262,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltip",
-      "community": 565,
+      "community": 9,
       "norm_label": "tooltip()"
     },
     {
@@ -15912,7 +16272,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltiptrigger",
-      "community": 565,
+      "community": 9,
       "norm_label": "tooltiptrigger()"
     },
     {
@@ -15922,7 +16282,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "components_ui_tooltip_tooltipcontent",
-      "community": 565,
+      "community": 9,
       "norm_label": "tooltipcontent()"
     },
     {
@@ -15932,7 +16292,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "components_ui_visually_hidden",
-      "community": 14,
+      "community": 518,
       "norm_label": "visually-hidden.tsx"
     },
     {
@@ -15942,7 +16302,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "components_ui_visually_hidden_visuallyhidden",
-      "community": 14,
+      "community": 518,
       "norm_label": "visuallyhidden()"
     },
     {
@@ -16202,7 +16562,7 @@
       "source_location": "L114",
       "_origin": "ast",
       "id": "db_schema_insertcategoryschema",
-      "community": 518,
+      "community": 19,
       "norm_label": "insertcategoryschema"
     },
     {
@@ -16252,7 +16612,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts",
-      "community": 567,
+      "community": 432,
       "norm_label": "use-bulk-delete-accounts.ts"
     },
     {
@@ -16262,7 +16622,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_responsetype",
-      "community": 567,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -16272,7 +16632,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_requesttype",
-      "community": 567,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -16282,7 +16642,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_accounts_api_use_bulk_delete_accounts_usebulkdeleteaccounts",
-      "community": 567,
+      "community": 432,
       "norm_label": "usebulkdeleteaccounts()"
     },
     {
@@ -16292,7 +16652,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account",
-      "community": 45,
+      "community": 432,
       "norm_label": "use-create-account.ts"
     },
     {
@@ -16302,7 +16662,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_responsetype",
-      "community": 45,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -16312,7 +16672,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_requesttype",
-      "community": 45,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -16322,7 +16682,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_accounts_api_use_create_account_usecreateaccount",
-      "community": 428,
+      "community": 432,
       "norm_label": "usecreateaccount()"
     },
     {
@@ -16352,7 +16712,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "features_accounts_api_use_delete_account_usedeleteaccount",
-      "community": 432,
+      "community": 260,
       "norm_label": "usedeleteaccount()"
     },
     {
@@ -16422,7 +16782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_accounts",
-      "community": 428,
+      "community": 432,
       "norm_label": "use-get-accounts.ts"
     },
     {
@@ -16432,7 +16792,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_accounts_api_use_get_accounts_usegetaccounts",
-      "community": 428,
+      "community": 432,
       "norm_label": "usegetaccounts()"
     },
     {
@@ -16482,7 +16842,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "features_accounts_components_account_form_accountform",
-      "community": 432,
+      "community": 518,
       "norm_label": "accountform()"
     },
     {
@@ -16492,7 +16852,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_components_edit_account_sheet",
-      "community": 432,
+      "community": 518,
       "norm_label": "edit-account-sheet.tsx"
     },
     {
@@ -16502,7 +16862,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "features_accounts_components_edit_account_sheet_formvalues",
-      "community": 432,
+      "community": 518,
       "norm_label": "formvalues"
     },
     {
@@ -16512,7 +16872,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "features_accounts_components_edit_account_sheet_editaccountsheet",
-      "community": 432,
+      "community": 260,
       "norm_label": "editaccountsheet()"
     },
     {
@@ -16612,7 +16972,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account",
-      "community": 35,
+      "community": 260,
       "norm_label": "use-select-account.tsx"
     },
     {
@@ -16622,7 +16982,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "features_accounts_hooks_use_select_account_useselectaccount",
-      "community": 428,
+      "community": 432,
       "norm_label": "useselectaccount()"
     },
     {
@@ -16662,7 +17022,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_categories_api_use_bulk_delete_categories_usebulkdeletecategories",
-      "community": 428,
+      "community": 432,
       "norm_label": "usebulkdeletecategories()"
     },
     {
@@ -16672,7 +17032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category",
-      "community": 518,
+      "community": 432,
       "norm_label": "use-create-category.ts"
     },
     {
@@ -16682,7 +17042,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_responsetype",
-      "community": 518,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -16692,7 +17052,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_requesttype",
-      "community": 518,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -16702,7 +17062,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_categories_api_use_create_category_usecreatecategory",
-      "community": 518,
+      "community": 432,
       "norm_label": "usecreatecategory()"
     },
     {
@@ -16712,7 +17072,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category",
-      "community": 549,
+      "community": 260,
       "norm_label": "use-delete-category.ts"
     },
     {
@@ -16722,7 +17082,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category_responsetype",
-      "community": 549,
+      "community": 260,
       "norm_label": "responsetype"
     },
     {
@@ -16732,7 +17092,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "features_categories_api_use_delete_category_usedeletecategory",
-      "community": 549,
+      "community": 260,
       "norm_label": "usedeletecategory()"
     },
     {
@@ -16742,7 +17102,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category",
-      "community": 549,
+      "community": 432,
       "norm_label": "use-edit-category.ts"
     },
     {
@@ -16752,7 +17112,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category_responsetype",
-      "community": 549,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -16762,7 +17122,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category_requesttype",
-      "community": 549,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -16772,7 +17132,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_categories_api_use_edit_category_useeditcategory",
-      "community": 549,
+      "community": 260,
       "norm_label": "useeditcategory()"
     },
     {
@@ -16782,7 +17142,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_api_use_get_categories",
-      "community": 428,
+      "community": 432,
       "norm_label": "use-get-categories.ts"
     },
     {
@@ -16792,7 +17152,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "features_categories_api_use_get_categories_usegetcategories",
-      "community": 428,
+      "community": 432,
       "norm_label": "usegetcategories()"
     },
     {
@@ -16812,7 +17172,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "features_categories_api_use_get_category_usegetcategory",
-      "community": 549,
+      "community": 260,
       "norm_label": "usegetcategory()"
     },
     {
@@ -16872,7 +17232,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet",
-      "community": 518,
+      "community": 260,
       "norm_label": "edit-category-sheet.tsx"
     },
     {
@@ -16882,7 +17242,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet_formvalues",
-      "community": 518,
+      "community": 260,
       "norm_label": "formvalues"
     },
     {
@@ -16892,7 +17252,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "features_categories_components_edit_category_sheet_editcategorysheet",
-      "community": 549,
+      "community": 260,
       "norm_label": "editcategorysheet()"
     },
     {
@@ -16992,7 +17352,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_summary_use_get_summary",
-      "community": 432,
+      "community": 35,
       "norm_label": "use-get-summary.ts"
     },
     {
@@ -17002,7 +17362,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_summary_use_get_summary_usegetsummary",
-      "community": 432,
+      "community": 35,
       "norm_label": "usegetsummary()"
     },
     {
@@ -17092,7 +17452,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction",
-      "community": 45,
+      "community": 432,
       "norm_label": "use-create-transaction.ts"
     },
     {
@@ -17102,7 +17462,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_responsetype",
-      "community": 45,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -17112,7 +17472,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_requesttype",
-      "community": 45,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -17122,7 +17482,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "features_transactions_api_use_create_transaction_usecreatetransaction",
-      "community": 428,
+      "community": 432,
       "norm_label": "usecreatetransaction()"
     },
     {
@@ -17162,7 +17522,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_edit_transaction",
-      "community": 45,
+      "community": 432,
       "norm_label": "use-edit-transaction.ts"
     },
     {
@@ -17172,7 +17532,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_edit_transaction_responsetype",
-      "community": 45,
+      "community": 432,
       "norm_label": "responsetype"
     },
     {
@@ -17182,7 +17542,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "features_transactions_api_use_edit_transaction_requesttype",
-      "community": 45,
+      "community": 432,
       "norm_label": "requesttype"
     },
     {
@@ -17192,7 +17552,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "features_transactions_api_use_edit_transaction_useedittransaction",
-      "community": 45,
+      "community": 432,
       "norm_label": "useedittransaction()"
     },
     {
@@ -17222,7 +17582,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transactions",
-      "community": 432,
+      "community": 35,
       "norm_label": "use-get-transactions.ts"
     },
     {
@@ -17232,7 +17592,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_api_use_get_transactions_usegettransactions",
-      "community": 432,
+      "community": 35,
       "norm_label": "usegettransactions()"
     },
     {
@@ -17242,7 +17602,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_components_edit_transaction_sheet",
-      "community": 518,
+      "community": 432,
       "norm_label": "edit-transaction-sheet.tsx"
     },
     {
@@ -17252,7 +17612,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "features_transactions_components_edit_transaction_sheet_formvalues",
-      "community": 518,
+      "community": 432,
       "norm_label": "formvalues"
     },
     {
@@ -17262,7 +17622,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "features_transactions_components_edit_transaction_sheet_edittransactionsheet",
-      "community": 428,
+      "community": 432,
       "norm_label": "edittransactionsheet()"
     },
     {
@@ -17272,7 +17632,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet",
-      "community": 428,
+      "community": 432,
       "norm_label": "new-transaction-sheet.tsx"
     },
     {
@@ -17282,7 +17642,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet_formvalues",
-      "community": 428,
+      "community": 432,
       "norm_label": "formvalues"
     },
     {
@@ -17292,7 +17652,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "features_transactions_components_new_transaction_sheet_newtransactionsheet",
-      "community": 428,
+      "community": 432,
       "norm_label": "newtransactionsheet()"
     },
     {
@@ -17352,7 +17712,7 @@
       "source_location": "L67",
       "_origin": "ast",
       "id": "features_transactions_components_transaction_form_transactionform",
-      "community": 428,
+      "community": 432,
       "norm_label": "transactionform()"
     },
     {
@@ -17362,7 +17722,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_new_transaction",
-      "community": 428,
+      "community": 432,
       "norm_label": "use-new-transaction.ts"
     },
     {
@@ -17372,7 +17732,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_new_transaction_newtransactionstate",
-      "community": 428,
+      "community": 432,
       "norm_label": "newtransactionstate"
     },
     {
@@ -17382,7 +17742,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_new_transaction_usenewtransaction",
-      "community": 428,
+      "community": 432,
       "norm_label": "usenewtransaction"
     },
     {
@@ -17392,7 +17752,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_open_transaction",
-      "community": 260,
+      "community": 432,
       "norm_label": "use-open-transaction.ts"
     },
     {
@@ -17402,7 +17762,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_open_transaction_opentransactionstate",
-      "community": 260,
+      "community": 432,
       "norm_label": "opentransactionstate"
     },
     {
@@ -17412,7 +17772,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "features_transactions_hooks_use_open_transaction_useopentransaction",
-      "community": 260,
+      "community": 432,
       "norm_label": "useopentransaction"
     },
     {
@@ -17422,7 +17782,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "hooks_use_confirm",
-      "community": 35,
+      "community": 260,
       "norm_label": "use-confirm.tsx"
     },
     {
@@ -17482,7 +17842,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_api_error",
-      "community": 45,
+      "community": 432,
       "norm_label": "api-error.ts"
     },
     {
@@ -17492,7 +17852,7 @@
       "source_location": "L22",
       "_origin": "ast",
       "id": "lib_api_error_apierrordetails",
-      "community": 45,
+      "community": 432,
       "norm_label": "apierrordetails"
     },
     {
@@ -17502,7 +17862,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "lib_api_error_apierror",
-      "community": 45,
+      "community": 432,
       "norm_label": "apierror"
     },
     {
@@ -17512,7 +17872,7 @@
       "source_location": "L38",
       "_origin": "ast",
       "id": "lib_api_error_apierror_constructor",
-      "community": 45,
+      "community": 432,
       "norm_label": ".constructor()"
     },
     {
@@ -17522,7 +17882,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "lib_api_error_apierror_isstatus",
-      "community": 45,
+      "community": 432,
       "norm_label": ".isstatus()"
     },
     {
@@ -17532,7 +17892,7 @@
       "source_location": "L59",
       "_origin": "ast",
       "id": "lib_api_error_apierror_isclienterror",
-      "community": 45,
+      "community": 432,
       "norm_label": ".isclienterror()"
     },
     {
@@ -17542,7 +17902,7 @@
       "source_location": "L66",
       "_origin": "ast",
       "id": "lib_api_error_apierror_isservererror",
-      "community": 45,
+      "community": 432,
       "norm_label": ".isservererror()"
     },
     {
@@ -17552,7 +17912,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "lib_api_error_apierror_isunauthorized",
-      "community": 45,
+      "community": 432,
       "norm_label": ".isunauthorized()"
     },
     {
@@ -17562,7 +17922,7 @@
       "source_location": "L80",
       "_origin": "ast",
       "id": "lib_api_error_apierror_isforbidden",
-      "community": 45,
+      "community": 432,
       "norm_label": ".isforbidden()"
     },
     {
@@ -17572,7 +17932,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "lib_api_error_apierror_isnotfound",
-      "community": 45,
+      "community": 432,
       "norm_label": ".isnotfound()"
     },
     {
@@ -17592,7 +17952,7 @@
       "source_location": "L149",
       "_origin": "ast",
       "id": "lib_api_error_logerror",
-      "community": 45,
+      "community": 432,
       "norm_label": "logerror()"
     },
     {
@@ -17602,7 +17962,7 @@
       "source_location": "L205",
       "_origin": "ast",
       "id": "lib_api_error_isapierror",
-      "community": 45,
+      "community": 432,
       "norm_label": "isapierror()"
     },
     {
@@ -17672,7 +18032,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items_test",
-      "community": 515,
+      "community": 432,
       "norm_label": "chunk-items.test.ts"
     },
     {
@@ -17682,7 +18042,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items",
-      "community": 515,
+      "community": 432,
       "norm_label": "chunk-items.ts"
     },
     {
@@ -17692,7 +18052,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_chunk_items_chunkitems",
-      "community": 515,
+      "community": 432,
       "norm_label": "chunkitems()"
     },
     {
@@ -17722,7 +18082,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_query_params",
-      "community": 432,
+      "community": 35,
       "norm_label": "query-params.ts"
     },
     {
@@ -17732,7 +18092,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "lib_query_params_omitemptyqueryparams",
-      "community": 432,
+      "community": 35,
       "norm_label": "omitemptyqueryparams()"
     },
     {
@@ -17742,7 +18102,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options_test",
-      "community": 35,
+      "community": 23,
       "norm_label": "select-options.test.ts"
     },
     {
@@ -17752,7 +18112,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options",
-      "community": 35,
+      "community": 23,
       "norm_label": "select-options.ts"
     },
     {
@@ -17762,7 +18122,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_select_options_selectoption",
-      "community": 35,
+      "community": 23,
       "norm_label": "selectoption"
     },
     {
@@ -17772,7 +18132,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "lib_select_options_mergecreatedselectoption",
-      "community": 35,
+      "community": 23,
       "norm_label": "mergecreatedselectoption()"
     },
     {
@@ -17782,7 +18142,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_import_test",
-      "community": 517,
+      "community": 515,
       "norm_label": "transaction-import.test.ts"
     },
     {
@@ -17792,7 +18152,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_import",
-      "community": 517,
+      "community": 515,
       "norm_label": "transaction-import.ts"
     },
     {
@@ -17802,7 +18162,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "lib_transaction_import_importedtransactionrow",
-      "community": 517,
+      "community": 515,
       "norm_label": "importedtransactionrow"
     },
     {
@@ -17812,7 +18172,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "lib_transaction_import_rawimportedtransactionrow",
-      "community": 517,
+      "community": 515,
       "norm_label": "rawimportedtransactionrow"
     },
     {
@@ -17822,7 +18182,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "lib_transaction_import_importedtransactionrowerror",
-      "community": 517,
+      "community": 515,
       "norm_label": "importedtransactionrowerror"
     },
     {
@@ -17832,7 +18192,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "lib_transaction_import_parseimportedtransactionrows",
-      "community": 517,
+      "community": 515,
       "norm_label": "parseimportedtransactionrows()"
     },
     {
@@ -17842,7 +18202,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_limits",
-      "community": 19,
+      "community": 31,
       "norm_label": "transaction-limits.ts"
     },
     {
@@ -17852,7 +18212,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_test",
-      "community": 19,
+      "community": 31,
       "norm_label": "transaction-route-utils.test.ts"
     },
     {
@@ -17862,7 +18222,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "lib_transaction_route_utils",
-      "community": 19,
+      "community": 31,
       "norm_label": "transaction-route-utils.ts"
     },
     {
@@ -17872,7 +18232,7 @@
       "source_location": "L20",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_mutationrequestsbykey",
-      "community": 19,
+      "community": 31,
       "norm_label": "mutationrequestsbykey"
     },
     {
@@ -17882,7 +18242,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_parsestrictdateoptions",
-      "community": 19,
+      "community": 31,
       "norm_label": "parsestrictdateoptions"
     },
     {
@@ -17892,7 +18252,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_daterangequeryoptions",
-      "community": 19,
+      "community": 31,
       "norm_label": "daterangequeryoptions"
     },
     {
@@ -17902,7 +18262,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_daterangequeryresult",
-      "community": 19,
+      "community": 31,
       "norm_label": "daterangequeryresult"
     },
     {
@@ -17912,7 +18272,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_parsestrictdate",
-      "community": 19,
+      "community": 31,
       "norm_label": "parsestrictdate()"
     },
     {
@@ -17922,7 +18282,7 @@
       "source_location": "L71",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_parsedaterangequery",
-      "community": 19,
+      "community": 31,
       "norm_label": "parsedaterangequery()"
     },
     {
@@ -17932,7 +18292,7 @@
       "source_location": "L124",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_cleanupmutationratelimit",
-      "community": 19,
+      "community": 31,
       "norm_label": "cleanupmutationratelimit()"
     },
     {
@@ -17942,7 +18302,7 @@
       "source_location": "L149",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_checktransactionmutationratelimit",
-      "community": 19,
+      "community": 31,
       "norm_label": "checktransactionmutationratelimit()"
     },
     {
@@ -17952,7 +18312,7 @@
       "source_location": "L179",
       "_origin": "ast",
       "id": "lib_transaction_route_utils_iscontentlengthtoolarge",
-      "community": 19,
+      "community": 31,
       "norm_label": "iscontentlengthtoolarge()"
     },
     {
@@ -17982,7 +18342,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "lib_utils_convertamountfrommiliunits",
-      "community": 432,
+      "community": 35,
       "norm_label": "convertamountfrommiliunits()"
     },
     {
@@ -17992,7 +18352,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "lib_utils_convertamounttomiliunits",
-      "community": 517,
+      "community": 515,
       "norm_label": "convertamounttomiliunits()"
     },
     {
@@ -18002,7 +18362,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "lib_utils_issafemiliunitamount",
-      "community": 517,
+      "community": 515,
       "norm_label": "issafemiliunitamount()"
     },
     {
@@ -18052,7 +18412,7 @@
       "source_location": "L100",
       "_origin": "ast",
       "id": "lib_utils_formatdaterange",
-      "community": 9,
+      "community": 35,
       "norm_label": "formatdaterange()"
     },
     {
@@ -18702,7 +19062,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "package_dependencies_sonner",
-      "community": 31,
+      "community": 518,
       "norm_label": "sonner"
     },
     {
@@ -18962,7 +19322,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "providers_query_provider",
-      "community": 31,
+      "community": 518,
       "norm_label": "query-provider.tsx"
     },
     {
@@ -18972,7 +19332,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "providers_query_provider_makequeryclient",
-      "community": 31,
+      "community": 518,
       "norm_label": "makequeryclient()"
     },
     {
@@ -18982,7 +19342,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "providers_query_provider_getqueryclient",
-      "community": 31,
+      "community": 518,
       "norm_label": "getqueryclient()"
     },
     {
@@ -18992,7 +19352,7 @@
       "source_location": "L29",
       "_origin": "ast",
       "id": "providers_query_provider_props",
-      "community": 31,
+      "community": 518,
       "norm_label": "props"
     },
     {
@@ -19002,7 +19362,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "providers_query_provider_queryprovider",
-      "community": 31,
+      "community": 518,
       "norm_label": "queryprovider()"
     },
     {
@@ -19022,7 +19382,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "providers_sheet_provider_sheetprovider",
-      "community": 31,
+      "community": 518,
       "norm_label": "sheetprovider()"
     },
     {
@@ -19172,7 +19532,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "scripts_seed",
-      "community": 532,
+      "community": 45,
       "norm_label": "seed.ts"
     },
     {
@@ -19182,7 +19542,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "scripts_seed_databaseurl",
-      "community": 532,
+      "community": 45,
       "norm_label": "databaseurl"
     },
     {
@@ -19192,7 +19552,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "scripts_seed_pool",
-      "community": 532,
+      "community": 45,
       "norm_label": "pool"
     },
     {
@@ -19202,7 +19562,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "scripts_seed_db",
-      "community": 532,
+      "community": 45,
       "norm_label": "db"
     },
     {
@@ -19212,7 +19572,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "scripts_seed_assertseedallowed",
-      "community": 532,
+      "community": 45,
       "norm_label": "assertseedallowed()"
     },
     {
@@ -19222,7 +19582,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "scripts_seed_seed_categories",
-      "community": 532,
+      "community": 45,
       "norm_label": "seed_categories"
     },
     {
@@ -19232,7 +19592,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "scripts_seed_seed_accounts",
-      "community": 532,
+      "community": 45,
       "norm_label": "seed_accounts"
     },
     {
@@ -19242,7 +19602,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "scripts_seed_defaultto",
-      "community": 532,
+      "community": 45,
       "norm_label": "defaultto"
     },
     {
@@ -19252,7 +19612,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "scripts_seed_defaultfrom",
-      "community": 532,
+      "community": 45,
       "norm_label": "defaultfrom"
     },
     {
@@ -19262,7 +19622,7 @@
       "source_location": "L63",
       "_origin": "ast",
       "id": "scripts_seed_seed_transactions",
-      "community": 532,
+      "community": 45,
       "norm_label": "seed_transactions"
     },
     {
@@ -19272,7 +19632,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "scripts_seed_generaterandomamount",
-      "community": 532,
+      "community": 45,
       "norm_label": "generaterandomamount()"
     },
     {
@@ -19282,7 +19642,7 @@
       "source_location": "L80",
       "_origin": "ast",
       "id": "scripts_seed_generatetransactionsforday",
-      "community": 532,
+      "community": 45,
       "norm_label": "generatetransactionsforday()"
     },
     {
@@ -19292,7 +19652,7 @@
       "source_location": "L104",
       "_origin": "ast",
       "id": "scripts_seed_generatetransactions",
-      "community": 532,
+      "community": 45,
       "norm_label": "generatetransactions()"
     },
     {
@@ -19302,7 +19662,7 @@
       "source_location": "L110",
       "_origin": "ast",
       "id": "scripts_seed_main",
-      "community": 532,
+      "community": 45,
       "norm_label": "main()"
     },
     {
@@ -19684,6 +20044,606 @@
       "id": "claude_skills_pr_review_cycle_skill_never",
       "community": 395,
       "norm_label": "never"
+    },
+    {
+      "label": "SKILL.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill",
+      "community": 14,
+      "norm_label": "skill.md"
+    },
+    {
+      "label": "/graphify",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_graphify",
+      "community": 14,
+      "norm_label": "/graphify"
+    },
+    {
+      "label": "Usage",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L10",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_usage",
+      "community": 14,
+      "norm_label": "usage"
+    },
+    {
+      "label": "What graphify is for",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L45",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_what_graphify_is_for",
+      "community": 14,
+      "norm_label": "what graphify is for"
+    },
+    {
+      "label": "What You Must Do When Invoked",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L49",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "community": 14,
+      "norm_label": "what you must do when invoked"
+    },
+    {
+      "label": "Step 0 - GitHub repos and multi-path merge (only if a URL or several paths)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L61",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_0_github_repos_and_multi_path_merge_only_if_a_url_or_several_paths",
+      "community": 14,
+      "norm_label": "step 0 - github repos and multi-path merge (only if a url or several paths)"
+    },
+    {
+      "label": "Step 1 - Ensure graphify is installed",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L65",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_1_ensure_graphify_is_installed",
+      "community": 14,
+      "norm_label": "step 1 - ensure graphify is installed"
+    },
+    {
+      "label": "Step 2 - Detect files",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L107",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_2_detect_files",
+      "community": 14,
+      "norm_label": "step 2 - detect files"
+    },
+    {
+      "label": "Step 2.5 - Video and audio (only if video files detected)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L144",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_2_5_video_and_audio_only_if_video_files_detected",
+      "community": 14,
+      "norm_label": "step 2.5 - video and audio (only if video files detected)"
+    },
+    {
+      "label": "Step 3 - Extract entities and relationships",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L148",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "community": 14,
+      "norm_label": "step 3 - extract entities and relationships"
+    },
+    {
+      "label": "Part A - Structural extraction for code files",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L167",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_part_a_structural_extraction_for_code_files",
+      "community": 14,
+      "norm_label": "part a - structural extraction for code files"
+    },
+    {
+      "label": "Part B - Semantic extraction (parallel subagents)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L193",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_part_b_semantic_extraction_parallel_subagents",
+      "community": 14,
+      "norm_label": "part b - semantic extraction (parallel subagents)"
+    },
+    {
+      "label": "Part C - Merge AST + semantic into final extraction",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L350",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_part_c_merge_ast_semantic_into_final_extraction",
+      "community": 14,
+      "norm_label": "part c - merge ast + semantic into final extraction"
+    },
+    {
+      "label": "Step 4 - Build graph, cluster, analyze, generate outputs",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L384",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_4_build_graph_cluster_analyze_generate_outputs",
+      "community": 14,
+      "norm_label": "step 4 - build graph, cluster, analyze, generate outputs"
+    },
+    {
+      "label": "Step 4.5 - Graph health check (read-only integrity gate)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L447",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_4_5_graph_health_check_read_only_integrity_gate",
+      "community": 14,
+      "norm_label": "step 4.5 - graph health check (read-only integrity gate)"
+    },
+    {
+      "label": "Step 5 - Label communities",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L473",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_5_label_communities",
+      "community": 14,
+      "norm_label": "step 5 - label communities"
+    },
+    {
+      "label": "Step 6 - Generate Obsidian vault (opt-in) + HTML",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L514",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_6_generate_obsidian_vault_opt_in_html",
+      "community": 14,
+      "norm_label": "step 6 - generate obsidian vault (opt-in) + html"
+    },
+    {
+      "label": "Steps 6b-8 - Wiki, Neo4j, FalkorDB, SVG, GraphML, MCP, benchmark (only on their flags)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L534",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_steps_6b_8_wiki_neo4j_falkordb_svg_graphml_mcp_benchmark_only_on_their_flags",
+      "community": 14,
+      "norm_label": "steps 6b-8 - wiki, neo4j, falkordb, svg, graphml, mcp, benchmark (only on their flags)"
+    },
+    {
+      "label": "Step 9 - Save manifest, update cost tracker, clean up, and report",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L540",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_step_9_save_manifest_update_cost_tracker_clean_up_and_report",
+      "community": 14,
+      "norm_label": "step 9 - save manifest, update cost tracker, clean up, and report"
+    },
+    {
+      "label": "Interpreter guard for subcommands",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L620",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_interpreter_guard_for_subcommands",
+      "community": 14,
+      "norm_label": "interpreter guard for subcommands"
+    },
+    {
+      "label": "For --update and --cluster-only",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L638",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_for_update_and_cluster_only",
+      "community": 14,
+      "norm_label": "for --update and --cluster-only"
+    },
+    {
+      "label": "For /graphify query",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L644",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_for_graphify_query",
+      "community": 14,
+      "norm_label": "for /graphify query"
+    },
+    {
+      "label": "For /graphify add and --watch",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L656",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_for_graphify_add_and_watch",
+      "community": 14,
+      "norm_label": "for /graphify add and --watch"
+    },
+    {
+      "label": "For the commit hook and native CLAUDE.md integration",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L662",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_for_the_commit_hook_and_native_claude_md_integration",
+      "community": 14,
+      "norm_label": "for the commit hook and native claude.md integration"
+    },
+    {
+      "label": "Honesty Rules",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L668",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_skill_honesty_rules",
+      "community": 14,
+      "norm_label": "honesty rules"
+    },
+    {
+      "label": "add-watch.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_add_watch",
+      "community": 550,
+      "norm_label": "add-watch.md"
+    },
+    {
+      "label": "graphify reference: add a URL and watch a folder",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_add_watch_graphify_reference_add_a_url_and_watch_a_folder",
+      "community": 550,
+      "norm_label": "graphify reference: add a url and watch a folder"
+    },
+    {
+      "label": "For /graphify add",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_add_watch_for_graphify_add",
+      "community": 550,
+      "norm_label": "for /graphify add"
+    },
+    {
+      "label": "For --watch",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L39",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_add_watch_for_watch",
+      "community": 550,
+      "norm_label": "for --watch"
+    },
+    {
+      "label": "exports.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports",
+      "community": 517,
+      "norm_label": "exports.md"
+    },
+    {
+      "label": "graphify reference: extra exports and benchmark",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "community": 517,
+      "norm_label": "graphify reference: extra exports and benchmark"
+    },
+    {
+      "label": "Step 6b - Wiki (only if --wiki flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_6b_wiki_only_if_wiki_flag",
+      "community": 517,
+      "norm_label": "step 6b - wiki (only if --wiki flag)"
+    },
+    {
+      "label": "Step 7 - Neo4j export (only if --neo4j or --neo4j-push flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L15",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7_neo4j_export_only_if_neo4j_or_neo4j_push_flag",
+      "community": 517,
+      "norm_label": "step 7 - neo4j export (only if --neo4j or --neo4j-push flag)"
+    },
+    {
+      "label": "Step 7a - FalkorDB export (only if --falkordb or --falkordb-push flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L31",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7a_falkordb_export_only_if_falkordb_or_falkordb_push_flag",
+      "community": 517,
+      "norm_label": "step 7a - falkordb export (only if --falkordb or --falkordb-push flag)"
+    },
+    {
+      "label": "Step 7b - SVG export (only if --svg flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L47",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7b_svg_export_only_if_svg_flag",
+      "community": 517,
+      "norm_label": "step 7b - svg export (only if --svg flag)"
+    },
+    {
+      "label": "Step 7c - GraphML export (only if --graphml flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L53",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7c_graphml_export_only_if_graphml_flag",
+      "community": 517,
+      "norm_label": "step 7c - graphml export (only if --graphml flag)"
+    },
+    {
+      "label": "Step 7d - MCP server (only if --mcp flag)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L59",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_7d_mcp_server_only_if_mcp_flag",
+      "community": 517,
+      "norm_label": "step 7d - mcp server (only if --mcp flag)"
+    },
+    {
+      "label": "Step 8 - Token reduction benchmark (only if total_words > 5000)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L79",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_exports_step_8_token_reduction_benchmark_only_if_total_words_5000",
+      "community": 517,
+      "norm_label": "step 8 - token reduction benchmark (only if total_words > 5000)"
+    },
+    {
+      "label": "extraction-spec.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/extraction-spec.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_extraction_spec",
+      "community": 571,
+      "norm_label": "extraction-spec.md"
+    },
+    {
+      "label": "graphify reference: extraction subagent prompt (compact)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/extraction-spec.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_extraction_spec_graphify_reference_extraction_subagent_prompt_compact",
+      "community": 571,
+      "norm_label": "graphify reference: extraction subagent prompt (compact)"
+    },
+    {
+      "label": "github-and-merge.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_github_and_merge",
+      "community": 564,
+      "norm_label": "github-and-merge.md"
+    },
+    {
+      "label": "graphify reference: GitHub clone and cross-repo merge",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_github_and_merge_graphify_reference_github_clone_and_cross_repo_merge",
+      "community": 564,
+      "norm_label": "graphify reference: github clone and cross-repo merge"
+    },
+    {
+      "label": "Step 0 - Clone GitHub repo(s) (only if a GitHub URL was given)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_github_and_merge_step_0_clone_github_repo_s_only_if_a_github_url_was_given",
+      "community": 564,
+      "norm_label": "step 0 - clone github repo(s) (only if a github url was given)"
+    },
+    {
+      "label": "hooks.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_hooks",
+      "community": 554,
+      "norm_label": "hooks.md"
+    },
+    {
+      "label": "graphify reference: commit hook and native CLAUDE.md integration",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_hooks_graphify_reference_commit_hook_and_native_claude_md_integration",
+      "community": 554,
+      "norm_label": "graphify reference: commit hook and native claude.md integration"
+    },
+    {
+      "label": "For git commit hook",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_hooks_for_git_commit_hook",
+      "community": 554,
+      "norm_label": "for git commit hook"
+    },
+    {
+      "label": "For native CLAUDE.md integration",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L21",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_hooks_for_native_claude_md_integration",
+      "community": 554,
+      "norm_label": "for native claude.md integration"
+    },
+    {
+      "label": "query.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query",
+      "community": 538,
+      "norm_label": "query.md"
+    },
+    {
+      "label": "graphify reference: query, path, explain",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "community": 538,
+      "norm_label": "graphify reference: query, path, explain"
+    },
+    {
+      "label": "Step 0 \u2014 Constrained query expansion (REQUIRED before traversal)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L23",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_step_0_constrained_query_expansion_required_before_traversal",
+      "community": 538,
+      "norm_label": "step 0 \u2014 constrained query expansion (required before traversal)"
+    },
+    {
+      "label": "Step 1 \u2014 Traversal",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L61",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_step_1_traversal",
+      "community": 538,
+      "norm_label": "step 1 \u2014 traversal"
+    },
+    {
+      "label": "For /graphify path",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L186",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_for_graphify_path",
+      "community": 538,
+      "norm_label": "for /graphify path"
+    },
+    {
+      "label": "For /graphify explain",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L254",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_query_for_graphify_explain",
+      "community": 538,
+      "norm_label": "for /graphify explain"
+    },
+    {
+      "label": "transcribe.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_transcribe",
+      "community": 565,
+      "norm_label": "transcribe.md"
+    },
+    {
+      "label": "graphify reference: transcribe video and audio",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_transcribe_graphify_reference_transcribe_video_and_audio",
+      "community": 565,
+      "norm_label": "graphify reference: transcribe video and audio"
+    },
+    {
+      "label": "Step 2.5 - Transcribe video / audio files (only if video files detected)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_transcribe_step_2_5_transcribe_video_audio_files_only_if_video_files_detected",
+      "community": 565,
+      "norm_label": "step 2.5 - transcribe video / audio files (only if video files detected)"
+    },
+    {
+      "label": "update.md",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_update",
+      "community": 560,
+      "norm_label": "update.md"
+    },
+    {
+      "label": "graphify reference: incremental update and cluster-only",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_update_graphify_reference_incremental_update_and_cluster_only",
+      "community": 560,
+      "norm_label": "graphify reference: incremental update and cluster-only"
+    },
+    {
+      "label": "For --update (incremental re-extraction)",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_update_for_update_incremental_re_extraction",
+      "community": 560,
+      "norm_label": "for --update (incremental re-extraction)"
+    },
+    {
+      "label": "For --cluster-only",
+      "file_type": "document",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L184",
+      "_origin": "ast",
+      "id": "codex_skills_graphify_references_update_for_cluster_only",
+      "community": 560,
+      "norm_label": "for --cluster-only"
     },
     {
       "label": "copilot-instructions.md",
@@ -21436,13 +22396,143 @@
       "norm_label": "known active debt"
     },
     {
+      "label": "summary.md",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_api_summary",
+      "community": 549,
+      "norm_label": "summary.md"
+    },
+    {
+      "label": "Summary API \u2014 Technical Reference",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_api_summary_summary_api_technical_reference",
+      "community": 49,
+      "norm_label": "summary api \u2014 technical reference"
+    },
+    {
+      "label": "The operation",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L10",
+      "_origin": "ast",
+      "id": "docs_api_summary_the_operation",
+      "community": 49,
+      "norm_label": "the operation"
+    },
+    {
+      "label": "Date handling is shared, not reimplemented",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "docs_api_summary_date_handling_is_shared_not_reimplemented",
+      "community": 49,
+      "norm_label": "date handling is shared, not reimplemented"
+    },
+    {
+      "label": "Four queries, one transaction",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L36",
+      "_origin": "ast",
+      "id": "docs_api_summary_four_queries_one_transaction",
+      "community": 49,
+      "norm_label": "four queries, one transaction"
+    },
+    {
+      "label": "The comparison period",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L48",
+      "_origin": "ast",
+      "id": "docs_api_summary_the_comparison_period",
+      "community": 49,
+      "norm_label": "the comparison period"
+    },
+    {
+      "label": "Percentage change",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L63",
+      "_origin": "ast",
+      "id": "docs_api_summary_percentage_change",
+      "community": 49,
+      "norm_label": "percentage change"
+    },
+    {
+      "label": "Category breakdown",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L81",
+      "_origin": "ast",
+      "id": "docs_api_summary_category_breakdown",
+      "community": 49,
+      "norm_label": "category breakdown"
+    },
+    {
+      "label": "What the breakdown excludes",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L91",
+      "_origin": "ast",
+      "id": "docs_api_summary_what_the_breakdown_excludes",
+      "community": 49,
+      "norm_label": "what the breakdown excludes"
+    },
+    {
+      "label": "Daily series",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L103",
+      "_origin": "ast",
+      "id": "docs_api_summary_daily_series",
+      "community": 49,
+      "norm_label": "daily series"
+    },
+    {
+      "label": "Empty state",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L118",
+      "_origin": "ast",
+      "id": "docs_api_summary_empty_state",
+      "community": 49,
+      "norm_label": "empty state"
+    },
+    {
+      "label": "Where the code lives",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L129",
+      "_origin": "ast",
+      "id": "docs_api_summary_where_the_code_lives",
+      "community": 49,
+      "norm_label": "where the code lives"
+    },
+    {
+      "label": "Divergences and gaps",
+      "file_type": "document",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L138",
+      "_origin": "ast",
+      "id": "docs_api_summary_divergences_and_gaps",
+      "community": 49,
+      "norm_label": "divergences and gaps"
+    },
+    {
       "label": "transactions.md",
       "file_type": "document",
       "source_file": "docs/api/transactions.md",
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_api_transactions",
-      "community": 545,
+      "community": 549,
       "norm_label": "transactions.md"
     },
     {
@@ -21512,7 +22602,7 @@
       "source_location": "L90",
       "_origin": "ast",
       "id": "docs_api_transactions_date_filtering",
-      "community": 560,
+      "community": 317,
       "norm_label": "date filtering"
     },
     {
@@ -21522,7 +22612,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "docs_api_transactions_presence_vs_emptiness",
-      "community": 560,
+      "community": 317,
       "norm_label": "presence vs emptiness"
     },
     {
@@ -21532,7 +22622,7 @@
       "source_location": "L114",
       "_origin": "ast",
       "id": "docs_api_transactions_the_three_date_errors",
-      "community": 560,
+      "community": 317,
       "norm_label": "the three date errors"
     },
     {
@@ -21712,7 +22802,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list",
-      "community": 545,
+      "community": 549,
       "norm_label": "roadmap_features_list.md"
     },
     {
@@ -21782,7 +22872,7 @@
       "source_location": "L31",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_2_import_review_normalization_and_deduplication",
-      "community": 388,
+      "community": 545,
       "norm_label": "2. import review, normalization, and deduplication"
     },
     {
@@ -21792,7 +22882,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_why_this_matters_33",
-      "community": 388,
+      "community": 545,
       "norm_label": "why this matters"
     },
     {
@@ -21802,7 +22892,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_what_this_feature_should_achieve_37",
-      "community": 388,
+      "community": 545,
       "norm_label": "what this feature should achieve"
     },
     {
@@ -21812,7 +22902,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_product_impact_45",
-      "community": 388,
+      "community": 545,
       "norm_label": "product impact"
     },
     {
@@ -21942,7 +23032,7 @@
       "source_location": "L103",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_strategic_notes",
-      "community": 564,
+      "community": 545,
       "norm_label": "strategic notes"
     },
     {
@@ -21952,7 +23042,7 @@
       "source_location": "L105",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_open_banking_readiness",
-      "community": 564,
+      "community": 545,
       "norm_label": "open banking readiness"
     },
     {
@@ -21962,7 +23052,7 @@
       "source_location": "L109",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_parser_service_alignment",
-      "community": 564,
+      "community": 545,
       "norm_label": "parser service alignment"
     },
     {
@@ -21972,7 +23062,7 @@
       "source_location": "L113",
       "_origin": "ast",
       "id": "docs_features_roadmap_roadmap_features_list_current_roadmap_principle",
-      "community": 564,
+      "community": 545,
       "norm_label": "current roadmap principle"
     },
     {
@@ -22196,13 +23286,133 @@
       "norm_label": "watch list (triggers a refresh of this investigation)"
     },
     {
+      "label": "summary.md",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_product_summary",
+      "community": 549,
+      "norm_label": "summary.md"
+    },
+    {
+      "label": "Summary \u2014 Product Behavior",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "docs_product_summary_summary_product_behavior",
+      "community": 229,
+      "norm_label": "summary \u2014 product behavior"
+    },
+    {
+      "label": "What the dashboard shows",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "docs_product_summary_what_the_dashboard_shows",
+      "community": 229,
+      "norm_label": "what the dashboard shows"
+    },
+    {
+      "label": "The period",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "docs_product_summary_the_period",
+      "community": 229,
+      "norm_label": "the period"
+    },
+    {
+      "label": "\"Compared to previous period\" means the period immediately before",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L30",
+      "_origin": "ast",
+      "id": "docs_product_summary_compared_to_previous_period_means_the_period_immediately_before",
+      "community": 229,
+      "norm_label": "\"compared to previous period\" means the period immediately before"
+    },
+    {
+      "label": "Why a change can read 100%",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L42",
+      "_origin": "ast",
+      "id": "docs_product_summary_why_a_change_can_read_100",
+      "community": 229,
+      "norm_label": "why a change can read 100%"
+    },
+    {
+      "label": "The category chart does not add up to the expenses total",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L54",
+      "_origin": "ast",
+      "id": "docs_product_summary_the_category_chart_does_not_add_up_to_the_expenses_total",
+      "community": 229,
+      "norm_label": "the category chart does not add up to the expenses total"
+    },
+    {
+      "label": "\"Other\"",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L74",
+      "_origin": "ast",
+      "id": "docs_product_summary_other",
+      "community": 229,
+      "norm_label": "\"other\""
+    },
+    {
+      "label": "The daily chart always covers every day",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L83",
+      "_origin": "ast",
+      "id": "docs_product_summary_the_daily_chart_always_covers_every_day",
+      "community": 229,
+      "norm_label": "the daily chart always covers every day"
+    },
+    {
+      "label": "Filtering by one account",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L93",
+      "_origin": "ast",
+      "id": "docs_product_summary_filtering_by_one_account",
+      "community": 229,
+      "norm_label": "filtering by one account"
+    },
+    {
+      "label": "What this deliberately cannot do yet",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L100",
+      "_origin": "ast",
+      "id": "docs_product_summary_what_this_deliberately_cannot_do_yet",
+      "community": 229,
+      "norm_label": "what this deliberately cannot do yet"
+    },
+    {
+      "label": "Related",
+      "file_type": "document",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L113",
+      "_origin": "ast",
+      "id": "docs_product_summary_related",
+      "community": 229,
+      "norm_label": "related"
+    },
+    {
       "label": "transactions.md",
       "file_type": "document",
       "source_file": "docs/product/transactions.md",
       "source_location": "L1",
       "_origin": "ast",
       "id": "docs_product_transactions",
-      "community": 545,
+      "community": 549,
       "norm_label": "transactions.md"
     },
     {
@@ -24553,6 +25763,66 @@
       "_origin": "ast",
       "id": "post_migration_improvements_claude_backend_improvements_0016_bulk_body_limit_enforced_against_the_stream_proposed_improvement",
       "community": 561,
+      "norm_label": "proposed improvement"
+    },
+    {
+      "label": "0017-summary-category-chart-excludes-uncategorized.md",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized",
+      "community": 541,
+      "norm_label": "0017-summary-category-chart-excludes-uncategorized.md"
+    },
+    {
+      "label": "0017 \u2014 The summary category chart silently excludes uncategorized spending",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_0017_the_summary_category_chart_silently_excludes_uncategorized_spending",
+      "community": 541,
+      "norm_label": "0017 \u2014 the summary category chart silently excludes uncategorized spending"
+    },
+    {
+      "label": "How it was migrated",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_how_it_was_migrated",
+      "community": 541,
+      "norm_label": "how it was migrated"
+    },
+    {
+      "label": "Why it was done this way",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L21",
+      "_origin": "ast",
+      "id": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_why_it_was_done_this_way",
+      "community": 541,
+      "norm_label": "why it was done this way"
+    },
+    {
+      "label": "The concern",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L40",
+      "_origin": "ast",
+      "id": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_the_concern",
+      "community": 541,
+      "norm_label": "the concern"
+    },
+    {
+      "label": "Proposed improvement",
+      "file_type": "document",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L54",
+      "_origin": "ast",
+      "id": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_proposed_improvement",
+      "community": 541,
       "norm_label": "proposed improvement"
     },
     {
@@ -34124,6 +35394,17 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L339",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_unauthorized",
+      "target": "backend_internal_auth_jwt_issueaccesstoken"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions_live_test.go",
       "source_location": "L552",
       "weight": 1.0,
@@ -39299,6 +40580,28 @@
     {
       "relation": "references",
       "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_bucketcategories",
+      "target": "gen_getcategoryspendingrow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L51",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_summary_test_categoryrow",
+      "target": "gen_getcategoryspendingrow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
       "source_file": "backend/internal/db/gen/summary.sql.go",
       "source_location": "L44",
       "weight": 1.0,
@@ -39379,6 +40682,28 @@
       "context": "parameter_type",
       "source": "gen_queries_getdailytotals",
       "target": "gen_getdailytotalsparams",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L194",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_fillmissingdays",
+      "target": "gen_getdailytotalsrow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L120",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_summary_test_dailyrow",
+      "target": "gen_getdailytotalsrow",
       "confidence_score": 1.0
     },
     {
@@ -39888,7 +41213,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L544",
+      "source_location": "L538",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_transactions_totransactionlistitem",
@@ -41138,7 +42463,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L225",
+      "source_location": "L259",
       "weight": 1.0,
       "source": "http_resourceserver_withuser",
       "target": "backend_internal_db_rls_withusertx"
@@ -43621,6 +44946,17 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L325",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_datequeryerrors",
+      "target": "backend_internal_http_accounts_live_test_decodeaccountsapierror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions_bulk_live_test.go",
       "source_location": "L192",
       "weight": 1.0,
@@ -43735,6 +45071,83 @@
       "source_location": "L452",
       "weight": 1.0,
       "source": "backend_internal_http_categories_live_test_testcategorieslive_deletesetstransactioncategorynull",
+      "target": "backend_internal_http_accounts_live_test_createtestaccount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L246",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_accountfilter",
+      "target": "backend_internal_http_accounts_live_test_createtestaccount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L166",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_categorybreakdown",
+      "target": "backend_internal_http_accounts_live_test_createtestaccount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L126",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changecomparestheprecedingwindow",
+      "target": "backend_internal_http_accounts_live_test_createtestaccount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L147",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changeis100whenpreviousperiodisempty",
+      "target": "backend_internal_http_accounts_live_test_createtestaccount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L275",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_crossuserisolation",
+      "target": "backend_internal_http_accounts_live_test_createtestaccount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L214",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_dailyseries",
+      "target": "backend_internal_http_accounts_live_test_createtestaccount"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_totals",
       "target": "backend_internal_http_accounts_live_test_createtestaccount"
     },
     {
@@ -44786,7 +46199,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L242",
+      "source_location": "L276",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_validateresourcename",
@@ -44819,7 +46232,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L523",
+      "source_location": "L517",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_parseamount",
@@ -44830,7 +46243,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L461",
+      "source_location": "L455",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_validatetransactioninput",
@@ -45459,7 +46872,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L186",
+      "source_location": "L180",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_auth_validationerror"
@@ -45481,7 +46894,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L266",
+      "source_location": "L260",
       "weight": 1.0,
       "source": "http_resourceserver_updatetransaction",
       "target": "backend_internal_http_auth_validationerror"
@@ -48432,6 +49845,28 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L170",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_categorybreakdown",
+      "target": "backend_internal_http_categories_live_test_createtestcategory"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L277",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_crossuserisolation",
+      "target": "backend_internal_http_categories_live_test_createtestcategory"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions_bulk_live_test.go",
       "source_location": "L52",
       "weight": 1.0,
@@ -48745,6 +50180,17 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_daterange_parsedaterange"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
       "source_location": "L89",
       "weight": 1.0,
@@ -48790,10 +50236,32 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L479",
+      "source_location": "L473",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_validatetransactioninput",
       "target": "backend_internal_http_daterange_parsecalendardate"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L205",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_fillmissingdays",
+      "target": "backend_internal_http_daterange_calendardaysbetween"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_daterange_calendardaysbetween"
     },
     {
       "relation": "contains",
@@ -50205,7 +51673,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L198",
+      "source_location": "L192",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_middleware_useridfromcontext"
@@ -50216,7 +51684,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L341",
+      "source_location": "L335",
       "weight": 1.0,
       "source": "http_resourceserver_deletetransaction",
       "target": "backend_internal_http_middleware_useridfromcontext"
@@ -50227,7 +51695,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L278",
+      "source_location": "L272",
       "weight": 1.0,
       "source": "http_resourceserver_updatetransaction",
       "target": "backend_internal_http_middleware_useridfromcontext"
@@ -50238,7 +51706,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L219",
+      "source_location": "L253",
       "weight": 1.0,
       "source": "http_resourceserver_withuser",
       "target": "backend_internal_http_middleware_useridfromcontext"
@@ -50425,7 +51893,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L200",
+      "source_location": "L194",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_middleware_writeunauthorizederror"
@@ -50436,7 +51904,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L343",
+      "source_location": "L337",
       "weight": 1.0,
       "source": "http_resourceserver_deletetransaction",
       "target": "backend_internal_http_middleware_writeunauthorizederror"
@@ -50447,7 +51915,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L280",
+      "source_location": "L274",
       "weight": 1.0,
       "source": "http_resourceserver_updatetransaction",
       "target": "backend_internal_http_middleware_writeunauthorizederror"
@@ -50458,7 +51926,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L221",
+      "source_location": "L255",
       "weight": 1.0,
       "source": "http_resourceserver_withuser",
       "target": "backend_internal_http_middleware_writeunauthorizederror"
@@ -51231,7 +52699,17 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L260",
+      "source_location": "L215",
+      "weight": 1.0,
+      "source": "backend_internal_http_resources",
+      "target": "backend_internal_http_resources_accountidfilter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L294",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_dberror",
@@ -51271,7 +52749,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L253",
+      "source_location": "L287",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_logresourceerror",
@@ -51301,7 +52779,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L197",
+      "source_location": "L199",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_optionalqueryparam",
@@ -51311,7 +52789,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L233",
+      "source_location": "L267",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_pguserid",
@@ -51321,7 +52799,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L242",
+      "source_location": "L276",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_validateresourcename",
@@ -51331,7 +52809,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L178",
+      "source_location": "L180",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_withlisttransactionsparams",
@@ -51341,10 +52819,20 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L163",
+      "source_location": "L165",
       "weight": 1.0,
       "source": "backend_internal_http_resources",
       "target": "backend_internal_http_resources_withresourceid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L229",
+      "weight": 1.0,
+      "source": "backend_internal_http_resources",
+      "target": "backend_internal_http_resources_withsummaryparams",
       "confidence_score": 1.0
     },
     {
@@ -51406,7 +52894,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L185",
+      "source_location": "L179",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_resources_decoderesourcebody"
@@ -51417,7 +52905,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L265",
+      "source_location": "L259",
       "weight": 1.0,
       "source": "http_resourceserver_updatetransaction",
       "target": "backend_internal_http_resources_decoderesourcebody"
@@ -51437,7 +52925,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L178",
+      "source_location": "L180",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withlisttransactionsparams",
@@ -51448,7 +52936,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L163",
+      "source_location": "L165",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -51459,7 +52947,18 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L218",
+      "source_location": "L229",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_resources_withsummaryparams",
+      "target": "backend_internal_http_resources_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L252",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -51481,7 +52980,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L253",
+      "source_location": "L287",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_logresourceerror",
@@ -51492,7 +52991,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L178",
+      "source_location": "L180",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withlisttransactionsparams",
@@ -51503,7 +53002,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L163",
+      "source_location": "L165",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -51514,7 +53013,18 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L218",
+      "source_location": "L229",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_resources_withsummaryparams",
+      "target": "backend_internal_http_resources_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L252",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -51591,7 +53101,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L218",
+      "source_location": "L252",
       "weight": 1.0,
       "source": "backend_internal_http_resources_go_http_resourceserver",
       "target": "http_resourceserver_withuser",
@@ -51678,7 +53188,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L163",
+      "source_location": "L165",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -51689,7 +53199,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L163",
+      "source_location": "L165",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withresourceid",
@@ -51711,7 +53221,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L178",
+      "source_location": "L180",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_withlisttransactionsparams",
@@ -51722,7 +53232,18 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L178",
+      "source_location": "L229",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_resources_withsummaryparams",
+      "target": "backend_internal_http_resources_go_handlerfunc",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L180",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_withlisttransactionsparams",
@@ -51734,7 +53255,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L184",
+      "source_location": "L186",
       "weight": 1.0,
       "source": "backend_internal_http_resources_withlisttransactionsparams",
       "target": "backend_internal_http_resources_optionalqueryparam",
@@ -51755,12 +53276,34 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L197",
+      "source_location": "L199",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_resources_optionalqueryparam",
       "target": "values",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L232",
+      "weight": 1.0,
+      "source": "backend_internal_http_resources_withsummaryparams",
+      "target": "backend_internal_http_resources_optionalqueryparam",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_resources_optionalqueryparam"
     },
     {
       "relation": "calls",
@@ -51777,7 +53320,62 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L218",
+      "source_location": "L215",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_resources_accountidfilter",
+      "target": "backend_internal_http_resources_go_text",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_resources_accountidfilter"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L96",
+      "weight": 1.0,
+      "source": "http_resourceserver_listtransactions",
+      "target": "backend_internal_http_resources_accountidfilter"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L229",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_resources_withsummaryparams",
+      "target": "openapi_getsummaryparams",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/router.go",
+      "source_location": "L77",
+      "weight": 1.0,
+      "source": "backend_internal_http_router_newrouter",
+      "target": "backend_internal_http_resources_withsummaryparams"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/resources.go",
+      "source_location": "L252",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -51788,7 +53386,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L218",
+      "source_location": "L252",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_withuser",
@@ -51799,7 +53397,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L233",
+      "source_location": "L267",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_pguserid",
@@ -51823,7 +53421,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L391",
+      "source_location": "L385",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_validatetransactionreferences",
       "target": "backend_internal_http_resources_pguserid"
@@ -51845,7 +53443,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L354",
+      "source_location": "L348",
       "weight": 1.0,
       "source": "http_resourceserver_deletetransaction",
       "target": "backend_internal_http_resources_pguserid"
@@ -51855,8 +53453,19 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L70",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_resources_pguserid"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L144",
+      "source_location": "L138",
       "weight": 1.0,
       "source": "http_resourceserver_gettransaction",
       "target": "backend_internal_http_resources_pguserid"
@@ -51867,7 +53476,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L113",
+      "source_location": "L107",
       "weight": 1.0,
       "source": "http_resourceserver_listtransactions",
       "target": "backend_internal_http_resources_pguserid"
@@ -51878,7 +53487,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L303",
+      "source_location": "L297",
       "weight": 1.0,
       "source": "http_resourceserver_updatetransaction",
       "target": "backend_internal_http_resources_pguserid"
@@ -51911,7 +53520,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L250",
+      "source_location": "L244",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_resources_logresourceerror"
@@ -51922,7 +53531,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L376",
+      "source_location": "L370",
       "weight": 1.0,
       "source": "http_resourceserver_deletetransaction",
       "target": "backend_internal_http_resources_logresourceerror"
@@ -51932,8 +53541,19 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L111",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_resources_logresourceerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L166",
+      "source_location": "L160",
       "weight": 1.0,
       "source": "http_resourceserver_gettransaction",
       "target": "backend_internal_http_resources_logresourceerror"
@@ -51944,7 +53564,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L124",
+      "source_location": "L118",
       "weight": 1.0,
       "source": "http_resourceserver_listtransactions",
       "target": "backend_internal_http_resources_logresourceerror"
@@ -51955,7 +53575,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L333",
+      "source_location": "L327",
       "weight": 1.0,
       "source": "http_resourceserver_updatetransaction",
       "target": "backend_internal_http_resources_logresourceerror"
@@ -51964,7 +53584,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/resources.go",
-      "source_location": "L260",
+      "source_location": "L294",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_resources_dberror",
@@ -51999,7 +53619,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L251",
+      "source_location": "L245",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_resources_dberror"
@@ -52010,7 +53630,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L377",
+      "source_location": "L371",
       "weight": 1.0,
       "source": "http_resourceserver_deletetransaction",
       "target": "backend_internal_http_resources_dberror"
@@ -52020,8 +53640,19 @@
       "context": "call",
       "confidence": "INFERRED",
       "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L112",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_resources_dberror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L167",
+      "source_location": "L161",
       "weight": 1.0,
       "source": "http_resourceserver_gettransaction",
       "target": "backend_internal_http_resources_dberror"
@@ -52032,7 +53663,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L125",
+      "source_location": "L119",
       "weight": 1.0,
       "source": "http_resourceserver_listtransactions",
       "target": "backend_internal_http_resources_dberror"
@@ -52043,7 +53674,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L334",
+      "source_location": "L328",
       "weight": 1.0,
       "source": "http_resourceserver_updatetransaction",
       "target": "backend_internal_http_resources_dberror"
@@ -52094,101 +53725,957 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L608",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L162",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_accountreferencenotfounderror",
+      "source": "backend_internal_http_summary",
+      "target": "backend_internal_http_summary_bucketcategories",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L614",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L194",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_categoryreferencenotfounderror",
+      "source": "backend_internal_http_summary",
+      "target": "backend_internal_http_summary_fillmissingdays",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L585",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L140",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_invaliddatequeryerror",
+      "source": "backend_internal_http_summary",
+      "target": "backend_internal_http_summary_percentagechange",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L596",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L220",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_invalidqueryerror",
+      "source": "backend_internal_http_summary",
+      "target": "backend_internal_http_summary_pgtimestamp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_go_http_resourceserver",
+      "target": "http_resourceserver_getsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L124",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_summary_bucketcategories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L125",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_summary_fillmissingdays",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L35",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_summary_go_request",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L35",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_summary_go_responsewriter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L119",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_summary_percentagechange",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L71",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_summary_pgtimestamp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_transactions_invaliddatequeryerror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "http_resourceserver_getsummary",
+      "target": "backend_internal_http_transactions_invalidqueryerror"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L35",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "http_resourceserver_getsummary",
+      "target": "openapi_getsummaryparams",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test_testpercentagechange",
+      "target": "backend_internal_http_summary_percentagechange"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test_testpercentagechange_usesfloatdivision",
+      "target": "backend_internal_http_summary_percentagechange"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L162",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_summary_bucketcategories",
+      "target": "openapi_summarycategory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test_testbucketcategories",
+      "target": "backend_internal_http_summary_bucketcategories"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L194",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_fillmissingdays",
+      "target": "backend_internal_http_summary_go_time",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L194",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_summary_fillmissingdays",
+      "target": "openapi_summaryday",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L134",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test_testfillmissingdays",
+      "target": "backend_internal_http_summary_fillmissingdays"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L220",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_pgtimestamp",
+      "target": "backend_internal_http_summary_go_time",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary.go",
+      "source_location": "L220",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_summary_pgtimestamp",
+      "target": "backend_internal_http_summary_go_timestamp",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L523",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L18",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_parseamount",
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_getsummary",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L620",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L33",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_ratelimitederror",
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_seedsummarytransaction",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L428",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L243",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_referenceerrorfromforeignkeyviolation",
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_accountfilter",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L576",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L163",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_textpointer",
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_categorybreakdown",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L561",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L123",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_totransaction",
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_changecomparestheprecedingwindow",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L544",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L144",
       "weight": 1.0,
-      "source": "backend_internal_http_transactions",
-      "target": "backend_internal_http_transactions_totransactionlistitem",
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_changeis100whenpreviousperiodisempty",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L270",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_crossuserisolation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L211",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_dailyseries",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L302",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_datequeryerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L70",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_emptystateiszerosandfilleddays",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_totals",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L336",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test",
+      "target": "backend_internal_http_summary_live_test_testsummarylive_unauthorized",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L18",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_getsummary",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L18",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_getsummary",
+      "target": "http_transactionstestenv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L18",
+      "weight": 1.0,
+      "context": "return_type",
+      "source": "backend_internal_http_summary_live_test_getsummary",
+      "target": "openapi_summary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L253",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_accountfilter",
+      "target": "backend_internal_http_summary_live_test_getsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L183",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_categorybreakdown",
+      "target": "backend_internal_http_summary_live_test_getsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L133",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changecomparestheprecedingwindow",
+      "target": "backend_internal_http_summary_live_test_getsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L151",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changeis100whenpreviousperiodisempty",
+      "target": "backend_internal_http_summary_live_test_getsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L283",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_crossuserisolation",
+      "target": "backend_internal_http_summary_live_test_getsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L219",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_dailyseries",
+      "target": "backend_internal_http_summary_live_test_getsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_totals",
+      "target": "backend_internal_http_summary_live_test_getsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L33",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L243",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_accountfilter",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L163",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_categorybreakdown",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L123",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changecomparestheprecedingwindow",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L144",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changeis100whenpreviousperiodisempty",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L270",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_crossuserisolation",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L211",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_dailyseries",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L302",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_datequeryerrors",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L70",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_emptystateiszerosandfilleddays",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L42",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_totals",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L336",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_testsummarylive_unauthorized",
+      "target": "backend_internal_http_summary_live_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "target": "backend_internal_http_transactions_live_test_createtesttransaction"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "target": "backend_internal_http_transactions_live_test_validtransactionbody"
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L33",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "target": "http_transactionstestenv",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L249",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_accountfilter",
+      "target": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L174",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_categorybreakdown",
+      "target": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L130",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changecomparestheprecedingwindow",
+      "target": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L149",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changeis100whenpreviousperiodisempty",
+      "target": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L279",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_crossuserisolation",
+      "target": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L216",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_dailyseries",
+      "target": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_totals",
+      "target": "backend_internal_http_summary_live_test_seedsummarytransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_totals",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L71",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_emptystateiszerosandfilleddays",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L124",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changecomparestheprecedingwindow",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L145",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_changeis100whenpreviousperiodisempty",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L164",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_categorybreakdown",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L212",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_dailyseries",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L244",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_accountfilter",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L271",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_crossuserisolation",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L303",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_datequeryerrors",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L360",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_unauthorized",
+      "target": "backend_internal_http_transactions_live_test_asserttransactionapierror"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "backend/internal/http/summary_live_test.go",
+      "source_location": "L337",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_live_test_testsummarylive_unauthorized",
+      "target": "backend_internal_http_transactions_live_test_newtransactionstestenv"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L51",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test",
+      "target": "backend_internal_http_summary_test_categoryrow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L120",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test",
+      "target": "backend_internal_http_summary_test_dailyrow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test",
+      "target": "backend_internal_http_summary_test_testbucketcategories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L129",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test",
+      "target": "backend_internal_http_summary_test_testfillmissingdays",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test",
+      "target": "backend_internal_http_summary_test_testpercentagechange",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test",
+      "target": "backend_internal_http_summary_test_testpercentagechange_usesfloatdivision",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L15",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_test_testpercentagechange",
+      "target": "backend_internal_http_summary_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L55",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_test_testbucketcategories",
+      "target": "backend_internal_http_summary_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L129",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_test_testfillmissingdays",
+      "target": "backend_internal_http_summary_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L44",
+      "weight": 1.0,
+      "context": "parameter_type",
+      "source": "backend_internal_http_summary_test_testpercentagechange_usesfloatdivision",
+      "target": "backend_internal_http_summary_test_go_t",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test_testbucketcategories",
+      "target": "backend_internal_http_summary_test_categoryrow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/summary_test.go",
+      "source_location": "L135",
+      "weight": 1.0,
+      "source": "backend_internal_http_summary_test_testfillmissingdays",
+      "target": "backend_internal_http_summary_test_dailyrow",
       "confidence_score": 1.0
     },
     {
@@ -52198,6 +54685,106 @@
       "source_location": "L602",
       "weight": 1.0,
       "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_accountreferencenotfounderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L608",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_categoryreferencenotfounderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L579",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_invaliddatequeryerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L590",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_invalidqueryerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L517",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_parseamount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L614",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_ratelimitederror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L422",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_referenceerrorfromforeignkeyviolation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L570",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_textpointer",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L555",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_totransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L538",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
+      "target": "backend_internal_http_transactions_totransactionlistitem",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L596",
+      "weight": 1.0,
+      "source": "backend_internal_http_transactions",
       "target": "backend_internal_http_transactions_transactionnotfounderror",
       "confidence_score": 1.0
     },
@@ -52205,7 +54792,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L461",
+      "source_location": "L455",
       "weight": 1.0,
       "source": "backend_internal_http_transactions",
       "target": "backend_internal_http_transactions_validatetransactioninput",
@@ -52215,7 +54802,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L390",
+      "source_location": "L384",
       "weight": 1.0,
       "source": "backend_internal_http_transactions",
       "target": "backend_internal_http_transactions_validatetransactionreferences",
@@ -52256,7 +54843,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L461",
+      "source_location": "L455",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_transactions_validatetransactioninput",
@@ -52278,7 +54865,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L523",
+      "source_location": "L517",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_transactions_parseamount",
@@ -52311,7 +54898,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L461",
+      "source_location": "L455",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_validatetransactioninput",
@@ -52322,7 +54909,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L390",
+      "source_location": "L384",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_transactions_validatetransactionreferences",
@@ -52355,7 +54942,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L576",
+      "source_location": "L570",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_transactions_textpointer",
@@ -52366,7 +54953,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L445",
+      "source_location": "L439",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_go_http_resourceserver",
       "target": "http_resourceserver_allowmutation",
@@ -52376,7 +54963,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L183",
+      "source_location": "L177",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_go_http_resourceserver",
       "target": "http_resourceserver_createtransaction",
@@ -52386,7 +54973,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L340",
+      "source_location": "L334",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_go_http_resourceserver",
       "target": "http_resourceserver_deletetransaction",
@@ -52396,7 +54983,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L141",
+      "source_location": "L135",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_go_http_resourceserver",
       "target": "http_resourceserver_gettransaction",
@@ -52416,7 +55003,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L634",
+      "source_location": "L628",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_go_http_resourceserver",
       "target": "http_resourceserver_now",
@@ -52426,7 +55013,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L263",
+      "source_location": "L257",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_go_http_resourceserver",
       "target": "http_resourceserver_updatetransaction",
@@ -52481,7 +55068,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L102",
+      "source_location": "L98",
       "weight": 1.0,
       "source": "http_resourceserver_listtransactions",
       "target": "backend_internal_http_transactions_invalidqueryerror",
@@ -52492,7 +55079,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L132",
+      "source_location": "L126",
       "weight": 1.0,
       "source": "http_resourceserver_listtransactions",
       "target": "backend_internal_http_transactions_totransactionlistitem",
@@ -52513,7 +55100,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L183",
+      "source_location": "L177",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_createtransaction",
@@ -52524,7 +55111,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L340",
+      "source_location": "L334",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_deletetransaction",
@@ -52535,7 +55122,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L141",
+      "source_location": "L135",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_gettransaction",
@@ -52546,7 +55133,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L263",
+      "source_location": "L257",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_updatetransaction",
@@ -52557,7 +55144,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L390",
+      "source_location": "L384",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_transactions_validatetransactionreferences",
@@ -52568,7 +55155,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L183",
+      "source_location": "L177",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_createtransaction",
@@ -52579,7 +55166,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L340",
+      "source_location": "L334",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_deletetransaction",
@@ -52590,7 +55177,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L141",
+      "source_location": "L135",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_gettransaction",
@@ -52601,7 +55188,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L263",
+      "source_location": "L257",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_updatetransaction",
@@ -52612,7 +55199,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L141",
+      "source_location": "L135",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_gettransaction",
@@ -52624,7 +55211,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L160",
+      "source_location": "L154",
       "weight": 1.0,
       "source": "http_resourceserver_gettransaction",
       "target": "backend_internal_http_transactions_totransaction",
@@ -52635,7 +55222,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L163",
+      "source_location": "L157",
       "weight": 1.0,
       "source": "http_resourceserver_gettransaction",
       "target": "backend_internal_http_transactions_transactionnotfounderror",
@@ -52645,7 +55232,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L340",
+      "source_location": "L334",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_deletetransaction",
@@ -52656,7 +55243,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L263",
+      "source_location": "L257",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_updatetransaction",
@@ -52668,7 +55255,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L244",
+      "source_location": "L238",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_transactions_accountreferencenotfounderror",
@@ -52679,7 +55266,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L247",
+      "source_location": "L241",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_transactions_categoryreferencenotfounderror",
@@ -52690,7 +55277,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L206",
+      "source_location": "L200",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_transactions_ratelimitederror",
@@ -52701,7 +55288,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L230",
+      "source_location": "L224",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_transactions_referenceerrorfromforeignkeyviolation",
@@ -52712,7 +55299,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L241",
+      "source_location": "L235",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_transactions_totransaction",
@@ -52723,7 +55310,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L191",
+      "source_location": "L185",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_transactions_validatetransactioninput",
@@ -52734,7 +55321,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L215",
+      "source_location": "L209",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
       "target": "backend_internal_http_transactions_validatetransactionreferences",
@@ -52745,9 +55332,108 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L205",
+      "source_location": "L199",
       "weight": 1.0,
       "source": "http_resourceserver_createtransaction",
+      "target": "http_resourceserver_allowmutation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L318",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatetransaction",
+      "target": "backend_internal_http_transactions_accountreferencenotfounderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L321",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatetransaction",
+      "target": "backend_internal_http_transactions_categoryreferencenotfounderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L278",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatetransaction",
+      "target": "backend_internal_http_transactions_ratelimitederror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L304",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatetransaction",
+      "target": "backend_internal_http_transactions_referenceerrorfromforeignkeyviolation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L315",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatetransaction",
+      "target": "backend_internal_http_transactions_totransaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L324",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatetransaction",
+      "target": "backend_internal_http_transactions_transactionnotfounderror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L265",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatetransaction",
+      "target": "backend_internal_http_transactions_validatetransactioninput",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L285",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatetransaction",
+      "target": "backend_internal_http_transactions_validatetransactionreferences",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "backend/internal/http/transactions.go",
+      "source_location": "L277",
+      "weight": 1.0,
+      "source": "http_resourceserver_updatetransaction",
       "target": "http_resourceserver_allowmutation",
       "confidence_score": 1.0
     },
@@ -52759,105 +55445,6 @@
       "source_location": "L324",
       "weight": 1.0,
       "source": "http_resourceserver_updatetransaction",
-      "target": "backend_internal_http_transactions_accountreferencenotfounderror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L327",
-      "weight": 1.0,
-      "source": "http_resourceserver_updatetransaction",
-      "target": "backend_internal_http_transactions_categoryreferencenotfounderror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L284",
-      "weight": 1.0,
-      "source": "http_resourceserver_updatetransaction",
-      "target": "backend_internal_http_transactions_ratelimitederror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L310",
-      "weight": 1.0,
-      "source": "http_resourceserver_updatetransaction",
-      "target": "backend_internal_http_transactions_referenceerrorfromforeignkeyviolation",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L321",
-      "weight": 1.0,
-      "source": "http_resourceserver_updatetransaction",
-      "target": "backend_internal_http_transactions_totransaction",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L330",
-      "weight": 1.0,
-      "source": "http_resourceserver_updatetransaction",
-      "target": "backend_internal_http_transactions_transactionnotfounderror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L271",
-      "weight": 1.0,
-      "source": "http_resourceserver_updatetransaction",
-      "target": "backend_internal_http_transactions_validatetransactioninput",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L291",
-      "weight": 1.0,
-      "source": "http_resourceserver_updatetransaction",
-      "target": "backend_internal_http_transactions_validatetransactionreferences",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L283",
-      "weight": 1.0,
-      "source": "http_resourceserver_updatetransaction",
-      "target": "http_resourceserver_allowmutation",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "context": "call",
-      "confidence": "EXTRACTED",
-      "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L330",
-      "weight": 1.0,
-      "source": "http_resourceserver_updatetransaction",
       "target": "openapi_transactionreferencenotfounderrorjsonresponse",
       "confidence_score": 1.0
     },
@@ -52866,7 +55453,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L347",
+      "source_location": "L341",
       "weight": 1.0,
       "source": "http_resourceserver_deletetransaction",
       "target": "backend_internal_http_transactions_ratelimitederror",
@@ -52877,7 +55464,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L373",
+      "source_location": "L367",
       "weight": 1.0,
       "source": "http_resourceserver_deletetransaction",
       "target": "backend_internal_http_transactions_transactionnotfounderror",
@@ -52888,7 +55475,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L346",
+      "source_location": "L340",
       "weight": 1.0,
       "source": "http_resourceserver_deletetransaction",
       "target": "http_resourceserver_allowmutation",
@@ -52898,7 +55485,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L390",
+      "source_location": "L384",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_transactions_validatetransactionreferences",
@@ -52909,7 +55496,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L390",
+      "source_location": "L384",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "backend_internal_http_transactions_validatetransactionreferences",
@@ -52920,7 +55507,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L445",
+      "source_location": "L439",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_allowmutation",
@@ -52953,7 +55540,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L445",
+      "source_location": "L439",
       "weight": 1.0,
       "context": "parameter_type",
       "source": "http_resourceserver_allowmutation",
@@ -52976,7 +55563,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L465",
+      "source_location": "L459",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_validatetransactioninput",
       "target": "backend_internal_http_transactions_parseamount",
@@ -52987,7 +55574,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L548",
+      "source_location": "L542",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_totransactionlistitem",
       "target": "backend_internal_http_transactions_textpointer",
@@ -52999,7 +55586,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L555",
+      "source_location": "L549",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_totransactionlistitem",
       "target": "openapi_currencycode"
@@ -53008,7 +55595,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L544",
+      "source_location": "L538",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_totransactionlistitem",
@@ -53030,7 +55617,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L561",
+      "source_location": "L555",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_totransaction",
@@ -53042,7 +55629,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L566",
+      "source_location": "L560",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_totransaction",
       "target": "backend_internal_http_transactions_textpointer",
@@ -53054,7 +55641,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L570",
+      "source_location": "L564",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_totransaction",
       "target": "openapi_currencycode"
@@ -53075,7 +55662,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L586",
+      "source_location": "L580",
       "weight": 1.0,
       "source": "backend_internal_http_transactions_invaliddatequeryerror",
       "target": "backend_internal_http_transactions_invalidqueryerror",
@@ -53085,7 +55672,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L585",
+      "source_location": "L579",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_invaliddatequeryerror",
@@ -53096,7 +55683,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L596",
+      "source_location": "L590",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_invalidqueryerror",
@@ -53107,7 +55694,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L602",
+      "source_location": "L596",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_transactionnotfounderror",
@@ -53118,7 +55705,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L608",
+      "source_location": "L602",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_accountreferencenotfounderror",
@@ -53140,7 +55727,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L614",
+      "source_location": "L608",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_categoryreferencenotfounderror",
@@ -53162,7 +55749,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L620",
+      "source_location": "L614",
       "weight": 1.0,
       "context": "return_type",
       "source": "backend_internal_http_transactions_ratelimitederror",
@@ -53195,7 +55782,7 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "backend/internal/http/transactions.go",
-      "source_location": "L634",
+      "source_location": "L628",
       "weight": 1.0,
       "context": "return_type",
       "source": "http_resourceserver_now",
@@ -80891,6 +83478,516 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill",
+      "target": "codex_skills_graphify_skill_graphify",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L656",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_for_graphify_add_and_watch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L644",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_for_graphify_query",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L662",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_for_the_commit_hook_and_native_claude_md_integration",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L638",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_for_update_and_cluster_only",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L668",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_honesty_rules",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L620",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_interpreter_guard_for_subcommands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_usage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_what_graphify_is_for",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_graphify",
+      "target": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_0_github_repos_and_multi_path_merge_only_if_a_url_or_several_paths",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L65",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_1_ensure_graphify_is_installed",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L144",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_2_5_video_and_audio_only_if_video_files_detected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L107",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_2_detect_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L148",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L447",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_4_5_graph_health_check_read_only_integrity_gate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L384",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_4_build_graph_cluster_analyze_generate_outputs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L473",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_5_label_communities",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L514",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_6_generate_obsidian_vault_opt_in_html",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L540",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_step_9_save_manifest_update_cost_tracker_clean_up_and_report",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L534",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_what_you_must_do_when_invoked",
+      "target": "codex_skills_graphify_skill_steps_6b_8_wiki_neo4j_falkordb_svg_graphml_mcp_benchmark_only_on_their_flags",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L167",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "target": "codex_skills_graphify_skill_part_a_structural_extraction_for_code_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L193",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "target": "codex_skills_graphify_skill_part_b_semantic_extraction_parallel_subagents",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/SKILL.md",
+      "source_location": "L350",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_skill_step_3_extract_entities_and_relationships",
+      "target": "codex_skills_graphify_skill_part_c_merge_ast_semantic_into_final_extraction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_add_watch",
+      "target": "codex_skills_graphify_references_add_watch_graphify_reference_add_a_url_and_watch_a_folder",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_add_watch_graphify_reference_add_a_url_and_watch_a_folder",
+      "target": "codex_skills_graphify_references_add_watch_for_graphify_add",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/add-watch.md",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_add_watch_graphify_reference_add_a_url_and_watch_a_folder",
+      "target": "codex_skills_graphify_references_add_watch_for_watch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports",
+      "target": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_6b_wiki_only_if_wiki_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7_neo4j_export_only_if_neo4j_or_neo4j_push_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7a_falkordb_export_only_if_falkordb_or_falkordb_push_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7b_svg_export_only_if_svg_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7c_graphml_export_only_if_graphml_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_7d_mcp_server_only_if_mcp_flag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/exports.md",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_exports_graphify_reference_extra_exports_and_benchmark",
+      "target": "codex_skills_graphify_references_exports_step_8_token_reduction_benchmark_only_if_total_words_5000",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/extraction-spec.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_extraction_spec",
+      "target": "codex_skills_graphify_references_extraction_spec_graphify_reference_extraction_subagent_prompt_compact",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_github_and_merge",
+      "target": "codex_skills_graphify_references_github_and_merge_graphify_reference_github_clone_and_cross_repo_merge",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/github-and-merge.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_github_and_merge_graphify_reference_github_clone_and_cross_repo_merge",
+      "target": "codex_skills_graphify_references_github_and_merge_step_0_clone_github_repo_s_only_if_a_github_url_was_given",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_hooks",
+      "target": "codex_skills_graphify_references_hooks_graphify_reference_commit_hook_and_native_claude_md_integration",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_hooks_graphify_reference_commit_hook_and_native_claude_md_integration",
+      "target": "codex_skills_graphify_references_hooks_for_git_commit_hook",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/hooks.md",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_hooks_graphify_reference_commit_hook_and_native_claude_md_integration",
+      "target": "codex_skills_graphify_references_hooks_for_native_claude_md_integration",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query",
+      "target": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L254",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "target": "codex_skills_graphify_references_query_for_graphify_explain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L186",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "target": "codex_skills_graphify_references_query_for_graphify_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "target": "codex_skills_graphify_references_query_step_0_constrained_query_expansion_required_before_traversal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/query.md",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_query_graphify_reference_query_path_explain",
+      "target": "codex_skills_graphify_references_query_step_1_traversal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_transcribe",
+      "target": "codex_skills_graphify_references_transcribe_graphify_reference_transcribe_video_and_audio",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/transcribe.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_transcribe_graphify_reference_transcribe_video_and_audio",
+      "target": "codex_skills_graphify_references_transcribe_step_2_5_transcribe_video_audio_files_only_if_video_files_detected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_update",
+      "target": "codex_skills_graphify_references_update_graphify_reference_incremental_update_and_cluster_only",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L184",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_update_graphify_reference_incremental_update_and_cluster_only",
+      "target": "codex_skills_graphify_references_update_for_cluster_only",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".codex/skills/graphify/references/update.md",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "codex_skills_graphify_references_update_graphify_reference_incremental_update_and_cluster_only",
+      "target": "codex_skills_graphify_references_update_for_update_incremental_re_extraction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": ".github/copilot-instructions.md",
       "source_location": "L1",
       "weight": 1.0,
@@ -82541,6 +85638,136 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "docs_api_summary",
+      "target": "docs_api_summary_summary_api_technical_reference",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "docs_product_summary",
+      "target": "docs_api_summary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_category_breakdown",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L103",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_daily_series",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_date_handling_is_shared_not_reimplemented",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L138",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_divergences_and_gaps",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L118",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_empty_state",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_four_queries_one_transaction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L63",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_percentage_change",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_the_comparison_period",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_the_operation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L129",
+      "weight": 1.0,
+      "source": "docs_api_summary_summary_api_technical_reference",
+      "target": "docs_api_summary_where_the_code_lives",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/api/summary.md",
+      "source_location": "L91",
+      "weight": 1.0,
+      "source": "docs_api_summary_category_breakdown",
+      "target": "docs_api_summary_what_the_breakdown_excludes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "docs/api/transactions.md",
       "source_location": "L1",
       "weight": 1.0,
@@ -83316,6 +86543,126 @@
       "weight": 1.0,
       "source": "docs_investigation_argentina_openbanking_summary_summary_argentina_open_banking_as_of_2026_07_10",
       "target": "docs_investigation_argentina_openbanking_summary_what_this_means_for_nuchi",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "docs_product_summary",
+      "target": "docs_product_summary_summary_product_behavior",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "docs_product_summary",
+      "target": "docs_product_transactions",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "docs_product_summary_summary_product_behavior",
+      "target": "docs_product_summary_compared_to_previous_period_means_the_period_immediately_before",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L93",
+      "weight": 1.0,
+      "source": "docs_product_summary_summary_product_behavior",
+      "target": "docs_product_summary_filtering_by_one_account",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L113",
+      "weight": 1.0,
+      "source": "docs_product_summary_summary_product_behavior",
+      "target": "docs_product_summary_related",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L54",
+      "weight": 1.0,
+      "source": "docs_product_summary_summary_product_behavior",
+      "target": "docs_product_summary_the_category_chart_does_not_add_up_to_the_expenses_total",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L83",
+      "weight": 1.0,
+      "source": "docs_product_summary_summary_product_behavior",
+      "target": "docs_product_summary_the_daily_chart_always_covers_every_day",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "docs_product_summary_summary_product_behavior",
+      "target": "docs_product_summary_the_period",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "docs_product_summary_summary_product_behavior",
+      "target": "docs_product_summary_what_the_dashboard_shows",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L100",
+      "weight": 1.0,
+      "source": "docs_product_summary_summary_product_behavior",
+      "target": "docs_product_summary_what_this_deliberately_cannot_do_yet",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "docs_product_summary_compared_to_previous_period_means_the_period_immediately_before",
+      "target": "docs_product_summary_why_a_change_can_read_100",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "docs/product/summary.md",
+      "source_location": "L74",
+      "weight": 1.0,
+      "source": "docs_product_summary_the_category_chart_does_not_add_up_to_the_expenses_total",
+      "target": "docs_product_summary_other",
       "confidence_score": 1.0
     },
     {
@@ -84702,6 +88049,16 @@
       "relation": "references",
       "confidence": "EXTRACTED",
       "source_file": "post-migration-improvements/README.md",
+      "source_location": "L110",
+      "weight": 1.0,
+      "source": "post_migration_improvements_readme",
+      "target": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/README.md",
       "source_location": "L81",
       "weight": 1.0,
       "source": "post_migration_improvements_readme",
@@ -85516,6 +88873,56 @@
       "weight": 1.0,
       "source": "post_migration_improvements_claude_backend_improvements_0016_bulk_body_limit_enforced_against_the_stream_0016_bulk_body_limits_are_enforced_against_the_stream_not_just_content_length",
       "target": "post_migration_improvements_claude_backend_improvements_0016_bulk_body_limit_enforced_against_the_stream_why_it_was_done_this_way",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized",
+      "target": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_0017_the_summary_category_chart_silently_excludes_uncategorized_spending",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_0017_the_summary_category_chart_silently_excludes_uncategorized_spending",
+      "target": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_how_it_was_migrated",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L54",
+      "weight": 1.0,
+      "source": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_0017_the_summary_category_chart_silently_excludes_uncategorized_spending",
+      "target": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_proposed_improvement",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_0017_the_summary_category_chart_silently_excludes_uncategorized_spending",
+      "target": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_the_concern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_0017_the_summary_category_chart_silently_excludes_uncategorized_spending",
+      "target": "post_migration_improvements_claude_backend_improvements_0017_summary_category_chart_excludes_uncategorized_why_it_was_done_this_way",
       "confidence_score": 1.0
     },
     {
@@ -87050,5 +90457,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "0e66a41945b4175d1b98c7a0437a07e916fc235a"
+  "built_at_commit": "79548587c06aa0c5430819480fdc67a32f2a52ab"
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1290,8 +1290,8 @@
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/README.md": {
-    "mtime": 1786214969.845413,
-    "ast_hash": "5e9b7f75a8e17501a4402d0ff838e365",
+    "mtime": 1786225371.6650388,
+    "ast_hash": "b33b56dcf8d6b414fef799eda910a380",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/templates/endpoint-review.md": {
@@ -1440,13 +1440,13 @@
     "semantic_hash": ""
   },
   "backend/internal/db/rls.go": {
-    "mtime": 1786214969.526411,
-    "ast_hash": "d23f4412ed3a5808c61deb9c75bd3ab4",
+    "mtime": 1786225371.6530662,
+    "ast_hash": "29540d53842519af5eef9a615babd767",
     "semantic_hash": ""
   },
   "backend/internal/db/rls_test.go": {
-    "mtime": 1786214969.5274143,
-    "ast_hash": "5fcce1f05bfcb7c444ed73765f063cd7",
+    "mtime": 1786225371.6620414,
+    "ast_hash": "2317e6848c26a332e84ebd714205dd9c",
     "semantic_hash": ""
   },
   "backend/internal/http/middleware.go": {
@@ -1490,8 +1490,8 @@
     "semantic_hash": ""
   },
   "backend/internal/http/resources.go": {
-    "mtime": 1786215117.8562024,
-    "ast_hash": "2ca13979328e246294e25c6a66082762",
+    "mtime": 1786225371.656041,
+    "ast_hash": "7ab7d17943063503029c78aec44b80ae",
     "semantic_hash": ""
   },
   "backend/internal/id/cuid2.go": {
@@ -1645,8 +1645,8 @@
     "semantic_hash": ""
   },
   "backend/internal/http/summary.go": {
-    "mtime": 1786215095.7123916,
-    "ast_hash": "88ce2cc730a72c4def430a7e90fa81a7",
+    "mtime": 1786225371.658042,
+    "ast_hash": "43f2c2e67fb07e9515e2b70971870219",
     "semantic_hash": ""
   },
   "backend/internal/http/summary_live_test.go": {
@@ -1655,13 +1655,13 @@
     "semantic_hash": ""
   },
   "backend/internal/http/summary_test.go": {
-    "mtime": 1786215170.968572,
-    "ast_hash": "716c6b1784be861857e6d3f5f188c2a5",
+    "mtime": 1786225371.6610458,
+    "ast_hash": "e5639031f7f54f7d31f1c37737cb7918",
     "semantic_hash": ""
   },
   "docs/api/summary.md": {
-    "mtime": 1786215353.5857306,
-    "ast_hash": "5fc2c165d324d553d9696230030a550b",
+    "mtime": 1786225371.6640372,
+    "ast_hash": "cd0a7de76d9ea453399f49acded6ce2f",
     "semantic_hash": ""
   },
   "docs/product/summary.md": {
@@ -1672,6 +1672,11 @@
   "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md": {
     "mtime": 1786215314.1706123,
     "ast_hash": "8865d4bd33388ddb388fd79ca8bce0ea",
+    "semantic_hash": ""
+  },
+  "post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md": {
+    "mtime": 1786225371.666049,
+    "ast_hash": "929d06b984521e71934380d078b06617",
     "semantic_hash": ""
   }
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,1652 +1,1677 @@
 {
   ".vscode/extensions.json": {
-    "mtime": 1783698026.630728,
+    "mtime": 1786214969.4324071,
     "ast_hash": "36e6640c0f3f8502e74aa2519e650e2e",
     "semantic_hash": "36e6640c0f3f8502e74aa2519e650e2e"
   },
   ".vscode/mcp.json": {
-    "mtime": 1783698026.6317263,
+    "mtime": 1786214969.4334106,
     "ast_hash": "46382058c9547d789e39f5fece62198d",
     "semantic_hash": "46382058c9547d789e39f5fece62198d"
   },
   ".vscode/settings.json": {
-    "mtime": 1783698026.6317263,
+    "mtime": 1786214969.4344144,
     "ast_hash": "9e961d3a67aa59bbf1f99ac1c99aa470",
     "semantic_hash": "9e961d3a67aa59bbf1f99ac1c99aa470"
   },
   "app/(auth)/sign-in/[[...sign-in]]/page.tsx": {
-    "mtime": 1783698026.6407292,
+    "mtime": 1786214969.4464104,
     "ast_hash": "c68779d3caf55983d25cd75574d5a176",
     "semantic_hash": "c68779d3caf55983d25cd75574d5a176"
   },
   "app/(auth)/sign-up/[[...sign-up]]/page.tsx": {
-    "mtime": 1783698026.6427307,
+    "mtime": 1786214969.448408,
     "ast_hash": "15042e883d27c10bae944ec6afc2daae",
     "semantic_hash": "15042e883d27c10bae944ec6afc2daae"
   },
   "app/(dashboard)/accounts/actions.tsx": {
-    "mtime": 1783698026.6437268,
+    "mtime": 1786214969.4514165,
     "ast_hash": "315e74a734d2f6f4799f9f8d1ce71495",
     "semantic_hash": "315e74a734d2f6f4799f9f8d1ce71495"
   },
   "app/(dashboard)/accounts/columns.tsx": {
-    "mtime": 1783698026.644727,
+    "mtime": 1786214969.4524078,
     "ast_hash": "98d37b4022593adcc2565fe5c2c85a06",
     "semantic_hash": "98d37b4022593adcc2565fe5c2c85a06"
   },
   "app/(dashboard)/accounts/page.tsx": {
-    "mtime": 1783698026.645727,
+    "mtime": 1786214969.4534152,
     "ast_hash": "ad0e1c443c11d0de7b68f61e91a15fa5",
     "semantic_hash": "ad0e1c443c11d0de7b68f61e91a15fa5"
   },
   "app/(dashboard)/categories/actions.tsx": {
-    "mtime": 1783698026.6467257,
+    "mtime": 1786214969.454409,
     "ast_hash": "4f61a34a890d7c56f7c257dd598317f7",
     "semantic_hash": "4f61a34a890d7c56f7c257dd598317f7"
   },
   "app/(dashboard)/categories/columns.tsx": {
-    "mtime": 1783698026.6477234,
+    "mtime": 1786214969.4554107,
     "ast_hash": "4227909a5834e47ccc8ee94359f2324e",
     "semantic_hash": "4227909a5834e47ccc8ee94359f2324e"
   },
   "app/(dashboard)/categories/page.tsx": {
-    "mtime": 1783698026.6477234,
+    "mtime": 1786214969.4564126,
     "ast_hash": "136e925c29f9dc6e9f8c38d0e9f9f438",
     "semantic_hash": "136e925c29f9dc6e9f8c38d0e9f9f438"
   },
   "app/(dashboard)/layout.tsx": {
-    "mtime": 1783698026.6487267,
+    "mtime": 1786214969.4574094,
     "ast_hash": "63185be01318f280f5ebc9c035de9135",
     "semantic_hash": "63185be01318f280f5ebc9c035de9135"
   },
   "app/(dashboard)/page.tsx": {
-    "mtime": 1783698026.6497252,
+    "mtime": 1786214969.458405,
     "ast_hash": "188c4550eb09cf168857ab186acfb957",
     "semantic_hash": "188c4550eb09cf168857ab186acfb957"
   },
   "app/(dashboard)/transactions/account-column.tsx": {
-    "mtime": 1783698026.6507232,
+    "mtime": 1786214969.4604099,
     "ast_hash": "e40922b1e8dc2d6bea4713b579426f4f",
     "semantic_hash": "e40922b1e8dc2d6bea4713b579426f4f"
   },
   "app/(dashboard)/transactions/actions.tsx": {
-    "mtime": 1783698026.6507232,
+    "mtime": 1786214969.4604099,
     "ast_hash": "e4e9879ebb0fbfa27c4707cc670bf44e",
     "semantic_hash": "e4e9879ebb0fbfa27c4707cc670bf44e"
   },
   "app/(dashboard)/transactions/category-column.tsx": {
-    "mtime": 1783698026.651726,
+    "mtime": 1786214969.4624124,
     "ast_hash": "eb23c51dff5efdc39b32575e4e3f1e8e",
     "semantic_hash": "eb23c51dff5efdc39b32575e4e3f1e8e"
   },
   "app/(dashboard)/transactions/columns.tsx": {
-    "mtime": 1783698026.6527295,
+    "mtime": 1786214969.4634118,
     "ast_hash": "0b8a1678cdf61fe69a3ed89160ac7e4c",
     "semantic_hash": "0b8a1678cdf61fe69a3ed89160ac7e4c"
   },
   "app/(dashboard)/transactions/import-card.tsx": {
-    "mtime": 1783698026.6537251,
+    "mtime": 1786214969.4644103,
     "ast_hash": "ebaad9a52017562b95b4149b7982adcc",
     "semantic_hash": "ebaad9a52017562b95b4149b7982adcc"
   },
   "app/(dashboard)/transactions/import-table.tsx": {
-    "mtime": 1783698026.6537251,
+    "mtime": 1786214969.4654176,
     "ast_hash": "b79716f109add1c0e70637507fe18464",
     "semantic_hash": "b79716f109add1c0e70637507fe18464"
   },
   "app/(dashboard)/transactions/page.tsx": {
-    "mtime": 1783698026.654728,
+    "mtime": 1786214969.466414,
     "ast_hash": "f2ca714712848388fb77c24390c04d35",
     "semantic_hash": "f2ca714712848388fb77c24390c04d35"
   },
   "app/(dashboard)/transactions/table-head-select.tsx": {
-    "mtime": 1783698026.654728,
+    "mtime": 1786214969.467417,
     "ast_hash": "99f36d8c45e1cffb94510d1241aa3e83",
     "semantic_hash": "99f36d8c45e1cffb94510d1241aa3e83"
   },
   "app/(dashboard)/transactions/upload-button.tsx": {
-    "mtime": 1783698026.655726,
+    "mtime": 1786214969.4684143,
     "ast_hash": "5e7894f75af604d220a426d1f0a8d0c8",
     "semantic_hash": "5e7894f75af604d220a426d1f0a8d0c8"
   },
   "app/api/[[...route]]/accounts.ts": {
-    "mtime": 1783698026.6577241,
+    "mtime": 1786214969.471416,
     "ast_hash": "2afcc4966311b4727d4bf9bbd7dfb8e5",
     "semantic_hash": "2afcc4966311b4727d4bf9bbd7dfb8e5"
   },
   "app/api/[[...route]]/categories.ts": {
-    "mtime": 1783698026.6577241,
+    "mtime": 1786214969.4724143,
     "ast_hash": "f3f3cfd4da3d4a2e03041ffe3a024cb0",
     "semantic_hash": "f3f3cfd4da3d4a2e03041ffe3a024cb0"
   },
   "app/api/[[...route]]/route.ts": {
-    "mtime": 1783698026.6587255,
+    "mtime": 1786214969.4734144,
     "ast_hash": "2b8fd8e03b9195350f20f8e36c22a236",
     "semantic_hash": "2b8fd8e03b9195350f20f8e36c22a236"
   },
   "app/api/[[...route]]/summary.ts": {
-    "mtime": 1783698026.6597254,
+    "mtime": 1786214969.4734144,
     "ast_hash": "52c363ad2d7c4b5079404d1b1964c998",
     "semantic_hash": "52c363ad2d7c4b5079404d1b1964c998"
   },
   "app/api/[[...route]]/transactions.ts": {
-    "mtime": 1783698026.6607246,
+    "mtime": 1786214969.4784107,
     "ast_hash": "9a4bdd8c6c8f3a5f1909dcf1c0b8c198",
     "semantic_hash": "9a4bdd8c6c8f3a5f1909dcf1c0b8c198"
   },
   "app/layout.tsx": {
-    "mtime": 1783698026.6637259,
+    "mtime": 1786214969.4824102,
     "ast_hash": "a974b84f869ed5e86967fc377f86a12a",
     "semantic_hash": "a974b84f869ed5e86967fc377f86a12a"
   },
   "backend/cmd/api/main.go": {
-    "mtime": 1785295957.359138,
+    "mtime": 1786214969.486409,
     "ast_hash": "fdd65ecf4e7f6764ee09d299eb21b888",
     "semantic_hash": ""
   },
   "backend/internal/config/config.go": {
-    "mtime": 1784664178.1085217,
+    "mtime": 1786214969.497412,
     "ast_hash": "8203cf0cfcc9b075241d7119822d6dc8",
     "semantic_hash": ""
   },
   "backend/internal/http/health.go": {
-    "mtime": 1783698026.6697252,
+    "mtime": 1786214969.543412,
     "ast_hash": "892e87794a60999e03ab630f9a141593",
     "semantic_hash": "892e87794a60999e03ab630f9a141593"
   },
   "backend/internal/http/health_test.go": {
-    "mtime": 1785295957.3716817,
+    "mtime": 1786214969.5444076,
     "ast_hash": "5091a1d5eb5dc4a745ef1c69f66fbfc4",
     "semantic_hash": ""
   },
   "backend/internal/http/router.go": {
-    "mtime": 1786205675.6146598,
-    "ast_hash": "09119246c2b4cda3539dd84202b01b41",
+    "mtime": 1786215117.850887,
+    "ast_hash": "080c481dba6ef4eda5e6684dcc408c64",
     "semantic_hash": ""
   },
   "components.json": {
-    "mtime": 1783698026.67873,
+    "mtime": 1786214969.586409,
     "ast_hash": "6d9018deb951297f49f351aac49c68a6",
     "semantic_hash": "6d9018deb951297f49f351aac49c68a6"
   },
   "components/account-filter.tsx": {
-    "mtime": 1783698026.679726,
+    "mtime": 1786214969.588413,
     "ast_hash": "c59551b47fd3183b6d8ff63f3188463b",
     "semantic_hash": "c59551b47fd3183b6d8ff63f3188463b"
   },
   "components/amount-input.tsx": {
-    "mtime": 1783698026.679726,
+    "mtime": 1786214969.589412,
     "ast_hash": "adcce293adc9b9056aed727a8ffd4e8b",
     "semantic_hash": "adcce293adc9b9056aed727a8ffd4e8b"
   },
   "components/area-variant.tsx": {
-    "mtime": 1783698026.680729,
+    "mtime": 1786214969.5914133,
     "ast_hash": "17d74c83f1b3d6f23b97bfbb20e08932",
     "semantic_hash": "17d74c83f1b3d6f23b97bfbb20e08932"
   },
   "components/bar-variant.tsx": {
-    "mtime": 1783698026.681727,
+    "mtime": 1786214969.5924094,
     "ast_hash": "0eefeafb7c7739d167a65a14f5a8065d",
     "semantic_hash": "0eefeafb7c7739d167a65a14f5a8065d"
   },
   "components/category-tooltip.tsx": {
-    "mtime": 1783698026.682728,
+    "mtime": 1786214969.5934105,
     "ast_hash": "78c4faf727e238549c68f52115b5e113",
     "semantic_hash": "78c4faf727e238549c68f52115b5e113"
   },
   "components/chart.tsx": {
-    "mtime": 1783698026.682728,
+    "mtime": 1786214969.5944097,
     "ast_hash": "74d6516a8d4331be3c1de2f5546f02c8",
     "semantic_hash": "74d6516a8d4331be3c1de2f5546f02c8"
   },
   "components/count-up.tsx": {
-    "mtime": 1783698026.683727,
+    "mtime": 1786214969.5954113,
     "ast_hash": "2a5e30686c2508ea1297d07290e8ab0a",
     "semantic_hash": "2a5e30686c2508ea1297d07290e8ab0a"
   },
   "components/custom-tooltip.tsx": {
-    "mtime": 1783698026.683727,
+    "mtime": 1786214969.596416,
     "ast_hash": "6ff4eadd897894c15b30eb3cf1814af6",
     "semantic_hash": "6ff4eadd897894c15b30eb3cf1814af6"
   },
   "components/data-card.tsx": {
-    "mtime": 1783698026.6847284,
+    "mtime": 1786214969.597409,
     "ast_hash": "2321ab5ad86822aa6ab8f2e187b7a03b",
     "semantic_hash": "2321ab5ad86822aa6ab8f2e187b7a03b"
   },
   "components/data-charts.tsx": {
-    "mtime": 1783698026.6847284,
+    "mtime": 1786214969.5984092,
     "ast_hash": "9d25bd8d4050d3a5852454fdd29d8075",
     "semantic_hash": "9d25bd8d4050d3a5852454fdd29d8075"
   },
   "components/data-grid.tsx": {
-    "mtime": 1783698026.6857238,
+    "mtime": 1786214969.5994115,
     "ast_hash": "60a5989035455640e62801b3f63338d5",
     "semantic_hash": "60a5989035455640e62801b3f63338d5"
   },
   "components/data-table.tsx": {
-    "mtime": 1783698026.6867247,
+    "mtime": 1786214969.6004117,
     "ast_hash": "0036603ad3c39c45593f5023a22e28e6",
     "semantic_hash": "0036603ad3c39c45593f5023a22e28e6"
   },
   "components/date-filter.tsx": {
-    "mtime": 1783698026.6867247,
+    "mtime": 1786214969.6014123,
     "ast_hash": "a9244f433aa9208513f183234d3f3520",
     "semantic_hash": "a9244f433aa9208513f183234d3f3520"
   },
   "components/date-picker.tsx": {
-    "mtime": 1783698026.6877248,
+    "mtime": 1786214969.602413,
     "ast_hash": "ed84ded8b671ffd9ad60272f9d11c00d",
     "semantic_hash": "ed84ded8b671ffd9ad60272f9d11c00d"
   },
   "components/filters.tsx": {
-    "mtime": 1783698026.6877248,
+    "mtime": 1786214969.6034124,
     "ast_hash": "e75b50e83846dba53c1898763595d123",
     "semantic_hash": "e75b50e83846dba53c1898763595d123"
   },
   "components/header-logo.tsx": {
-    "mtime": 1783698026.688725,
+    "mtime": 1786214969.6034124,
     "ast_hash": "c46ab98f0bacb4de80cf4edb4c615abd",
     "semantic_hash": "c46ab98f0bacb4de80cf4edb4c615abd"
   },
   "components/header.tsx": {
-    "mtime": 1783698026.6897311,
+    "mtime": 1786214969.6044104,
     "ast_hash": "7802b7fd1726fea6aa089a9250fdffde",
     "semantic_hash": "7802b7fd1726fea6aa089a9250fdffde"
   },
   "components/line-variant.tsx": {
-    "mtime": 1783698026.6897311,
+    "mtime": 1786214969.6054187,
     "ast_hash": "8dc9ece9d612703a75f566706708ba2b",
     "semantic_hash": "8dc9ece9d612703a75f566706708ba2b"
   },
   "components/nav-button.tsx": {
-    "mtime": 1783698026.6907363,
+    "mtime": 1786214969.6064134,
     "ast_hash": "b2c4d52348074882daa31c134d88b2d8",
     "semantic_hash": "b2c4d52348074882daa31c134d88b2d8"
   },
   "components/navigation.tsx": {
-    "mtime": 1783698026.6918538,
+    "mtime": 1786214969.6074085,
     "ast_hash": "997f8a982058f5412d757a788d9516d9",
     "semantic_hash": "997f8a982058f5412d757a788d9516d9"
   },
   "components/pie-variant.tsx": {
-    "mtime": 1783698026.6927245,
+    "mtime": 1786214969.6084065,
     "ast_hash": "7569854c8d21bf9c912c37ffee6e7b2c",
     "semantic_hash": "7569854c8d21bf9c912c37ffee6e7b2c"
   },
   "components/radar-variant.tsx": {
-    "mtime": 1783698026.6937232,
+    "mtime": 1786214969.6094084,
     "ast_hash": "f88facb25684dc4cb57a53d88d2f2b2d",
     "semantic_hash": "f88facb25684dc4cb57a53d88d2f2b2d"
   },
   "components/radial-variant.tsx": {
-    "mtime": 1783698026.6937232,
+    "mtime": 1786214969.6104064,
     "ast_hash": "b7ae0721877e097af9c60f51ee8c5d53",
     "semantic_hash": "b7ae0721877e097af9c60f51ee8c5d53"
   },
   "components/select.tsx": {
-    "mtime": 1783698026.6947315,
+    "mtime": 1786214969.6114109,
     "ast_hash": "ec40de40d9c2ebac1f51fc91cc26482a",
     "semantic_hash": "ec40de40d9c2ebac1f51fc91cc26482a"
   },
   "components/spending-pie.tsx": {
-    "mtime": 1783698026.6957326,
+    "mtime": 1786214969.612413,
     "ast_hash": "d84612a66f0575ca30483841e3f1ace0",
     "semantic_hash": "d84612a66f0575ca30483841e3f1ace0"
   },
   "components/ui/badge.tsx": {
-    "mtime": 1783698026.6967292,
+    "mtime": 1786214969.6144116,
     "ast_hash": "4dbaeb29689b069d2b5c29e4403c22ed",
     "semantic_hash": "4dbaeb29689b069d2b5c29e4403c22ed"
   },
   "components/ui/button.tsx": {
-    "mtime": 1783698026.6967292,
+    "mtime": 1786214969.6154118,
     "ast_hash": "c146cd1d6f1e0d54e4a7bb5f15a0834b",
     "semantic_hash": "c146cd1d6f1e0d54e4a7bb5f15a0834b"
   },
   "components/ui/calendar.tsx": {
-    "mtime": 1783698026.6977258,
+    "mtime": 1786214969.6164112,
     "ast_hash": "5d3fb01c5e7002fb7d8a3a9b7eb490da",
     "semantic_hash": "5d3fb01c5e7002fb7d8a3a9b7eb490da"
   },
   "components/ui/card.tsx": {
-    "mtime": 1783698026.6987243,
+    "mtime": 1786214969.617416,
     "ast_hash": "a6752f4d1da504c7f03196d90cde4b2c",
     "semantic_hash": "a6752f4d1da504c7f03196d90cde4b2c"
   },
   "components/ui/checkbox.tsx": {
-    "mtime": 1783698026.6987243,
+    "mtime": 1786214969.618409,
     "ast_hash": "a6f8a3a1887026cb83a784484e17fea5",
     "semantic_hash": "a6f8a3a1887026cb83a784484e17fea5"
   },
   "components/ui/dialog.tsx": {
-    "mtime": 1783698026.699728,
+    "mtime": 1786214969.6194148,
     "ast_hash": "f1a1f40caa86d72f9863b966b4f61c54",
     "semantic_hash": "f1a1f40caa86d72f9863b966b4f61c54"
   },
   "components/ui/dropdown-menu.tsx": {
-    "mtime": 1783698026.7007246,
+    "mtime": 1786214969.620411,
     "ast_hash": "4d34f2b82c3880388c0eda72d38365dc",
     "semantic_hash": "4d34f2b82c3880388c0eda72d38365dc"
   },
   "components/ui/form.tsx": {
-    "mtime": 1783698026.7017264,
+    "mtime": 1786214969.6214163,
     "ast_hash": "cc761fa32f15b47f7cacf623f48b115f",
     "semantic_hash": "cc761fa32f15b47f7cacf623f48b115f"
   },
   "components/ui/input.tsx": {
-    "mtime": 1783698026.7017264,
+    "mtime": 1786214969.6224134,
     "ast_hash": "6666f8369b53c79d39be8060dc6c4ce5",
     "semantic_hash": "6666f8369b53c79d39be8060dc6c4ce5"
   },
   "components/ui/label.tsx": {
-    "mtime": 1783698026.7027252,
+    "mtime": 1786214969.6234124,
     "ast_hash": "14f124762142b39a666ce10d3b42d28c",
     "semantic_hash": "14f124762142b39a666ce10d3b42d28c"
   },
   "components/ui/popover.tsx": {
-    "mtime": 1783698026.7037253,
+    "mtime": 1786214969.6244092,
     "ast_hash": "ccb677b4322e7cde381fd479f6b6ec3d",
     "semantic_hash": "ccb677b4322e7cde381fd479f6b6ec3d"
   },
   "components/ui/select.tsx": {
-    "mtime": 1783698026.7037253,
+    "mtime": 1786214969.625414,
     "ast_hash": "57eeee9dc97be258532e1a2242f6052a",
     "semantic_hash": "57eeee9dc97be258532e1a2242f6052a"
   },
   "components/ui/separator.tsx": {
-    "mtime": 1783698026.7047248,
+    "mtime": 1786214969.6264148,
     "ast_hash": "a27e39c797c6856cf5843b7b84d81cff",
     "semantic_hash": "a27e39c797c6856cf5843b7b84d81cff"
   },
   "components/ui/sheet.tsx": {
-    "mtime": 1783698026.7057245,
+    "mtime": 1786214969.628412,
     "ast_hash": "0fe0e7acf5cf19ddc3b138c1ed249ca3",
     "semantic_hash": "0fe0e7acf5cf19ddc3b138c1ed249ca3"
   },
   "components/ui/skeleton.tsx": {
-    "mtime": 1783698026.7077246,
+    "mtime": 1786214969.6294117,
     "ast_hash": "ee5017bac14efeda715feaceb488382a",
     "semantic_hash": "ee5017bac14efeda715feaceb488382a"
   },
   "components/ui/sonner.tsx": {
-    "mtime": 1783698026.7087278,
+    "mtime": 1786214969.631409,
     "ast_hash": "5dde0d04f3ecf6b5e812104aca12c546",
     "semantic_hash": "5dde0d04f3ecf6b5e812104aca12c546"
   },
   "components/ui/table.tsx": {
-    "mtime": 1783698026.7097285,
+    "mtime": 1786214969.6324153,
     "ast_hash": "294d03324937ba75b77ad45ca31a0770",
     "semantic_hash": "294d03324937ba75b77ad45ca31a0770"
   },
   "components/ui/textarea.tsx": {
-    "mtime": 1783698026.7097285,
+    "mtime": 1786214969.6324153,
     "ast_hash": "04f9af2a78672f7018b16db2bcec5036",
     "semantic_hash": "04f9af2a78672f7018b16db2bcec5036"
   },
   "components/ui/tooltip.tsx": {
-    "mtime": 1783698026.7107282,
+    "mtime": 1786214969.6344137,
     "ast_hash": "17aeef2e263039ea21914a51d71e290f",
     "semantic_hash": "17aeef2e263039ea21914a51d71e290f"
   },
   "components/ui/visually-hidden.tsx": {
-    "mtime": 1783698026.7117264,
+    "mtime": 1786214969.6354134,
     "ast_hash": "fccdf5ff7ac1a80fa0092ebbeccae487",
     "semantic_hash": "fccdf5ff7ac1a80fa0092ebbeccae487"
   },
   "components/welcome-msg.tsx": {
-    "mtime": 1783698026.712728,
+    "mtime": 1786214969.6364157,
     "ast_hash": "eae01daa519d10611ce285e97ec0b88c",
     "semantic_hash": "eae01daa519d10611ce285e97ec0b88c"
   },
   "db/connection.test.ts": {
-    "mtime": 1783698026.713726,
+    "mtime": 1786214969.6394112,
     "ast_hash": "795511b3f6d89d418a6c83cae9f00436",
     "semantic_hash": "795511b3f6d89d418a6c83cae9f00436"
   },
   "db/connection.ts": {
-    "mtime": 1783698026.713726,
+    "mtime": 1786214969.6404157,
     "ast_hash": "0a76c321e21b4cd0e497be9a4927574f",
     "semantic_hash": "0a76c321e21b4cd0e497be9a4927574f"
   },
   "db/drizzle.ts": {
-    "mtime": 1783698026.7147307,
+    "mtime": 1786214969.6424105,
     "ast_hash": "231c8d06860dc3b91a8736ed7018f6be",
     "semantic_hash": "231c8d06860dc3b91a8736ed7018f6be"
   },
   "db/schema.ts": {
-    "mtime": 1785382046.1930807,
+    "mtime": 1786214969.6434097,
     "ast_hash": "f882f0444652131c2a9d72dd8db58065",
     "semantic_hash": ""
   },
   "drizzle.config.ts": {
-    "mtime": 1783698026.7217247,
+    "mtime": 1786214969.66841,
     "ast_hash": "e943f9e498a9323436e5e17709e05fed",
     "semantic_hash": "e943f9e498a9323436e5e17709e05fed"
   },
   "drizzle/0000_optimal_luckman.sql": {
-    "mtime": 1783698026.7227278,
+    "mtime": 1786214969.6704106,
     "ast_hash": "bd2145027d2bbbc98d26731f1226a1c7",
     "semantic_hash": "bd2145027d2bbbc98d26731f1226a1c7"
   },
   "drizzle/0001_swift_arclight.sql": {
-    "mtime": 1783698026.7237337,
+    "mtime": 1786214969.6704106,
     "ast_hash": "967fb21d10f6e12a1f6fc3dcbc877c60",
     "semantic_hash": "967fb21d10f6e12a1f6fc3dcbc877c60"
   },
   "drizzle/0002_fantastic_puff_adder.sql": {
-    "mtime": 1783698026.724724,
+    "mtime": 1786214969.6714125,
     "ast_hash": "cd4b63737426b98becafe6ff3a6d75ef",
     "semantic_hash": "cd4b63737426b98becafe6ff3a6d75ef"
   },
   "drizzle/0003_rich_clea.sql": {
-    "mtime": 1783698026.72573,
+    "mtime": 1786214969.6724067,
     "ast_hash": "d7bc04fb4b92ff8699c9825a20f4a06e",
     "semantic_hash": "d7bc04fb4b92ff8699c9825a20f4a06e"
   },
   "drizzle/0004_dazzling_changeling.sql": {
-    "mtime": 1783698026.7267325,
+    "mtime": 1786214969.6734135,
     "ast_hash": "5bfc6634def7305187ce73ca331e6ee9",
     "semantic_hash": "5bfc6634def7305187ce73ca331e6ee9"
   },
   "drizzle/0005_square_grey_gargoyle.sql": {
-    "mtime": 1783698026.7267325,
+    "mtime": 1786214969.6744149,
     "ast_hash": "b89b8036526aa7ac1e176b4eb5e94daa",
     "semantic_hash": "b89b8036526aa7ac1e176b4eb5e94daa"
   },
   "drizzle/0006_melted_supernaut.sql": {
-    "mtime": 1783698026.7277303,
+    "mtime": 1786214969.6754115,
     "ast_hash": "42c949a692333a0e9a172a1b6806a951",
     "semantic_hash": "42c949a692333a0e9a172a1b6806a951"
   },
   "drizzle/0007_modern_virginia_dare.sql": {
-    "mtime": 1783698026.7277303,
+    "mtime": 1786214969.67641,
     "ast_hash": "2c346ad11dcffe8d5df1960242faf954",
     "semantic_hash": "2c346ad11dcffe8d5df1960242faf954"
   },
   "drizzle/meta/0000_snapshot.json": {
-    "mtime": 1783698026.7297313,
+    "mtime": 1786214969.6784124,
     "ast_hash": "758d52119d2e618c6f6a94e5b67dc2e3",
     "semantic_hash": "758d52119d2e618c6f6a94e5b67dc2e3"
   },
   "drizzle/meta/0001_snapshot.json": {
-    "mtime": 1783698026.7297313,
+    "mtime": 1786214969.6794126,
     "ast_hash": "bc4b3d07d564bb41f9cc45d4f0dad487",
     "semantic_hash": "bc4b3d07d564bb41f9cc45d4f0dad487"
   },
   "drizzle/meta/0002_snapshot.json": {
-    "mtime": 1783698026.7317283,
+    "mtime": 1786214969.681408,
     "ast_hash": "36372ab5b284c91ff60fd2f28d0292e3",
     "semantic_hash": "36372ab5b284c91ff60fd2f28d0292e3"
   },
   "drizzle/meta/0003_snapshot.json": {
-    "mtime": 1783698026.732726,
+    "mtime": 1786214969.6824186,
     "ast_hash": "cf0a270eed48ec3418d3da247b953162",
     "semantic_hash": "cf0a270eed48ec3418d3da247b953162"
   },
   "drizzle/meta/0004_snapshot.json": {
-    "mtime": 1783698026.732726,
+    "mtime": 1786214969.683415,
     "ast_hash": "97ffb3bda68144cf4192026240f80d8d",
     "semantic_hash": "97ffb3bda68144cf4192026240f80d8d"
   },
   "drizzle/meta/0005_snapshot.json": {
-    "mtime": 1783698026.733726,
+    "mtime": 1786214969.684411,
     "ast_hash": "84f8238dc35bc960c5a48b909e4dad08",
     "semantic_hash": "84f8238dc35bc960c5a48b909e4dad08"
   },
   "drizzle/meta/0006_snapshot.json": {
-    "mtime": 1783698026.7347307,
+    "mtime": 1786214969.6854117,
     "ast_hash": "a4db910e41810f476ded9eb06dc6d37f",
     "semantic_hash": "a4db910e41810f476ded9eb06dc6d37f"
   },
   "drizzle/meta/0007_snapshot.json": {
-    "mtime": 1783698026.7347307,
+    "mtime": 1786214969.68641,
     "ast_hash": "b6a5ba0ed99498dc0f661aa193e023a2",
     "semantic_hash": "b6a5ba0ed99498dc0f661aa193e023a2"
   },
   "drizzle/meta/_journal.json": {
-    "mtime": 1783698026.7357252,
+    "mtime": 1786214969.6874106,
     "ast_hash": "637181a5a2a3b22a9bedbc518f5da57b",
     "semantic_hash": "637181a5a2a3b22a9bedbc518f5da57b"
   },
   "eslint.config.mjs": {
-    "mtime": 1783698026.7367315,
+    "mtime": 1786214969.6884098,
     "ast_hash": "340888b6e27069429228a613a145a858",
     "semantic_hash": "340888b6e27069429228a613a145a858"
   },
   "features/accounts/api/use-bulk-delete-accounts.ts": {
-    "mtime": 1783698026.738732,
+    "mtime": 1786214969.6914127,
     "ast_hash": "9f506b412d13313aea175b88fbebf566",
     "semantic_hash": "9f506b412d13313aea175b88fbebf566"
   },
   "features/accounts/api/use-create-account.ts": {
-    "mtime": 1783698026.73973,
+    "mtime": 1786214969.6924102,
     "ast_hash": "19a27cff878cdfe1049ec38490522315",
     "semantic_hash": "19a27cff878cdfe1049ec38490522315"
   },
   "features/accounts/api/use-delete-account.ts": {
-    "mtime": 1783698026.7427294,
+    "mtime": 1786214969.6934104,
     "ast_hash": "012dc8f6db0a1d1f1e27bfe5fe82d72f",
     "semantic_hash": "012dc8f6db0a1d1f1e27bfe5fe82d72f"
   },
   "features/accounts/api/use-edit-account.ts": {
-    "mtime": 1783698026.7427294,
+    "mtime": 1786214969.694412,
     "ast_hash": "5d30fa3abf5adae66613a0c5ec66466a",
     "semantic_hash": "5d30fa3abf5adae66613a0c5ec66466a"
   },
   "features/accounts/api/use-get-account.ts": {
-    "mtime": 1783698026.7437315,
+    "mtime": 1786214969.6954114,
     "ast_hash": "6958e1f2e321f36e7016177e4cc3832a",
     "semantic_hash": "6958e1f2e321f36e7016177e4cc3832a"
   },
   "features/accounts/api/use-get-accounts.ts": {
-    "mtime": 1783698026.7447295,
+    "mtime": 1786214969.6964107,
     "ast_hash": "45579b5c52f7712b855b0c7cff89e5f8",
     "semantic_hash": "45579b5c52f7712b855b0c7cff89e5f8"
   },
   "features/accounts/components/account-form.tsx": {
-    "mtime": 1783698026.7457252,
+    "mtime": 1786214969.6984138,
     "ast_hash": "9fe855c98f49152c7fd3602a4727445f",
     "semantic_hash": "9fe855c98f49152c7fd3602a4727445f"
   },
   "features/accounts/components/edit-account-sheet.tsx": {
-    "mtime": 1783698026.7467346,
+    "mtime": 1786214969.6994114,
     "ast_hash": "903cbf5c453ad80f619e815d47f05528",
     "semantic_hash": "903cbf5c453ad80f619e815d47f05528"
   },
   "features/accounts/components/new-account-sheet.tsx": {
-    "mtime": 1783698026.7467346,
+    "mtime": 1786214969.701408,
     "ast_hash": "f5a1d9a155604c8b8d58153f47a71624",
     "semantic_hash": "f5a1d9a155604c8b8d58153f47a71624"
   },
   "features/accounts/hooks/use-new-account.ts": {
-    "mtime": 1783698026.7487342,
+    "mtime": 1786214969.7034082,
     "ast_hash": "fb1670915c9440350ceb21ae6cca2cc0",
     "semantic_hash": "fb1670915c9440350ceb21ae6cca2cc0"
   },
   "features/accounts/hooks/use-open-account.ts": {
-    "mtime": 1783698026.7487342,
+    "mtime": 1786214969.7044127,
     "ast_hash": "98bee9f77378a9ec8e38647c9e32ebb5",
     "semantic_hash": "98bee9f77378a9ec8e38647c9e32ebb5"
   },
   "features/accounts/hooks/use-select-account.tsx": {
-    "mtime": 1783698026.749732,
+    "mtime": 1786214969.7054079,
     "ast_hash": "c055cdf0090e8ea14e5c17f3d8d64ac5",
     "semantic_hash": "c055cdf0090e8ea14e5c17f3d8d64ac5"
   },
   "features/categories/api/use-bulk-delete-categories.ts": {
-    "mtime": 1783698026.75173,
+    "mtime": 1786214969.707411,
     "ast_hash": "6c35e3f92077b6b90e9f81c107ee1106",
     "semantic_hash": "6c35e3f92077b6b90e9f81c107ee1106"
   },
   "features/categories/api/use-create-category.ts": {
-    "mtime": 1783698026.75173,
+    "mtime": 1786214969.7084131,
     "ast_hash": "934a542997766c5f9d92ad50e0949f11",
     "semantic_hash": "934a542997766c5f9d92ad50e0949f11"
   },
   "features/categories/api/use-delete-category.ts": {
-    "mtime": 1783698026.7537296,
+    "mtime": 1786214969.7104115,
     "ast_hash": "8fb473fe2293d8426d5170978daef45f",
     "semantic_hash": "8fb473fe2293d8426d5170978daef45f"
   },
   "features/categories/api/use-edit-category.ts": {
-    "mtime": 1783698026.754728,
+    "mtime": 1786214969.7114084,
     "ast_hash": "acd026b34c1bc7d7699a62938631d000",
     "semantic_hash": "acd026b34c1bc7d7699a62938631d000"
   },
   "features/categories/api/use-get-categories.ts": {
-    "mtime": 1783698026.754728,
+    "mtime": 1786214969.712418,
     "ast_hash": "a754c910faddd7056fd7d0aae8580296",
     "semantic_hash": "a754c910faddd7056fd7d0aae8580296"
   },
   "features/categories/api/use-get-category.ts": {
-    "mtime": 1783698026.75573,
+    "mtime": 1786214969.7134063,
     "ast_hash": "e487a09f03820a988f1fba7af46efd9b",
     "semantic_hash": "e487a09f03820a988f1fba7af46efd9b"
   },
   "features/categories/components/category-form.tsx": {
-    "mtime": 1783698026.7579055,
+    "mtime": 1786214969.714414,
     "ast_hash": "fab3b1ee581c6a7a3bc11777fbfa44cb",
     "semantic_hash": "fab3b1ee581c6a7a3bc11777fbfa44cb"
   },
   "features/categories/components/edit-category-sheet.tsx": {
-    "mtime": 1783698026.7579055,
+    "mtime": 1786214969.7154112,
     "ast_hash": "eac9c84208ac474bfa500ebb2078f6fc",
     "semantic_hash": "eac9c84208ac474bfa500ebb2078f6fc"
   },
   "features/categories/components/new-category-sheet.tsx": {
-    "mtime": 1783698026.7587247,
+    "mtime": 1786214969.717408,
     "ast_hash": "44c4510df4d98642cbde5f163048e2b2",
     "semantic_hash": "44c4510df4d98642cbde5f163048e2b2"
   },
   "features/categories/hooks/use-new-category.ts": {
-    "mtime": 1783698026.759732,
+    "mtime": 1786214969.7194095,
     "ast_hash": "62c621c2b5c510b0c69a874325da21d9",
     "semantic_hash": "62c621c2b5c510b0c69a874325da21d9"
   },
   "features/categories/hooks/use-open-category.ts": {
-    "mtime": 1783698026.7607288,
+    "mtime": 1786214969.7214067,
     "ast_hash": "cf1b909f1cc666056c826133f28ff687",
     "semantic_hash": "cf1b909f1cc666056c826133f28ff687"
   },
   "features/summary/use-get-summary.ts": {
-    "mtime": 1785382046.1971014,
+    "mtime": 1786214969.7224092,
     "ast_hash": "a1de2b85f18953713659096f55038e36",
     "semantic_hash": ""
   },
   "features/transactions/api/use-bulk-create-transactions.ts": {
-    "mtime": 1783698026.7637303,
+    "mtime": 1786214969.725409,
     "ast_hash": "53337c2baddf08b70e20ea2744fc15c4",
     "semantic_hash": "53337c2baddf08b70e20ea2744fc15c4"
   },
   "features/transactions/api/use-bulk-delete-transactions.ts": {
-    "mtime": 1783698026.7637303,
+    "mtime": 1786214969.7264068,
     "ast_hash": "23716d6abac7b5a9e69fc2e3685490c1",
     "semantic_hash": "23716d6abac7b5a9e69fc2e3685490c1"
   },
   "features/transactions/api/use-create-transaction.ts": {
-    "mtime": 1783698026.7647276,
+    "mtime": 1786214969.728408,
     "ast_hash": "044508d87a96ebcccdadfccc576b11f8",
     "semantic_hash": "044508d87a96ebcccdadfccc576b11f8"
   },
   "features/transactions/api/use-delete-transaction.ts": {
-    "mtime": 1783698026.765733,
+    "mtime": 1786214969.7304094,
     "ast_hash": "4b0a01e8b9a8077331d54e352ed9344a",
     "semantic_hash": "4b0a01e8b9a8077331d54e352ed9344a"
   },
   "features/transactions/api/use-edit-transaction.ts": {
-    "mtime": 1783698026.765733,
+    "mtime": 1786214969.7314098,
     "ast_hash": "21fda0694c1345ba54cc76df9b2e15aa",
     "semantic_hash": "21fda0694c1345ba54cc76df9b2e15aa"
   },
   "features/transactions/api/use-get-transaction.ts": {
-    "mtime": 1783698026.7667286,
+    "mtime": 1786214969.7324123,
     "ast_hash": "f1acd3c01aa08aef4154b85beaee7777",
     "semantic_hash": "f1acd3c01aa08aef4154b85beaee7777"
   },
   "features/transactions/api/use-get-transactions.ts": {
-    "mtime": 1785382046.199191,
+    "mtime": 1786214969.7334077,
     "ast_hash": "5d3046f43c236a859db17997fb441dac",
     "semantic_hash": ""
   },
   "features/transactions/components/edit-transaction-sheet.tsx": {
-    "mtime": 1783698026.767732,
+    "mtime": 1786214969.73441,
     "ast_hash": "48bb9fbbe7f41d8ea67950bd86b6a079",
     "semantic_hash": "48bb9fbbe7f41d8ea67950bd86b6a079"
   },
   "features/transactions/components/new-transaction-sheet.tsx": {
-    "mtime": 1783698026.7687278,
+    "mtime": 1786214969.7364094,
     "ast_hash": "687a00a2104d398ea3644aaadda4f56e",
     "semantic_hash": "687a00a2104d398ea3644aaadda4f56e"
   },
   "features/transactions/components/transaction-form.tsx": {
-    "mtime": 1785382046.2012725,
+    "mtime": 1786214969.7384121,
     "ast_hash": "412b7b7c50e1bcd6cc226cdf2ef78b04",
     "semantic_hash": ""
   },
   "features/transactions/hooks/use-new-transaction.ts": {
-    "mtime": 1783698026.7707274,
+    "mtime": 1786214969.7394097,
     "ast_hash": "406300d4fe753393fb2511fd580dc237",
     "semantic_hash": "406300d4fe753393fb2511fd580dc237"
   },
   "features/transactions/hooks/use-open-transaction.ts": {
-    "mtime": 1783698026.7717302,
+    "mtime": 1786214969.7404077,
     "ast_hash": "b5fb68ce3ee90e730a0ff90ceb053bf2",
     "semantic_hash": "b5fb68ce3ee90e730a0ff90ceb053bf2"
   },
   "hooks/use-confirm.tsx": {
-    "mtime": 1783698026.7857275,
+    "mtime": 1786214969.7824147,
     "ast_hash": "b997aa85b43ca41d936c526373c1a690",
     "semantic_hash": "b997aa85b43ca41d936c526373c1a690"
   },
   "lib/api-base-url.test.ts": {
-    "mtime": 1783698026.7867272,
+    "mtime": 1786214969.7844093,
     "ast_hash": "26dca4a2e42cc3b2b5715f8138cf6380",
     "semantic_hash": "26dca4a2e42cc3b2b5715f8138cf6380"
   },
   "lib/api-base-url.ts": {
-    "mtime": 1783698026.7867272,
+    "mtime": 1786214969.7854035,
     "ast_hash": "0466af5fa2a369989955fcfa20b9fbb2",
     "semantic_hash": "0466af5fa2a369989955fcfa20b9fbb2"
   },
   "lib/api-error.ts": {
-    "mtime": 1783698026.7877283,
+    "mtime": 1786214969.786411,
     "ast_hash": "2872eb16f0b1bde6a0f2846d3f0f08ba",
     "semantic_hash": "2872eb16f0b1bde6a0f2846d3f0f08ba"
   },
   "lib/chunk-items.test.ts": {
-    "mtime": 1783698026.7917266,
+    "mtime": 1786214969.791413,
     "ast_hash": "085fa5724c2d7a4d69f089ea2085de5b",
     "semantic_hash": "085fa5724c2d7a4d69f089ea2085de5b"
   },
   "lib/chunk-items.ts": {
-    "mtime": 1783698026.7927282,
+    "mtime": 1786214969.7924135,
     "ast_hash": "189dbe829e294fa23f8911b96b2058a2",
     "semantic_hash": "189dbe829e294fa23f8911b96b2058a2"
   },
   "lib/hono.ts": {
-    "mtime": 1783698026.793728,
+    "mtime": 1786214969.7934153,
     "ast_hash": "9d52fd96018b274dc387f48e607105c2",
     "semantic_hash": "9d52fd96018b274dc387f48e607105c2"
   },
   "lib/select-options.test.ts": {
-    "mtime": 1783698026.793728,
+    "mtime": 1786214969.7964184,
     "ast_hash": "76beb3bfa1e41d1469b1cbec4e312e24",
     "semantic_hash": "76beb3bfa1e41d1469b1cbec4e312e24"
   },
   "lib/select-options.ts": {
-    "mtime": 1783698026.7947247,
+    "mtime": 1786214969.7974138,
     "ast_hash": "33346a4dd0d8b9f14f60e6de1327e85a",
     "semantic_hash": "33346a4dd0d8b9f14f60e6de1327e85a"
   },
   "lib/transaction-import.test.ts": {
-    "mtime": 1783698026.7957249,
+    "mtime": 1786214969.7984128,
     "ast_hash": "4d374a452c5574fdd81560c9b7701baf",
     "semantic_hash": "4d374a452c5574fdd81560c9b7701baf"
   },
   "lib/transaction-import.ts": {
-    "mtime": 1785382046.2596283,
+    "mtime": 1786214969.799418,
     "ast_hash": "9cb56255fdc248578cf1a41d6827ef6b",
     "semantic_hash": ""
   },
   "lib/transaction-limits.ts": {
-    "mtime": 1783698026.7967248,
+    "mtime": 1786214969.800411,
     "ast_hash": "fff8d0679f824e17df45c3128f5453fc",
     "semantic_hash": "fff8d0679f824e17df45c3128f5453fc"
   },
   "lib/transaction-route-utils.test.ts": {
-    "mtime": 1783698026.7977252,
+    "mtime": 1786214969.8014102,
     "ast_hash": "a2cbbfa132acbd51958ee1d3a7b759de",
     "semantic_hash": "a2cbbfa132acbd51958ee1d3a7b759de"
   },
   "lib/transaction-route-utils.ts": {
-    "mtime": 1783698026.7977252,
+    "mtime": 1786214969.802413,
     "ast_hash": "d5b31a484ab4348ed3b91ca1243b88c3",
     "semantic_hash": "d5b31a484ab4348ed3b91ca1243b88c3"
   },
   "lib/utils.ts": {
-    "mtime": 1785382046.2616405,
+    "mtime": 1786214969.8034143,
     "ast_hash": "e45b0765f9aa80e8561d8b0df322a1c5",
     "semantic_hash": ""
   },
   "next.config.ts": {
-    "mtime": 1783698026.7987258,
+    "mtime": 1786214969.8044145,
     "ast_hash": "1bb2f779f0a75d33af448649d3793ff9",
     "semantic_hash": "1bb2f779f0a75d33af448649d3793ff9"
   },
   "package.json": {
-    "mtime": 1784742043.7327802,
+    "mtime": 1786214969.809408,
     "ast_hash": "b12ce8a02f9c31286cdd3a4ba807424a",
     "semantic_hash": ""
   },
   "postcss.config.mjs": {
-    "mtime": 1783698026.8057396,
+    "mtime": 1786214969.84941,
     "ast_hash": "e9d66e1263ec6f84f9c7f4b88b00e4f9",
     "semantic_hash": "e9d66e1263ec6f84f9c7f4b88b00e4f9"
   },
   "providers/query-provider.tsx": {
-    "mtime": 1783698026.812728,
+    "mtime": 1786214969.8514123,
     "ast_hash": "9ecd69a2c447c1b35a6ed3d5decae60b",
     "semantic_hash": "9ecd69a2c447c1b35a6ed3d5decae60b"
   },
   "providers/sheet-provider.tsx": {
-    "mtime": 1783698026.8137352,
+    "mtime": 1786214969.8524077,
     "ast_hash": "04d761cf7b5e877bb9de17d75822de28",
     "semantic_hash": "04d761cf7b5e877bb9de17d75822de28"
   },
   "proxy.ts": {
-    "mtime": 1783698026.815732,
+    "mtime": 1786214969.8534095,
     "ast_hash": "48745f85b81daa2435b98d7b30bdfe9d",
     "semantic_hash": "48745f85b81daa2435b98d7b30bdfe9d"
   },
   "scripts/dev-local.ts": {
-    "mtime": 1783698026.825726,
+    "mtime": 1786214969.8674078,
     "ast_hash": "7bffc8a9f0abd5f4e89dbc4f797005a2",
     "semantic_hash": "7bffc8a9f0abd5f4e89dbc4f797005a2"
   },
   "scripts/migrate.ts": {
-    "mtime": 1783698026.8267236,
+    "mtime": 1786214969.868412,
     "ast_hash": "c3978e78f7441fd5ea4f8f0821bed4a3",
     "semantic_hash": "c3978e78f7441fd5ea4f8f0821bed4a3"
   },
   "scripts/seed.ts": {
-    "mtime": 1783698026.8267236,
+    "mtime": 1786214969.8694086,
     "ast_hash": "5c2eda2cd604e35c10e716ee32143c89",
     "semantic_hash": "5c2eda2cd604e35c10e716ee32143c89"
   },
   "tsconfig.json": {
-    "mtime": 1783698026.827724,
+    "mtime": 1786214969.872411,
     "ast_hash": "02fc19ad21338c2ab820a70136310db4",
     "semantic_hash": "02fc19ad21338c2ab820a70136310db4"
   },
   "AGENTS.md": {
-    "mtime": 1783698026.6327255,
+    "mtime": 1786214969.4354095,
     "ast_hash": "84b181fae5bdfc5707f0fba5ac5e8c3c",
     "semantic_hash": ""
   },
   "PR-Reviews/13.Upload-Transactions-Import.md": {
-    "mtime": 1783698026.6347277,
+    "mtime": 1786214969.4384098,
     "ast_hash": "bc9c10e9559c4fbc0e22c11e0493f8fa",
     "semantic_hash": "bc9c10e9559c4fbc0e22c11e0493f8fa"
   },
   "PR-Reviews/Agents instructions/copilot_review_prompt.md": {
-    "mtime": 1783698026.6357257,
+    "mtime": 1786214969.4394069,
     "ast_hash": "02820e48e71bf49720d4beba6168839c",
     "semantic_hash": "02820e48e71bf49720d4beba6168839c"
   },
   "PR-Reviews/Agents instructions/tech_debt_instructions.md": {
-    "mtime": 1783698026.636725,
+    "mtime": 1786214969.4404104,
     "ast_hash": "4bc40013bd1a94835f993cb2b0c94093",
     "semantic_hash": "4bc40013bd1a94835f993cb2b0c94093"
   },
   "PR_REVIEW_TECH_DEBT_CONSOLIDATED.md": {
-    "mtime": 1783698026.636725,
+    "mtime": 1786214969.4414089,
     "ast_hash": "63554a20789b246c658cfbd38898b199",
     "semantic_hash": "63554a20789b246c658cfbd38898b199"
   },
   "README.md": {
-    "mtime": 1784664178.1015217,
+    "mtime": 1786214969.4424112,
     "ast_hash": "600ed002df03e363026bdc5a4020f273",
     "semantic_hash": ""
   },
   "backend/README.md": {
-    "mtime": 1784664178.1035283,
+    "mtime": 1786214969.4844131,
     "ast_hash": "c0d59faef1f81423a9fd6cb63d986c97",
     "semantic_hash": ""
   },
   "docker-compose.dev.yml": {
-    "mtime": 1783698026.7157264,
+    "mtime": 1786214969.6444178,
     "ast_hash": "641a0abbc4bcd1e6636d89aab283628b",
     "semantic_hash": "641a0abbc4bcd1e6636d89aab283628b"
   },
   "docker-compose.yml": {
-    "mtime": 1784664178.137525,
+    "mtime": 1786214969.645414,
     "ast_hash": "6ea49b72ecc0efcd9f97d6a194fe3bcd",
     "semantic_hash": ""
   },
   "docs/CODEX_CONTEXT.md": {
-    "mtime": 1783698026.7177246,
+    "mtime": 1786214969.6504142,
     "ast_hash": "9afd74a76dd596e56746c4685a6cdb40",
     "semantic_hash": "9afd74a76dd596e56746c4685a6cdb40"
   },
   "docs/features-roadmap/roadmap_features_list.md": {
-    "mtime": 1783698026.718733,
+    "mtime": 1786214969.6534138,
     "ast_hash": "614d3f13c04f409e3c36559b38c8a5db",
     "semantic_hash": "614d3f13c04f409e3c36559b38c8a5db"
   },
   "docs/specs/18-go-backend-replacement/spec.md": {
-    "mtime": 1784748314.222078,
+    "mtime": 1786214969.6674125,
     "ast_hash": "cb85d7c923228886aa883c052365e242",
     "semantic_hash": ""
   },
   "refreshApp/CODEX_CONTEXT.md": {
-    "mtime": 1783698026.8237402,
+    "mtime": 1786214969.864408,
     "ast_hash": "84d15e20cddd4de32b421607e3b8df58",
     "semantic_hash": "84d15e20cddd4de32b421607e3b8df58"
   },
   "refreshApp/pr summaries/project-polish-pr-summary.md": {
-    "mtime": 1783698026.8247252,
+    "mtime": 1786214969.8664162,
     "ast_hash": "b3239a8197aa94eaa5cd1f627941b33f",
     "semantic_hash": "b3239a8197aa94eaa5cd1f627941b33f"
   },
   "public/file.svg": {
-    "mtime": 1783698026.816731,
+    "mtime": 1786214969.855409,
     "ast_hash": "d09f95206c3fa0bb9bd9fefabfd0ea71",
     "semantic_hash": "d09f95206c3fa0bb9bd9fefabfd0ea71"
   },
   "public/globe.svg": {
-    "mtime": 1783698026.8177302,
+    "mtime": 1786214969.8574085,
     "ast_hash": "2aaafa6a49b6563925fe440891e32717",
     "semantic_hash": "2aaafa6a49b6563925fe440891e32717"
   },
   "public/logo.svg": {
-    "mtime": 1783698026.8187287,
+    "mtime": 1786214969.8584087,
     "ast_hash": "7b5e20dc584002f6561ef811f3e1464d",
     "semantic_hash": "7b5e20dc584002f6561ef811f3e1464d"
   },
   "public/next.svg": {
-    "mtime": 1783698026.8207247,
+    "mtime": 1786214969.8604085,
     "ast_hash": "8e061864f388b47f33a1c3780831193e",
     "semantic_hash": "8e061864f388b47f33a1c3780831193e"
   },
   "public/vercel.svg": {
-    "mtime": 1783698026.8217244,
+    "mtime": 1786214969.862411,
     "ast_hash": "c0af2f507b369b085b35ef4bbe3bcf1e",
     "semantic_hash": "c0af2f507b369b085b35ef4bbe3bcf1e"
   },
   "public/window.svg": {
-    "mtime": 1783698026.8217244,
+    "mtime": 1786214969.8634074,
     "ast_hash": "a2760511c65806022ad20adf74370ff3",
     "semantic_hash": "a2760511c65806022ad20adf74370ff3"
   },
   "openapi/nuchi.openapi.json": {
-    "mtime": 1786205675.652077,
+    "mtime": 1786214969.8074105,
     "ast_hash": "2b5c8f6c1a12721af8910e352933fefd",
     "semantic_hash": ""
   },
   "scripts/validate-openapi.ts": {
-    "mtime": 1783698026.827724,
+    "mtime": 1786214969.8704133,
     "ast_hash": "d3b95441be9cc70c68755656681ace75",
     "semantic_hash": "d3b95441be9cc70c68755656681ace75"
   },
   "backend/internal/openapi/README.md": {
-    "mtime": 1783698026.671726,
+    "mtime": 1786214969.5684109,
     "ast_hash": "e797f9a57d120da32ba7b8ebee253ae6",
     "semantic_hash": "e797f9a57d120da32ba7b8ebee253ae6"
   },
   "docs/specs/18-go-backend-replacement/api-parity-fixtures.md": {
-    "mtime": 1783698026.7207258,
+    "mtime": 1786214969.6664133,
     "ast_hash": "98c0c0219dd7f1c5dccc6896bce89bba",
     "semantic_hash": "98c0c0219dd7f1c5dccc6896bce89bba"
   },
   "lib/api/generated/README.md": {
-    "mtime": 1783698026.7897284,
+    "mtime": 1786214969.7894123,
     "ast_hash": "58840bd101db026d04637a1cf07bb8cf",
     "semantic_hash": "58840bd101db026d04637a1cf07bb8cf"
   },
   "openapi/README.md": {
-    "mtime": 1783698026.800723,
+    "mtime": 1786214969.805412,
     "ast_hash": "744ff7b621c032eba306b350d636ff93",
     "semantic_hash": ""
   },
   "openapi/oapi-codegen.yaml": {
-    "mtime": 1783698026.801723,
+    "mtime": 1786214969.8084147,
     "ast_hash": "81d1787ebd0ac01e2bb85021ec353b8b",
     "semantic_hash": ""
   },
   ".codex/hooks.json": {
-    "mtime": 1785194106.5079558,
+    "mtime": 1786214969.4084098,
     "ast_hash": "efead0799c3e7316bae44143fdd0c63a",
     "semantic_hash": ""
   },
   "backend/go.mod": {
-    "mtime": 1784296925.9112468,
+    "mtime": 1786214969.4874098,
     "ast_hash": "9c492f412148cd9969d630216864f84c",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/SKILL.md": {
-    "mtime": 1785194106.5129552,
+    "mtime": 1786214969.4134076,
     "ast_hash": "21f78a7f96e2f9aecc0f7afc053bd3cc",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/add-watch.md": {
-    "mtime": 1785194106.5149543,
+    "mtime": 1786214969.414412,
     "ast_hash": "d59d027fe449f06aa03905a01184e779",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/exports.md": {
-    "mtime": 1785194106.5159552,
+    "mtime": 1786214969.4154093,
     "ast_hash": "9da2a2152e60a22f07f05fed5158f287",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/extraction-spec.md": {
-    "mtime": 1785194106.516956,
+    "mtime": 1786214969.41641,
     "ast_hash": "bf895ec4d4e40f5f66f7d31c2a9bd4a7",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/github-and-merge.md": {
-    "mtime": 1785194106.5179486,
+    "mtime": 1786214969.4174101,
     "ast_hash": "cde13df085e4c492aeb7ba298a996d0d",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/hooks.md": {
-    "mtime": 1785194106.5179486,
+    "mtime": 1786214969.4184096,
     "ast_hash": "3f545db6ce646650bb9de588f5512a27",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/query.md": {
-    "mtime": 1785194106.5189497,
+    "mtime": 1786214969.4194074,
     "ast_hash": "3c46f8ad006874260614ed8657d02307",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/transcribe.md": {
-    "mtime": 1785194106.5199485,
+    "mtime": 1786214969.4204104,
     "ast_hash": "67b6a5fa6c0974e18f60db9f8932fbd8",
     "semantic_hash": ""
   },
   ".codex/skills/graphify/references/update.md": {
-    "mtime": 1785194106.5209494,
+    "mtime": 1786214969.4214067,
     "ast_hash": "c698309979460d0f02ba616417844399",
     "semantic_hash": ""
   },
-  ".claude/settings.local.json": {
-    "mtime": 1783544439.3917391,
-    "ast_hash": "59f0c90705d235d81ba103a2a9544785",
-    "semantic_hash": ""
-  },
   ".claude/settings.json": {
-    "mtime": 1783698026.6117263,
+    "mtime": 1786214969.4054134,
     "ast_hash": "e2078912071ec3800daf5e38e480c97e",
     "semantic_hash": ""
   },
   ".claude/agents/go-migrator.md": {
-    "mtime": 1783698026.6097245,
+    "mtime": 1786214969.4024124,
     "ast_hash": "e2a0d1530cfd5594e4575fb71794f92f",
     "semantic_hash": ""
   },
   ".claude/agents/parity-reviewer.md": {
-    "mtime": 1783698026.6097245,
+    "mtime": 1786214969.4034133,
     "ast_hash": "600cdce7e43ec1386cda547db80d4cdd",
     "semantic_hash": ""
   },
   ".claude/agents/researcher.md": {
-    "mtime": 1783698026.6107347,
+    "mtime": 1786214969.404415,
     "ast_hash": "734052bd3b657c0db31df9e9827a7e8b",
     "semantic_hash": ""
   },
   ".claude/skills/pr-review-cycle/SKILL.md": {
-    "mtime": 1783698026.6127312,
+    "mtime": 1786214969.407413,
     "ast_hash": "1a5460a3ea945aa8d875f8781840776b",
     "semantic_hash": ""
   },
   ".github/copilot-instructions.md": {
-    "mtime": 1783698026.626726,
+    "mtime": 1786214969.4254115,
     "ast_hash": "9538cefd640d4ba4dc1298b8f39a7296",
     "semantic_hash": ""
   },
   ".github/workflows/ci.yml": {
-    "mtime": 1784748314.222078,
+    "mtime": 1786214969.4264095,
     "ast_hash": "2d4aa10d182684983fb4909f4aece8f5",
     "semantic_hash": ""
   },
   "CLAUDE.md": {
-    "mtime": 1784776584.287385,
+    "mtime": 1786214969.4364085,
     "ast_hash": "e00415072c5cc93dd907b12aae164551",
     "semantic_hash": ""
   },
   "backend/tools.go": {
-    "mtime": 1783698026.6757264,
+    "mtime": 1786214969.5814111,
     "ast_hash": "23cf25294ceccdbda20370b02cb84e60",
     "semantic_hash": ""
   },
   "lib/api/generated/schema.d.ts": {
-    "mtime": 1786205675.650061,
+    "mtime": 1786214969.7904122,
     "ast_hash": "36bdf0b2af2d3e30318cdf7dd3b698a6",
     "semantic_hash": ""
   },
   "backend/internal/openapi/generated.gen.go": {
-    "mtime": 1786205675.6197796,
+    "mtime": 1786214969.5694141,
     "ast_hash": "b36bf8c7610fd5d85e6cf8ee3bbd894a",
     "semantic_hash": ""
   },
   "backend/internal/config/config_test.go": {
-    "mtime": 1784664178.110524,
+    "mtime": 1786214969.4984193,
     "ast_hash": "d4989f1882f4c30be77d4ba609358360",
     "semantic_hash": ""
   },
   "backend/internal/db/db.go": {
-    "mtime": 1783701470.0356092,
+    "mtime": 1786214969.5024161,
     "ast_hash": "703aa2ff939c3ef2b02afcd332a05456",
     "semantic_hash": ""
   },
   "backend/internal/db/db_test.go": {
-    "mtime": 1784664178.1135266,
+    "mtime": 1786214969.5034087,
     "ast_hash": "11881577635a7488b07bb7e93bb0747c",
     "semantic_hash": ""
   },
   "backend/sqlc.yaml": {
-    "mtime": 1783887559.0670724,
+    "mtime": 1786214969.5804105,
     "ast_hash": "5afb93ae3e86332b4b2628259f4f2da4",
     "semantic_hash": ""
   },
   "backend/internal/db/auth_schema_test.go": {
-    "mtime": 1784664178.1115255,
+    "mtime": 1786214969.5014112,
     "ast_hash": "3840960a3a8fe1ad99c5813546c3c7d4",
     "semantic_hash": ""
   },
   "backend/migrations/00001_auth_base.sql": {
-    "mtime": 1783712765.761052,
+    "mtime": 1786214969.575409,
     "ast_hash": "2864776619a3cd615f7e6cca5c49ca99",
     "semantic_hash": ""
   },
   "backend/internal/db/finance_rls_test.go": {
-    "mtime": 1784664178.1145236,
+    "mtime": 1786214969.5044122,
     "ast_hash": "193db5b30c5be881cc4632c19b861739",
     "semantic_hash": ""
   },
   "backend/internal/db/finance_schema_test.go": {
-    "mtime": 1785382046.169994,
+    "mtime": 1786214969.506416,
     "ast_hash": "38c0b368150f285a1fbff4997f005ae0",
     "semantic_hash": ""
   },
   "backend/migrations/00002_finance_base.sql": {
-    "mtime": 1783737060.975606,
+    "mtime": 1786214969.575409,
     "ast_hash": "4c11467f09bb1f26c06ba0d89685ce4d",
     "semantic_hash": ""
   },
   "backend/migrations/00003_finance_rls.sql": {
-    "mtime": 1783737060.975606,
+    "mtime": 1786214969.5774066,
     "ast_hash": "35da157d2e9249449f9777bd62d8a12c",
     "semantic_hash": ""
   },
   "docs/investigation/Argentina_Openbanking/README.md": {
-    "mtime": 1783737060.975606,
+    "mtime": 1786214969.6564193,
     "ast_hash": "e77c5b72d96913778bf0182ffbd54ef2",
     "semantic_hash": ""
   },
   "docs/investigation/Argentina_Openbanking/briefing.md": {
-    "mtime": 1783737060.975606,
+    "mtime": 1786214969.6574106,
     "ast_hash": "4beed5fee8ba44e01a97c39ca01f3cee",
     "semantic_hash": ""
   },
   "docs/investigation/Argentina_Openbanking/findings.md": {
-    "mtime": 1783737060.975606,
+    "mtime": 1786214969.6584158,
     "ast_hash": "d726752ccb7a768a0edc9d241ce3895a",
     "semantic_hash": ""
   },
   "docs/investigation/Argentina_Openbanking/summary.md": {
-    "mtime": 1783737060.975606,
+    "mtime": 1786214969.6604135,
     "ast_hash": "c589199ac4a3041110ca967bef2d686e",
     "semantic_hash": ""
   },
   "post-migration-improvements/README.md": {
-    "mtime": 1786205675.6540983,
-    "ast_hash": "b6a6de7dd9a8bc0711d4f7b75a88dacd",
+    "mtime": 1786215323.7864304,
+    "ast_hash": "73faf717bfe82bd7a76791aad5566db3",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/accounts.sql.go": {
-    "mtime": 1786205675.602012,
+    "mtime": 1786214969.5074122,
     "ast_hash": "662a577165788f29aad38fb538884980",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/auth_tokens.sql.go": {
-    "mtime": 1785387845.03398,
+    "mtime": 1786214969.5084145,
     "ast_hash": "42e6f12daa50c1456b94131a8c1e2e7e",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/categories.sql.go": {
-    "mtime": 1786205675.6030352,
+    "mtime": 1786214969.509408,
     "ast_hash": "8fc58f397476f06527675c4959c8d481",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/db.go": {
-    "mtime": 1785387845.027807,
+    "mtime": 1786214969.5104105,
     "ast_hash": "2cbddc42f0f37817a76d68976a4de47e",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/models.go": {
-    "mtime": 1785387845.0284746,
+    "mtime": 1786214969.5114079,
     "ast_hash": "467f6f14eefc04c8f5694fe777ed5fcf",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/summary.sql.go": {
-    "mtime": 1785387845.0271144,
+    "mtime": 1786214969.5124152,
     "ast_hash": "e85b9f8abe428d8d4fb9d174f9d6d26e",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/transactions.sql.go": {
-    "mtime": 1786205675.605087,
+    "mtime": 1786214969.5134094,
     "ast_hash": "d94bb4b360bd888db883954b82483820",
     "semantic_hash": ""
   },
   "backend/internal/db/gen/users.sql.go": {
-    "mtime": 1785387845.0265749,
+    "mtime": 1786214969.5154123,
     "ast_hash": "04e56c6a60df24019975998c499b029f",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/accounts.sql": {
-    "mtime": 1786205675.6061096,
+    "mtime": 1786214969.519524,
     "ast_hash": "fc43ffc2ff6f1bd329cee30fb7cccf26",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/auth_tokens.sql": {
-    "mtime": 1783887559.058889,
+    "mtime": 1786214969.5204115,
     "ast_hash": "1de03d1bde5c37b2d819e8a220acdedd",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/categories.sql": {
-    "mtime": 1786205675.6071298,
+    "mtime": 1786214969.5214107,
     "ast_hash": "477f3e1dfb311b392c1d260d60e473b9",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/summary.sql": {
-    "mtime": 1783887559.0609229,
+    "mtime": 1786214969.5224123,
     "ast_hash": "d5d0817b00911263f72cea337607a775",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/transactions.sql": {
-    "mtime": 1786205675.6081526,
+    "mtime": 1786214969.5234098,
     "ast_hash": "912750b5551deae6a005dd6206513fc2",
     "semantic_hash": ""
   },
   "backend/internal/db/queries/users.sql": {
-    "mtime": 1784664178.1205192,
+    "mtime": 1786214969.524412,
     "ast_hash": "44ea3644e18d081175d20d4cd3fb756a",
     "semantic_hash": ""
   },
   "backend/internal/db/queries_live_test.go": {
-    "mtime": 1784664178.1225293,
+    "mtime": 1786214969.525411,
     "ast_hash": "7731f5f10e10f56cb1b8274892715813",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0001-transactions-date-timestamp.md": {
-    "mtime": 1783742949.6068866,
+    "mtime": 1786214969.8124113,
     "ast_hash": "bdb237aff47235dbcfd6f545799bf218",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0002-finance-ids-and-uuidv7-default.md": {
-    "mtime": 1783742958.4917693,
+    "mtime": 1786214969.8134086,
     "ast_hash": "3821814262de62bc4748b757732d7487",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0003-in-memory-rate-limiting.md": {
-    "mtime": 1783742966.9757066,
+    "mtime": 1786214969.8174114,
     "ast_hash": "f8a432d1eac12d3c0305088e6209b047",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0004-bulk-delete-silent-ignore.md": {
-    "mtime": 1783742975.4338036,
+    "mtime": 1786214969.818416,
     "ast_hash": "2b31a879438178d4fe50712087d2b062",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0005-category-duplicate-update-500.md": {
-    "mtime": 1785299160.5282168,
+    "mtime": 1786214969.819411,
     "ast_hash": "3ca1effceff479aa718196dc8ddfb53b",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0006-amount-int32-milliunit-cap.md": {
-    "mtime": 1785382046.284557,
+    "mtime": 1786214969.8204148,
     "ast_hash": "12c1fbfe74424d1c11395138b3e134cb",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/00-current-state.md": {
-    "mtime": 1783886259.7899237,
+    "mtime": 1786214969.8344092,
     "ast_hash": "24215e20cd45ee75c52d5835d8f4a597",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/01-target-architecture.md": {
-    "mtime": 1783886259.7909331,
+    "mtime": 1786214969.8354127,
     "ast_hash": "c1d09ee4f014e24aad97a18c65d7b795",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/02-security.md": {
-    "mtime": 1783886259.7929242,
+    "mtime": 1786214969.8374062,
     "ast_hash": "4a1821f45c74c6bc0d1f76dd1d6aecc4",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/03-performance-and-queries.md": {
-    "mtime": 1783886369.2243311,
+    "mtime": 1786214969.8384106,
     "ast_hash": "d9c3e87abb1e1f9635599a02ea971a5d",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/04-robustness-and-transactions.md": {
-    "mtime": 1786205798.1811972,
+    "mtime": 1786214969.839414,
     "ast_hash": "201c715d72c549583e498f59f60fbc03",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/05-api-documentation.md": {
-    "mtime": 1783886369.2263217,
+    "mtime": 1786214969.8404155,
     "ast_hash": "dd065cb03d1572ad43c0642a12102122",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/06-observability-readiness.md": {
-    "mtime": 1783886369.2273376,
+    "mtime": 1786214969.8414097,
     "ast_hash": "8cea1acfcda440ba4857f0022d15e36e",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/07-module-improvement-map.md": {
-    "mtime": 1783886441.7495658,
+    "mtime": 1786214969.8424141,
     "ast_hash": "9523b6bedd5d7f26c387f7647e06d6f2",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/08-delivery-roadmap.md": {
-    "mtime": 1783886441.7505753,
+    "mtime": 1786214969.8434124,
     "ast_hash": "ef6276032dfba882145ac3c2e4fe7b32",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/README.md": {
-    "mtime": 1786205798.1811972,
+    "mtime": 1786214969.845413,
     "ast_hash": "5e9b7f75a8e17501a4402d0ff838e365",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/templates/endpoint-review.md": {
-    "mtime": 1783886441.7525747,
+    "mtime": 1786214969.8474143,
     "ast_hash": "7191eb90724b140e153f0f308d010206",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/templates/improvement-proposal.md": {
-    "mtime": 1783886441.753572,
+    "mtime": 1786214969.8484085,
     "ast_hash": "00bd4fa4acf9f6ff0c5291c2520d8e9d",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0008-no-midlife-access-token-revocation.md": {
-    "mtime": 1783998225.9647148,
+    "mtime": 1786214969.82241,
     "ast_hash": "52fd1695466063418820cb36d926f223",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0009-refresh-reuse-detection-session-listing.md": {
-    "mtime": 1783998235.2082634,
+    "mtime": 1786214969.8234098,
     "ast_hash": "909c538cdeb7a782ec8c80070d852533",
     "semantic_hash": ""
   },
   "backend/internal/auth/jwt.go": {
-    "mtime": 1785182787.549009,
+    "mtime": 1786214969.4904194,
     "ast_hash": "6d9277432d896f349a116430df14f23a",
     "semantic_hash": ""
   },
   "backend/internal/auth/jwt_test.go": {
-    "mtime": 1785182787.5510066,
+    "mtime": 1786214969.4914145,
     "ast_hash": "b0710242431507a04035b72e5bb08911",
     "semantic_hash": ""
   },
   "backend/internal/auth/password.go": {
-    "mtime": 1784296925.91784,
+    "mtime": 1786214969.4924164,
     "ast_hash": "185dd2946e9d45e53af209091acbc69a",
     "semantic_hash": ""
   },
   "backend/internal/auth/password_test.go": {
-    "mtime": 1784296925.9227943,
+    "mtime": 1786214969.4934106,
     "ast_hash": "11f7c3d603351c5e925beb96a345bd99",
     "semantic_hash": ""
   },
   "backend/internal/auth/token.go": {
-    "mtime": 1784296925.9227943,
+    "mtime": 1786214969.4944162,
     "ast_hash": "cc2d1d3c8987927c3ce120c9cc440c27",
     "semantic_hash": ""
   },
   "backend/internal/auth/token_test.go": {
-    "mtime": 1784296925.9248064,
+    "mtime": 1786214969.49541,
     "ast_hash": "e651536884cee427ba4e8a435d039dcc",
     "semantic_hash": ""
   },
   "backend/internal/http/auth.go": {
-    "mtime": 1785295957.3667932,
+    "mtime": 1786214969.534413,
     "ast_hash": "95687344b5ee195e2be36e78aedc8830",
     "semantic_hash": ""
   },
   "backend/internal/http/auth_live_test.go": {
-    "mtime": 1785295957.3686926,
+    "mtime": 1786214969.5364115,
     "ast_hash": "e528ecd421ef17dbb9a02b16683c67c0",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260714_131130_got_ticket__41_done_by_claude__please_review_the_p.md": {
-    "mtime": 1784034690.381011,
-    "ast_hash": "a9e36397da37905470e4315d54019dab",
+    "mtime": 1786214969.7614121,
+    "ast_hash": "6ca8770a1f7138a550049a55a5ca822b",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260714_162453_recheck_the_fixes_and_give_another_pass_for_review.md": {
-    "mtime": 1784046293.3942628,
-    "ast_hash": "e2ceb19665e5c766b6ae3c18e156608a",
+    "mtime": 1786214969.762414,
+    "ast_hash": "edee4902544d478254e36558268a7786",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260715_022121_give_it_a_last_review_of_all_the_files_changend_in.md": {
-    "mtime": 1784082081.5438933,
-    "ast_hash": "6d977fb265dae34a94fda15fc0adf635",
+    "mtime": 1786214969.7674086,
+    "ast_hash": "32739c926d5d93bcf8ab5c93ead1839a",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0010-auth-contract-omits-500.md": {
-    "mtime": 1784296925.9444642,
+    "mtime": 1786214969.8244095,
     "ast_hash": "0f5ccef73b4e6343bbf4303cff08ea95",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260717_150834_review_pr__64_against_post_merge_pr__62_comment_an.md": {
-    "mtime": 1784300914.0623503,
-    "ast_hash": "b86c85d7b31c9bbc03aadb2678d9f8be",
+    "mtime": 1786214969.7684114,
+    "ast_hash": "da65100a0778e79ca39eb827c06f8c16",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0011-no-resend-endpoint-fire-and-forget-mail.md": {
-    "mtime": 1784315785.0611346,
+    "mtime": 1786214969.825411,
     "ast_hash": "496c201389dbe529abd4e3869d7ded9d",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0012-reset-request-timing-oracle.md": {
-    "mtime": 1784315795.5497026,
+    "mtime": 1786214969.8264096,
     "ast_hash": "a90d642eee349d26e0a64a9afd7ca614",
     "semantic_hash": ""
   },
   "backend/internal/http/email_flows_live_test.go": {
-    "mtime": 1785295957.3706844,
+    "mtime": 1786214969.542411,
     "ast_hash": "cc704878b401f91f4e16a36d4699b503",
     "semantic_hash": ""
   },
   "backend/internal/mail/fake.go": {
-    "mtime": 1784664178.1325233,
+    "mtime": 1786214969.5634065,
     "ast_hash": "7c3b36862e7d13c9af86569cd0122932",
     "semantic_hash": ""
   },
   "backend/internal/mail/mail.go": {
-    "mtime": 1784664178.1335218,
+    "mtime": 1786214969.5644102,
     "ast_hash": "25cc3dfb79130623a1915455e626dfe7",
     "semantic_hash": ""
   },
   "backend/internal/mail/mail_test.go": {
-    "mtime": 1784664178.1345239,
+    "mtime": 1786214969.5654075,
     "ast_hash": "2ebd12b7fd8317f2cbee48c255877cd8",
     "semantic_hash": ""
   },
   "backend/internal/mail/smtp.go": {
-    "mtime": 1784664178.1355252,
+    "mtime": 1786214969.5664103,
     "ast_hash": "57fa574c964177409d06097d36b6d835",
     "semantic_hash": ""
   },
   "backend/internal/db/livedb_test.go": {
-    "mtime": 1785182787.5520103,
+    "mtime": 1786214969.516414,
     "ast_hash": "8c4ad41d29cc74b7077c2556cd08100e",
     "semantic_hash": ""
   },
   "backend/internal/http/livedb_test.go": {
-    "mtime": 1784664178.1295264,
+    "mtime": 1786214969.5454102,
     "ast_hash": "ec6da0358ebdfb4ffa84cd26798a1107",
     "semantic_hash": ""
   },
   "docker/postgres/init/01-app-role.sql": {
-    "mtime": 1784664178.1415224,
+    "mtime": 1786214969.64841,
     "ast_hash": "bf2ab260c5b03d5432d4f4d0670584a1",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260721_182422_review_pr_65_email_verification_and_password_reset.md": {
-    "mtime": 1784658262.6666281,
-    "ast_hash": "a615d7d66ca013b1bf4f200a7ef84502",
+    "mtime": 1786214969.7704103,
+    "ast_hash": "1d0d3ad556b5520396ff0728a21ae495",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260721_192433_recheck_latest_pr_65_changes_and_comments_for_merg.md": {
-    "mtime": 1784661873.344869,
-    "ast_hash": "fe8c2399fff5f53327746ca88dd2c5db",
+    "mtime": 1786214969.7714088,
+    "ast_hash": "6e07e9638589f4dc8304c8ea4ba39666",
     "semantic_hash": ""
   },
   "backend/internal/db/rls.go": {
-    "mtime": 1785182787.554007,
+    "mtime": 1786214969.526411,
     "ast_hash": "d23f4412ed3a5808c61deb9c75bd3ab4",
     "semantic_hash": ""
   },
   "backend/internal/db/rls_test.go": {
-    "mtime": 1785182787.5560062,
+    "mtime": 1786214969.5274143,
     "ast_hash": "5fcce1f05bfcb7c444ed73765f063cd7",
     "semantic_hash": ""
   },
   "backend/internal/http/middleware.go": {
-    "mtime": 1785182787.5610056,
+    "mtime": 1786214969.5464091,
     "ast_hash": "15e71d733007418b2dedd157ad99f588",
     "semantic_hash": ""
   },
   "backend/internal/http/middleware_live_test.go": {
-    "mtime": 1785182787.5620027,
+    "mtime": 1786214969.5474079,
     "ast_hash": "fadb0f78c23feb90acd86867afd5648b",
     "semantic_hash": ""
   },
   "backend/internal/http/middleware_test.go": {
-    "mtime": 1785182787.5630095,
+    "mtime": 1786214969.5494092,
     "ast_hash": "6547f1cd81048be755c64376cd8cafc4",
     "semantic_hash": ""
   },
   "backend/internal/db/transactions_category_rls_test.go": {
-    "mtime": 1785182787.557009,
+    "mtime": 1786214969.5294118,
     "ast_hash": "097e6feb916ddea6d38c68ae24a91b39",
     "semantic_hash": ""
   },
   "backend/migrations/00004_transactions_category_owner_rls.sql": {
-    "mtime": 1785182787.5670047,
+    "mtime": 1786214969.5784109,
     "ast_hash": "a74c516d8f1d8cf6e6271aac9f5c704f",
     "semantic_hash": ""
   },
   "backend/internal/db/migration_upgrade_test.go": {
-    "mtime": 1785382046.169994,
+    "mtime": 1786214969.5174124,
     "ast_hash": "82d5c38c3f2213cc2c4b291777127f6a",
     "semantic_hash": ""
   },
   "backend/internal/http/accounts.go": {
-    "mtime": 1785299160.496461,
+    "mtime": 1786214969.5314157,
     "ast_hash": "90a2f62231fe98ac838506f3d100c83d",
     "semantic_hash": ""
   },
   "backend/internal/http/accounts_live_test.go": {
-    "mtime": 1785295957.359138,
+    "mtime": 1786214969.5324094,
     "ast_hash": "a794c5368298d0862fa765a49e13e0c4",
     "semantic_hash": ""
   },
   "backend/internal/http/resources.go": {
-    "mtime": 1786205675.6125054,
-    "ast_hash": "17a1c288c003881f3ab22a240b5f58ee",
+    "mtime": 1786215117.8562024,
+    "ast_hash": "2ca13979328e246294e25c6a66082762",
     "semantic_hash": ""
   },
   "backend/internal/id/cuid2.go": {
-    "mtime": 1785295957.375682,
+    "mtime": 1786214969.560409,
     "ast_hash": "67e3a2aa49628ad515fbcb5cabbbbfbe",
     "semantic_hash": ""
   },
   "backend/internal/id/cuid2_test.go": {
-    "mtime": 1785295957.3766847,
+    "mtime": 1786214969.5614111,
     "ast_hash": "7639a0b9e89d3218c09a9aeb69edf515",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0013-no-request-body-size-cap-on-resource-endpoints.md": {
-    "mtime": 1785295957.3943532,
+    "mtime": 1786214969.8274095,
     "ast_hash": "971125d26b3207e86db94ba74797ed99",
     "semantic_hash": ""
   },
   "backend/internal/http/categories.go": {
-    "mtime": 1785299160.496461,
+    "mtime": 1786214969.538408,
     "ast_hash": "5b0189e0f4f2d1a284fd7626828bc12b",
     "semantic_hash": ""
   },
   "backend/internal/http/categories_live_test.go": {
-    "mtime": 1785299160.4984727,
+    "mtime": 1786214969.5394099,
     "ast_hash": "35a4159d0d68143caf47847f860414bb",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260729_041253_check_the_graphify_outcome_for_nuchi_and_tell_me_h.md": {
-    "mtime": 1785298373.5607057,
-    "ast_hash": "36610d5fe04c2dead60e99a0eb200875",
+    "mtime": 1786214969.7714088,
+    "ast_hash": "ee35d60af451dce428a42e5353ddd74d",
     "semantic_hash": ""
   },
   "backend/internal/http/daterange.go": {
-    "mtime": 1785382046.1779087,
+    "mtime": 1786214969.5404088,
     "ast_hash": "b0f11c60cc7ce4d4a1b89784f68cab53",
     "semantic_hash": ""
   },
   "backend/internal/http/daterange_test.go": {
-    "mtime": 1785382046.179924,
+    "mtime": 1786214969.5414116,
     "ast_hash": "2c3c9b75f321fd199b978bc124982387",
     "semantic_hash": ""
   },
   "backend/internal/http/transactions.go": {
-    "mtime": 1785382046.1830046,
-    "ast_hash": "30f728287fba077f817d5b1a3c1199ad",
+    "mtime": 1786215095.7068565,
+    "ast_hash": "3b020adbd53db14861729e6bc30d508a",
     "semantic_hash": ""
   },
   "backend/internal/http/transactions_live_test.go": {
-    "mtime": 1785382046.1850157,
+    "mtime": 1786214969.5594132,
     "ast_hash": "e3c5fbdf16e1d4080648e7a24abb3e2f",
     "semantic_hash": ""
   },
   "backend/internal/ratelimit/mutation.go": {
-    "mtime": 1786205675.6208014,
+    "mtime": 1786214969.5724096,
     "ast_hash": "e4d122b74f20fbd3f8a07b124527aaa9",
     "semantic_hash": ""
   },
   "backend/internal/ratelimit/mutation_test.go": {
-    "mtime": 1785382046.1910694,
+    "mtime": 1786214969.5734143,
     "ast_hash": "46c98e173ab058d9c1fef438d828e173",
     "semantic_hash": ""
   },
   "backend/migrations/00005_transactions_amount_bigint.sql": {
-    "mtime": 1785382046.1910694,
+    "mtime": 1786214969.5794156,
     "ast_hash": "ac7023a33b2e205a157a4b1e2b3aa435",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260729_042659_would_it_be_a_good_complement_or_suplement_adding.md": {
-    "mtime": 1785382046.237031,
+    "mtime": 1786214969.7724142,
     "ast_hash": "43ab680db9768f4eb226969cee01b17e",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260729_043740_should_nuchi_create_shared_claude_and_codex_skills.md": {
-    "mtime": 1785382046.237031,
+    "mtime": 1786214969.773407,
     "ast_hash": "f12f6b1c7257179f147c6ade0539538f",
     "semantic_hash": ""
   },
   "backend/internal/http/transactions_fkrace_test.go": {
-    "mtime": 1785382046.1830046,
+    "mtime": 1786214969.5574124,
     "ast_hash": "65f3f375698668cb25a569cfed65eee0",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0014-date-filters-parsed-in-utc.md": {
-    "mtime": 1785382046.284557,
+    "mtime": 1786214969.8284104,
     "ast_hash": "7afc0abc80baf4d158faffda9c12b7e9",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0015-out-of-range-amount-returns-400.md": {
-    "mtime": 1785382046.2865741,
+    "mtime": 1786214969.8304074,
     "ast_hash": "fdc85b6c64f7aa1c6661a13b2af2b701",
     "semantic_hash": ""
   },
   "lib/query-params.ts": {
-    "mtime": 1785382046.257614,
+    "mtime": 1786214969.794417,
     "ast_hash": "466ba851a6f782dbe9fcad81ce408fe2",
     "semantic_hash": ""
   },
   "docs/api/transactions.md": {
-    "mtime": 1786205798.1811972,
+    "mtime": 1786214969.652415,
     "ast_hash": "4eba0955b18b868f7c1b3508080ea8a6",
     "semantic_hash": ""
   },
   "docs/product/transactions.md": {
-    "mtime": 1786205675.6238768,
+    "mtime": 1786214969.6634083,
     "ast_hash": "a99fc7ec330667df86170bc8216d2982",
     "semantic_hash": ""
   },
   "backend/internal/http/transactions_bulk.go": {
-    "mtime": 1786205675.6156833,
+    "mtime": 1786214969.5534124,
     "ast_hash": "5057a157350f57861b2499efb670cc72",
     "semantic_hash": ""
   },
   "backend/internal/http/transactions_bulk_live_test.go": {
-    "mtime": 1786205675.6167073,
+    "mtime": 1786214969.5554073,
     "ast_hash": "3199014c856584a5f8c81fb970c00d0b",
     "semantic_hash": ""
   },
   "post-migration-improvements/claude-backend-improvements/0016-bulk-body-limit-enforced-against-the-stream.md": {
-    "mtime": 1786205675.6561148,
+    "mtime": 1786214969.8324082,
     "ast_hash": "53720804aca869e5d4d6744a4e29b232",
     "semantic_hash": ""
   },
   "backend/internal/http/transactions_bulk_order_test.go": {
-    "mtime": 1786205675.6177285,
+    "mtime": 1786214969.5564165,
     "ast_hash": "1378baad588cf863ef089c88c453ea72",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260808_121354_recheck_the_changes_and_doanother_review.md": {
-    "mtime": 1786205675.646038,
+    "mtime": 1786214969.7744126,
     "ast_hash": "1814ad3113896bb0ca6e69a79384604f",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260808_122407_check_the_tickets_going_foward__what_we_shall_cont.md": {
-    "mtime": 1786205675.6480496,
+    "mtime": 1786214969.7754083,
     "ast_hash": "daebc9936ba45a51029cf3ca5e62f677",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260808_134543_check_the_changes_introduced_for_your_reviews_and.md": {
-    "mtime": 1786205675.6480496,
+    "mtime": 1786214969.7774072,
     "ast_hash": "21b35d2dc70b3e62fb019a44841a5141",
     "semantic_hash": ""
   },
   "post-migration-improvements/codex-backend-improvements/Codex-atomic-multi-chunk-transaction-imports.md": {
-    "mtime": 1786205798.179185,
+    "mtime": 1786214969.844411,
     "ast_hash": "cfb8686ca1500c7e13df40c5a917b0e6",
     "semantic_hash": ""
   },
   "graphify-out/memory/query_20260808_161854_last_comment_address_if_you_have_anything_more_to.md": {
-    "mtime": 1786205934.9202065,
-    "ast_hash": "5b666f7e59862ae7dd5c4122aca53698",
+    "mtime": 1786214969.7784114,
+    "ast_hash": "464017fd7f9a1ef2d47944c9a1b6c739",
+    "semantic_hash": ""
+  },
+  "backend/internal/http/summary.go": {
+    "mtime": 1786215095.7123916,
+    "ast_hash": "88ce2cc730a72c4def430a7e90fa81a7",
+    "semantic_hash": ""
+  },
+  "backend/internal/http/summary_live_test.go": {
+    "mtime": 1786215280.6977985,
+    "ast_hash": "2a102b0f9163df9aaa83f400e08556a1",
+    "semantic_hash": ""
+  },
+  "backend/internal/http/summary_test.go": {
+    "mtime": 1786215170.968572,
+    "ast_hash": "716c6b1784be861857e6d3f5f188c2a5",
+    "semantic_hash": ""
+  },
+  "docs/api/summary.md": {
+    "mtime": 1786215353.5857306,
+    "ast_hash": "5fc2c165d324d553d9696230030a550b",
+    "semantic_hash": ""
+  },
+  "docs/product/summary.md": {
+    "mtime": 1786215378.748727,
+    "ast_hash": "5fb30afb0278b49d0bc60d0670749862",
+    "semantic_hash": ""
+  },
+  "post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md": {
+    "mtime": 1786215314.1706123,
+    "ast_hash": "8865d4bd33388ddb388fd79ca8bce0ea",
     "semantic_hash": ""
   }
 }

--- a/post-migration-improvements/README.md
+++ b/post-migration-improvements/README.md
@@ -107,3 +107,4 @@ gates. Numbering stays global and sequential within
 | 0014 | [Date filters are parsed in UTC, not the host timezone](claude-backend-improvements/0014-date-filters-parsed-in-utc.md) | api | low |
 | 0015 | [Out-of-range amounts return 400, where legacy returned 500](claude-backend-improvements/0015-out-of-range-amount-returns-400.md) | api | low |
 | 0016 | [Bulk body limits are enforced against the stream, not just Content-Length](claude-backend-improvements/0016-bulk-body-limit-enforced-against-the-stream.md) | http | low |
+| 0017 | [The summary category chart silently excludes uncategorized spending](claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md) | api/product | medium |

--- a/post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md
+++ b/post-migration-improvements/claude-backend-improvements/0017-summary-category-chart-excludes-uncategorized.md
@@ -1,0 +1,70 @@
+# 0017 — The summary category chart silently excludes uncategorized spending
+
+- **Migration ticket:** #48 (https://github.com/GonzaloSecades/nuchi/issues/48)
+- **Area:** api / product
+- **Priority guess:** medium
+
+## How it was migrated
+
+`GetCategorySpending` inner-joins `categories`, so the breakdown contains only
+expenses that have a category. `expensesAmount` comes from a separate query
+with no such join and therefore includes everything.
+
+Consequence: **the category chart does not sum to the expenses total** whenever
+the user has any uncategorized spending. A user with 155,000 in expenses, 1,000
+of it uncategorized, sees a chart totalling 154,000 with nothing explaining the
+gap.
+
+Ported faithfully. Legacy does exactly this — `innerJoin(categories, ...)` in
+`app/api/[[...route]]/summary.ts`.
+
+## Why it was done this way
+
+Parity freezes observable behavior, and this is observable: adding an
+"Uncategorized" bucket would change what the dashboard renders for most users
+on day one. The fixtures state the rule plainly ("Category breakdown includes
+only negative transactions with a category"), so it is frozen behavior rather
+than an oversight to quietly correct mid-migration.
+
+It is also genuinely a product decision rather than a bug to fix by reflex.
+Both readings are defensible:
+
+- **Current behavior:** the chart answers "where does my categorized spending
+  go", and an Uncategorized slice is noise that crowds out real categories —
+  especially for a user who has not set categories up yet, where it would be
+  100% of the chart.
+- **The alternative:** a chart that claims to break down expenses should
+  account for all of them, and the invisible gap is worse than an ugly slice
+  because the user cannot see that anything is missing.
+
+## The concern
+
+The numbers on one screen disagree and nothing says why. That is the kind of
+discrepancy that erodes trust in a finance app more than a missing feature
+would, because the user cannot tell whether the total or the chart is wrong.
+
+It also hides a real prompt: uncategorized spending is exactly what the user
+should be nudged to categorize, and the current design makes it invisible
+rather than actionable.
+
+Interacts with the `Other` bucket: with more than three categories the chart
+already aggregates a tail, so a user seeing "Other" may reasonably assume it
+covers uncategorized spending too. It does not.
+
+## Proposed improvement
+
+After parity, make the gap visible. In rough order of increasing effort:
+
+1. **Add an explicit `Uncategorized` entry** computed as
+   `expensesAmount - sum(categorized)`, so the chart always reconciles with the
+   total. Needs a decision on whether it participates in the top-3 ranking or
+   is pinned last — pinned last is probably right, since it is a prompt rather
+   than a category.
+2. **Surface it as a call to action** rather than a slice: "12,500 uncategorized
+   — categorize now", linking to a filtered transaction list.
+3. Revisit the fixed top-3 cap while there, which is a display choice hardcoded
+   in the API. Returning the full breakdown and letting the client decide how
+   many to show would make the endpoint less opinionated.
+
+Whichever is chosen, the contract's `SummaryCategory` description and the
+product documentation both need updating alongside it.

--- a/post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md
+++ b/post-migration-improvements/codex-backend-improvements/Codex-summary-aggregate-contract-range.md
@@ -1,0 +1,53 @@
+# Codex — Summary Aggregate Contract Range
+
+- **Modules/operations:** summary queries, `GET /api/summary`
+- **Owner:** summary/API contract
+- **Priority:** P2
+- **Parent registry entry:** none; discovered during migration ticket #48
+- **Target milestone:** post-migration Phase 2 — monetary correctness hardening
+
+## Problem and evidence
+
+Each transaction amount is bounded to JavaScript's safe integer range, but a
+summary adds an unbounded number of rows. The OpenAPI summary amount fields use
+that same safe range, while the SQL currently casts PostgreSQL's wider
+`SUM(bigint)` result back to `bigint`.
+
+Consequently, individually valid rows can produce an aggregate that does not
+fit either the API contract or, at a higher threshold, PostgreSQL `bigint`.
+There is no honest in-place parity fix: clamping returns incorrect money,
+floating-point output loses milliunit precision, and silently widening the JSON
+number violates the published safe-integer bound.
+
+## Required decision
+
+Choose and document one representation for aggregates beyond the current
+range:
+
+1. decimal strings with generated client helpers;
+2. a structured money value carrying a decimal amount and currency;
+3. a deliberately smaller per-user/per-period domain limit enforced at write
+   time and transactionally safe under concurrent mutations; or
+4. an explicit aggregate-range error response added to the contract.
+
+Do not use saturation or wrapping arithmetic. Until this decision lands, the
+migration retains existing response shapes and records the limitation rather
+than claiming the aggregate cannot overflow.
+
+## Verification
+
+- Boundary tests cover the largest representable positive and negative totals.
+- Bulk and concurrent writes cannot bypass any chosen domain limit.
+- Generated Go and TypeScript types match the selected representation.
+- Frontend currency formatting never passes an unsafe integer through a
+  JavaScript `number`.
+- Summary totals, categories, daily values, and percentage baselines follow the
+  same range policy.
+
+## Decision record
+
+- **Status:** proposed
+- **Decision/date:** pending
+- **Approvers:** pending
+- **Follow-up tickets:** create after the Go migration and legacy teardown are
+  complete

--- a/post-migration-improvements/codex-backend-improvements/README.md
+++ b/post-migration-improvements/codex-backend-improvements/README.md
@@ -35,7 +35,9 @@ Read in this order:
    phases, evidence, and release gates.
 6. [`Codex-atomic-multi-chunk-transaction-imports.md`](Codex-atomic-multi-chunk-transaction-imports.md)
    is the first scoped proposal produced from a migration review.
-7. [`templates/`](templates/) contains the required proposal and endpoint
+7. [`Codex-summary-aggregate-contract-range.md`](Codex-summary-aggregate-contract-range.md)
+   records the summary range mismatch that needs an explicit contract decision.
+8. [`templates/`](templates/) contains the required proposal and endpoint
    review templates.
 
 ## Decision hierarchy


### PR DESCRIPTION
Closes #48. **This is the last backend operation** — all 28 contract operations now have Go implementations.

## Mostly reuse, deliberately

The interesting thing about this ticket is how little new code it needed:

- **`parseDateRange` is reused verbatim.** Defaults, the "provided `to` doesn't re-anchor the default `from`" rule, the 366-day cap, UTC pinning, and the three exact `INVALID_QUERY` messages are literally the same code the transaction list runs.
- **All three sqlc queries landed in #40** and needed no changes — already `::bigint` cast, already `ABS(t.amount::bigint)`.
- **`accountId` handling was duplicated inline** in `ListTransactions`. Extracted as `accountIDFilter`; both handlers now share it rather than drifting.

## Four queries, one transaction

Current totals, previous-period totals, category spending, daily series — all inside one `WithUserTx`. One RLS binding, and one snapshot: legacy fires them independently, so a write landing mid-request can make its totals disagree with its own daily series.

## The parts that look wrong and aren't

**The comparison period is length-based.** A 30-day view compares against the 30 days immediately before it — never "last month". Ported exactly from `differenceInCalendarDays` + `subDays`.

**`percentageChange`'s zero rule is a product decision, not a divide-by-zero guard.** 0 when both periods are empty; 100 when something appears from nothing. Both branches tested. It's the only float in the money path — a ratio, not an amount — and the division runs in `float64` so a 0.5% change isn't truncated to zero (that case is pinned).

**The category chart doesn't sum to the expenses total.** Uncategorized spending counts toward `expensesAmount` but is excluded from the breakdown, and nothing explains the gap. Legacy behavior, ported faithfully, recorded as **improvement 0017** with the product options. The live test asserts the discrepancy explicitly (155,000 total vs 154,000 charted) rather than leaving it implied — if someone "fixes" it without deciding, that test fails and asks the question.

## Coverage

- **21 unit cases** for the pure arithmetic — percentage change across 8 states plus the float-division guard, bucketing across the top-3 boundary, day filling across gaps at both ends and the middle.
- **21 live subtests** — totals, empty state, comparison window, category exclusions, daily series, account filter, cross-user isolation, the three date errors plus empty `accountId`, and four unauthorized modes.

Empty state is asserted on the raw wire body: `categories: []` never `null`, and `days` fully populated with 31 zero entries.

## Docs

`docs/api/summary.md` and `docs/product/summary.md`. The product one leads with the two questions this endpoint will actually generate: why the comparison isn't month-over-month, and why the chart doesn't add up.

## Verification

Full backend suite green against live PostgreSQL, `go vet` clean, `openapi:validate` 28 operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)