### PR TITLE
[Issue - #50] Migrate accounts and categories hooks to the generated client

### DIFF
--- a/app/(dashboard)/accounts/columns.tsx
+++ b/app/(dashboard)/accounts/columns.tsx
@@ -1,19 +1,14 @@
 'use client';
 
-import { InferResponseType } from 'hono';
-
 import { ColumnDef } from '@tanstack/react-table';
 import { ArrowUpDown } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { client } from '@/lib/hono';
+import type { components } from '@/lib/api/generated/schema';
 import { Actions } from './actions';
 
-export type ResponseType = InferResponseType<
-  typeof client.api.accounts.$get,
-  200
->['data'][0];
+export type ResponseType = components['schemas']['AccountSummary'];
 
 export const columns: ColumnDef<ResponseType>[] = [
   {

--- a/app/(dashboard)/categories/columns.tsx
+++ b/app/(dashboard)/categories/columns.tsx
@@ -1,19 +1,14 @@
 'use client';
 
-import { InferResponseType } from 'hono';
-
 import { ColumnDef } from '@tanstack/react-table';
 import { ArrowUpDown } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { client } from '@/lib/hono';
+import type { components } from '@/lib/api/generated/schema';
 import { Actions } from './actions';
 
-export type ResponseType = InferResponseType<
-  typeof client.api.categories.$get,
-  200
->['data'][0];
+export type ResponseType = components['schemas']['CategorySummary'];
 
 export const columns: ColumnDef<ResponseType>[] = [
   {

--- a/features/accounts/api/account-mutation-error.test.ts
+++ b/features/accounts/api/account-mutation-error.test.ts
@@ -35,6 +35,21 @@ describe('accountMutationErrorMessage', () => {
     );
   });
 
+  it('uses the existing fallback when the API error has no message', () => {
+    const error = new ApiError('Failed to fetch accounts: 500', {
+      status: 500,
+      statusText: 'Internal Server Error',
+      url: '/api/accounts',
+      resource: 'accounts',
+      timestamp: '2026-08-08T00:00:00.000Z',
+      errorData: null,
+    });
+
+    expect(accountMutationErrorMessage(error, 'Error creating account')).toBe(
+      'Error creating account'
+    );
+  });
+
   it('uses the existing fallback for non-API errors', () => {
     expect(
       accountMutationErrorMessage(new Error('boom'), 'Error creating account')

--- a/features/accounts/api/account-mutation-error.test.ts
+++ b/features/accounts/api/account-mutation-error.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+
+import { ApiError } from '@/lib/api-error';
+
+import { accountMutationErrorMessage } from './account-mutation-error';
+import { accountPathParams } from './account-path-params';
+
+const apiError = (code: string, message: string) =>
+  new ApiError(message, {
+    status: 409,
+    statusText: 'Conflict',
+    url: '/api/accounts',
+    resource: 'accounts',
+    timestamp: '2026-08-08T00:00:00.000Z',
+    errorData: { error: { code, message } },
+  });
+
+describe('accountMutationErrorMessage', () => {
+  it('uses the API message for a duplicate account name', () => {
+    const error = apiError(
+      'DUPLICATE_ACCOUNT_NAME',
+      'You already have an account with this name.'
+    );
+
+    expect(accountMutationErrorMessage(error, 'Error creating account')).toBe(
+      'You already have an account with this name.'
+    );
+  });
+
+  it('keeps structured messages for other API errors', () => {
+    const error = apiError('DB_ERROR', 'Database unavailable');
+
+    expect(accountMutationErrorMessage(error, 'Error editing account')).toBe(
+      'Database unavailable'
+    );
+  });
+
+  it('uses the existing fallback for non-API errors', () => {
+    expect(
+      accountMutationErrorMessage(new Error('boom'), 'Error creating account')
+    ).toBe('Error creating account');
+  });
+});
+
+describe('accountPathParams', () => {
+  it('builds the generated client path parameters', () => {
+    expect(accountPathParams('account-1')).toEqual({
+      path: { id: 'account-1' },
+    });
+  });
+
+  it('rejects an absent id before a request can retain the path placeholder', () => {
+    expect(() => accountPathParams()).toThrow('Account id is required');
+    expect(() => accountPathParams('')).toThrow('Account id is required');
+  });
+});

--- a/features/accounts/api/account-mutation-error.ts
+++ b/features/accounts/api/account-mutation-error.ts
@@ -1,0 +1,12 @@
+import { ApiError } from '@/lib/api-error';
+
+export const accountMutationErrorMessage = (
+  error: unknown,
+  fallback: string
+): string => {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return fallback;
+};

--- a/features/accounts/api/account-mutation-error.ts
+++ b/features/accounts/api/account-mutation-error.ts
@@ -5,7 +5,15 @@ export const accountMutationErrorMessage = (
   fallback: string
 ): string => {
   if (error instanceof ApiError) {
-    return error.message;
+    const apiMessage = (
+      error.details.errorData as {
+        error?: { message?: unknown };
+      } | null
+    )?.error?.message;
+
+    if (typeof apiMessage === 'string' && apiMessage !== '') {
+      return apiMessage;
+    }
   }
 
   return fallback;

--- a/features/accounts/api/account-path-params.ts
+++ b/features/accounts/api/account-path-params.ts
@@ -1,0 +1,7 @@
+export const accountPathParams = (id?: string) => {
+  if (!id) {
+    throw new Error('Account id is required');
+  }
+
+  return { path: { id } };
+};

--- a/features/accounts/api/use-bulk-delete-accounts.ts
+++ b/features/accounts/api/use-bulk-delete-accounts.ts
@@ -1,31 +1,23 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+import type { components } from '@/lib/api/generated/schema';
 
-type ResponseType = InferResponseType<
-  (typeof client.api.accounts)['bulk-delete']['$post']
->;
-type RequestType = InferRequestType<
-  (typeof client.api.accounts)['bulk-delete']['$post']
->['json'];
+type ResponseType = components['schemas']['DeletedResourceListResponse'];
+type RequestType = components['schemas']['BulkDeleteRequest'];
 
 export const useBulkDeleteAccounts = () => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation<ResponseType, Error, RequestType>({
     mutationFn: async (json) => {
-      const response = await client.api.accounts['bulk-delete']['$post']({
-        json,
+      const result = await apiClient.POST('/accounts/bulk-delete', {
+        body: json,
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'accounts');
-      }
-      return await response.json();
+      return unwrap(result, 'accounts');
     },
     onSuccess: () => {
       toast.success('Accounts deleted successfully');

--- a/features/accounts/api/use-create-account.ts
+++ b/features/accounts/api/use-create-account.ts
@@ -1,38 +1,30 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { ApiError, createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+import type { components } from '@/lib/api/generated/schema';
 
-type ResponseType = InferResponseType<typeof client.api.accounts.$post>;
-type RequestType = InferRequestType<typeof client.api.accounts.$post>['json'];
+import { accountMutationErrorMessage } from './account-mutation-error';
+
+type ResponseType = components['schemas']['AccountResponse'];
+type RequestType = components['schemas']['AccountInput'];
 
 export const useCreateAccount = () => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation<ResponseType, Error, RequestType>({
     mutationFn: async (json) => {
-      const response = await client.api.accounts.$post({ json });
+      const result = await apiClient.POST('/accounts', { body: json });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'accounts');
-      }
-      return await response.json();
+      return unwrap(result, 'accounts');
     },
     onSuccess: () => {
       toast.success('Account created successfully');
       queryClient.invalidateQueries({ queryKey: ['accounts'] });
     },
     onError: (error) => {
-      const apiMessage =
-        error instanceof ApiError
-          ? (error.details.errorData as { error?: { message?: string } } | null)
-              ?.error?.message
-          : null;
-
-      toast.error(apiMessage ?? 'Error creating account');
+      toast.error(accountMutationErrorMessage(error, 'Error creating account'));
     },
   });
   return mutation;

--- a/features/accounts/api/use-delete-account.ts
+++ b/features/accounts/api/use-delete-account.ts
@@ -1,28 +1,24 @@
-import { InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+import type { components } from '@/lib/api/generated/schema';
 
-type ResponseType = InferResponseType<
-  (typeof client.api.accounts)[':id']['$delete']
->;
+import { accountPathParams } from './account-path-params';
+
+type ResponseType = components['schemas']['DeletedResourceResponse'];
 
 export const useDeleteAccount = (id?: string) => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation<ResponseType, Error>({
     mutationFn: async () => {
-      const response = await client.api.accounts[':id']['$delete']({
-        param: { id: id },
+      const result = await apiClient.DELETE('/accounts/{id}', {
+        params: accountPathParams(id),
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'delete account ');
-      }
-      return await response.json();
+      return unwrap(result, 'delete account ');
     },
     onSuccess: () => {
       toast.success('Account deleted successfully');

--- a/features/accounts/api/use-delete-account.ts
+++ b/features/accounts/api/use-delete-account.ts
@@ -18,7 +18,7 @@ export const useDeleteAccount = (id?: string) => {
         params: accountPathParams(id),
       });
 
-      return unwrap(result, 'delete account ');
+      return unwrap(result, 'delete account');
     },
     onSuccess: () => {
       toast.success('Account deleted successfully');

--- a/features/accounts/api/use-edit-account.ts
+++ b/features/accounts/api/use-edit-account.ts
@@ -21,7 +21,7 @@ export const useEditAccount = (id?: string) => {
         body: json,
       });
 
-      return unwrap(result, 'edit account ');
+      return unwrap(result, 'edit account');
     },
     onSuccess: () => {
       toast.success('Account edited successfully');

--- a/features/accounts/api/use-edit-account.ts
+++ b/features/accounts/api/use-edit-account.ts
@@ -1,32 +1,27 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { ApiError, createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+import type { components } from '@/lib/api/generated/schema';
 
-type ResponseType = InferResponseType<
-  (typeof client.api.accounts)[':id']['$patch']
->;
-type RequestType = InferRequestType<
-  (typeof client.api.accounts)[':id']['$patch']
->['json'];
+import { accountMutationErrorMessage } from './account-mutation-error';
+import { accountPathParams } from './account-path-params';
+
+type ResponseType = components['schemas']['AccountResponse'];
+type RequestType = components['schemas']['AccountInput'];
 
 export const useEditAccount = (id?: string) => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation<ResponseType, Error, RequestType>({
     mutationFn: async (json) => {
-      const response = await client.api.accounts[':id']['$patch']({
-        param: { id: id },
-        json,
+      const result = await apiClient.PATCH('/accounts/{id}', {
+        params: accountPathParams(id),
+        body: json,
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'edit account ');
-      }
-      return await response.json();
+      return unwrap(result, 'edit account ');
     },
     onSuccess: () => {
       toast.success('Account edited successfully');
@@ -36,13 +31,7 @@ export const useEditAccount = (id?: string) => {
       queryClient.invalidateQueries({ queryKey: ['summary'] }); //jic
     },
     onError: (error) => {
-      const apiMessage =
-        error instanceof ApiError
-          ? (error.details.errorData as { error?: { message?: string } } | null)
-              ?.error?.message
-          : null;
-
-      toast.error(apiMessage ?? 'Error editing account');
+      toast.error(accountMutationErrorMessage(error, 'Error editing account'));
     },
   });
   return mutation;

--- a/features/accounts/api/use-get-account.ts
+++ b/features/accounts/api/use-get-account.ts
@@ -2,23 +2,20 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+
+import { accountPathParams } from './account-path-params';
 
 export const useGetAccount = (id?: string) => {
   const query = useQuery({
     enabled: !!id,
     queryKey: ['accounts', { id }],
     queryFn: async () => {
-      const response = await client.api.accounts[':id'].$get({
-        param: { id },
+      const result = await apiClient.GET('/accounts/{id}', {
+        params: accountPathParams(id),
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'getSingleAccount');
-      }
-
-      const { data } = await response.json();
+      const { data } = unwrap(result, 'getSingleAccount');
       return data;
     },
   });

--- a/features/accounts/api/use-get-accounts.ts
+++ b/features/accounts/api/use-get-accounts.ts
@@ -2,20 +2,15 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
 
 export const useGetAccounts = () => {
   const query = useQuery({
     queryKey: ['accounts'],
     queryFn: async () => {
-      const response = await client.api.accounts.$get();
+      const result = await apiClient.GET('/accounts');
 
-      if (!response.ok) {
-        throw await createApiError(response, 'accounts');
-      }
-
-      const { data } = await response.json();
+      const { data } = unwrap(result, 'accounts');
       return data;
     },
   });

--- a/features/categories/api/category-mutation-error.ts
+++ b/features/categories/api/category-mutation-error.ts
@@ -1,0 +1,20 @@
+import { ApiError } from '@/lib/api-error';
+
+export const categoryMutationErrorMessage = (
+  error: unknown,
+  fallback: string
+): string => {
+  if (error instanceof ApiError) {
+    const apiMessage = (
+      error.details.errorData as {
+        error?: { message?: unknown };
+      } | null
+    )?.error?.message;
+
+    if (typeof apiMessage === 'string' && apiMessage !== '') {
+      return apiMessage;
+    }
+  }
+
+  return fallback;
+};

--- a/features/categories/api/category-path-params.ts
+++ b/features/categories/api/category-path-params.ts
@@ -1,0 +1,7 @@
+export const categoryPathParams = (id?: string) => {
+  if (!id) {
+    throw new Error('Category id is required');
+  }
+
+  return { path: { id } };
+};

--- a/features/categories/api/category-transport.test.ts
+++ b/features/categories/api/category-transport.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+
+import { ApiError } from '@/lib/api-error';
+
+import { categoryMutationErrorMessage } from './category-mutation-error';
+import { categoryPathParams } from './category-path-params';
+
+const apiError = (message: string) =>
+  new ApiError(message, {
+    status: 409,
+    statusText: 'Conflict',
+    url: '/api/categories',
+    resource: 'categories',
+    timestamp: '2026-08-09T00:00:00.000Z',
+    errorData: {
+      error: { code: 'DUPLICATE_CATEGORY_NAME', message },
+    },
+  });
+
+describe('categoryMutationErrorMessage', () => {
+  it('keeps the API message used by the existing create hook', () => {
+    expect(
+      categoryMutationErrorMessage(
+        apiError('You already have a category with this name.'),
+        'Error creating category'
+      )
+    ).toBe('You already have a category with this name.');
+  });
+
+  it('uses the existing fallback when no structured message exists', () => {
+    expect(
+      categoryMutationErrorMessage(
+        new Error('network failure'),
+        'Error creating category'
+      )
+    ).toBe('Error creating category');
+  });
+});
+
+describe('categoryPathParams', () => {
+  it('builds generated-client path parameters', () => {
+    expect(categoryPathParams('category-1')).toEqual({
+      path: { id: 'category-1' },
+    });
+  });
+
+  it('rejects a missing id before the path placeholder reaches fetch', () => {
+    expect(() => categoryPathParams()).toThrow('Category id is required');
+    expect(() => categoryPathParams('')).toThrow('Category id is required');
+  });
+});

--- a/features/categories/api/use-bulk-delete-categories.ts
+++ b/features/categories/api/use-bulk-delete-categories.ts
@@ -1,31 +1,23 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+import type { components } from '@/lib/api/generated/schema';
 
-type ResponseType = InferResponseType<
-  (typeof client.api.categories)['bulk-delete']['$post']
->;
-type RequestType = InferRequestType<
-  (typeof client.api.categories)['bulk-delete']['$post']
->['json'];
+type ResponseType = components['schemas']['DeletedResourceListResponse'];
+type RequestType = components['schemas']['BulkDeleteRequest'];
 
 export const useBulkDeleteCategories = () => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation<ResponseType, Error, RequestType>({
     mutationFn: async (json) => {
-      const response = await client.api.categories['bulk-delete']['$post']({
-        json,
+      const result = await apiClient.POST('/categories/bulk-delete', {
+        body: json,
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'categories');
-      }
-      return await response.json();
+      return unwrap(result, 'categories');
     },
     onSuccess: () => {
       toast.success('Categories deleted successfully');

--- a/features/categories/api/use-create-category.ts
+++ b/features/categories/api/use-create-category.ts
@@ -1,38 +1,32 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { ApiError, createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+import type { components } from '@/lib/api/generated/schema';
 
-type ResponseType = InferResponseType<typeof client.api.categories.$post>;
-type RequestType = InferRequestType<typeof client.api.categories.$post>['json'];
+import { categoryMutationErrorMessage } from './category-mutation-error';
+
+type ResponseType = components['schemas']['CategoryResponse'];
+type RequestType = components['schemas']['CategoryInput'];
 
 export const useCreateCategory = () => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation<ResponseType, Error, RequestType>({
     mutationFn: async (json) => {
-      const response = await client.api.categories.$post({ json });
+      const result = await apiClient.POST('/categories', { body: json });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'categories');
-      }
-      return await response.json();
+      return unwrap(result, 'categories');
     },
     onSuccess: () => {
       toast.success('Category created successfully');
       queryClient.invalidateQueries({ queryKey: ['categories'] });
     },
     onError: (error) => {
-      const apiMessage =
-        error instanceof ApiError
-          ? (error.details.errorData as { error?: { message?: string } } | null)
-              ?.error?.message
-          : null;
-
-      toast.error(apiMessage ?? 'Error creating category');
+      toast.error(
+        categoryMutationErrorMessage(error, 'Error creating category')
+      );
     },
   });
   return mutation;

--- a/features/categories/api/use-delete-category.ts
+++ b/features/categories/api/use-delete-category.ts
@@ -18,7 +18,7 @@ export const useDeleteCategory = (id?: string) => {
         params: categoryPathParams(id),
       });
 
-      return unwrap(result, 'delete category ');
+      return unwrap(result, 'delete category');
     },
     onSuccess: () => {
       toast.success('Category deleted successfully');

--- a/features/categories/api/use-delete-category.ts
+++ b/features/categories/api/use-delete-category.ts
@@ -1,28 +1,24 @@
-import { InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+import type { components } from '@/lib/api/generated/schema';
 
-type ResponseType = InferResponseType<
-  (typeof client.api.categories)[':id']['$delete']
->;
+import { categoryPathParams } from './category-path-params';
+
+type ResponseType = components['schemas']['DeletedResourceResponse'];
 
 export const useDeleteCategory = (id?: string) => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation<ResponseType, Error>({
     mutationFn: async () => {
-      const response = await client.api.categories[':id']['$delete']({
-        param: { id: id },
+      const result = await apiClient.DELETE('/categories/{id}', {
+        params: categoryPathParams(id),
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'delete category ');
-      }
-      return await response.json();
+      return unwrap(result, 'delete category ');
     },
     onSuccess: () => {
       toast.success('Category deleted successfully');

--- a/features/categories/api/use-edit-category.ts
+++ b/features/categories/api/use-edit-category.ts
@@ -1,32 +1,26 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+import type { components } from '@/lib/api/generated/schema';
 
-type ResponseType = InferResponseType<
-  (typeof client.api.categories)[':id']['$patch']
->;
-type RequestType = InferRequestType<
-  (typeof client.api.categories)[':id']['$patch']
->['json'];
+import { categoryPathParams } from './category-path-params';
+
+type ResponseType = components['schemas']['CategoryResponse'];
+type RequestType = components['schemas']['CategoryInput'];
 
 export const useEditCategory = (id?: string) => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation<ResponseType, Error, RequestType>({
     mutationFn: async (json) => {
-      const response = await client.api.categories[':id']['$patch']({
-        param: { id: id },
-        json,
+      const result = await apiClient.PATCH('/categories/{id}', {
+        params: categoryPathParams(id),
+        body: json,
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'edit category ');
-      }
-      return await response.json();
+      return unwrap(result, 'edit category ');
     },
     onSuccess: () => {
       toast.success('Category edited successfully');

--- a/features/categories/api/use-edit-category.ts
+++ b/features/categories/api/use-edit-category.ts
@@ -20,7 +20,7 @@ export const useEditCategory = (id?: string) => {
         body: json,
       });
 
-      return unwrap(result, 'edit category ');
+      return unwrap(result, 'edit category');
     },
     onSuccess: () => {
       toast.success('Category edited successfully');

--- a/features/categories/api/use-get-categories.ts
+++ b/features/categories/api/use-get-categories.ts
@@ -2,20 +2,15 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
 
 export const useGetCategories = () => {
   const query = useQuery({
     queryKey: ['categories'],
     queryFn: async () => {
-      const response = await client.api.categories.$get();
+      const result = await apiClient.GET('/categories');
 
-      if (!response.ok) {
-        throw await createApiError(response, 'categories');
-      }
-
-      const { data } = await response.json();
+      const { data } = unwrap(result, 'categories');
       return data;
     },
   });

--- a/features/categories/api/use-get-category.ts
+++ b/features/categories/api/use-get-category.ts
@@ -1,22 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
+
+import { categoryPathParams } from './category-path-params';
 
 export const useGetCategory = (id?: string) => {
   const query = useQuery({
     enabled: !!id,
     queryKey: ['category', { id }],
     queryFn: async () => {
-      const response = await client.api.categories[':id'].$get({
-        param: { id },
+      const result = await apiClient.GET('/categories/{id}', {
+        params: categoryPathParams(id),
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'getSingleCategory');
-      }
-
-      const { data } = await response.json();
+      const { data } = unwrap(result, 'getSingleCategory');
       return data;
     },
   });


### PR DESCRIPTION
## Summary

- migrate all six accounts hooks and all six categories hooks from Hono RPC to the authenticated generated OpenAPI client
- preserve hook APIs, response envelopes, query keys, invalidations, and existing toast behavior
- reject missing account/category path IDs before openapi-fetch can send a literal `{id}` placeholder
- remove the accounts and categories table runtime dependency on the legacy Hono client

## Why

This completes the accounts/categories half of issue #50. Together with #81, every active account, category, transaction, and summary server-state hook uses the generated client required by the Go-auth cutover in #80.

## Verification

- `bun run lint` — passed
- `bun test` — 80 passed, 0 failed
- `bun run build` with CI environment values — passed
- generated-client path/error behavior covered by focused Bun tests
- Graphify refreshed locally; generated graph files intentionally excluded from the feature commit

## Follow-up classification

The pre-existing account detail key mismatch (`['accounts', { id }]` query versus singular mutation invalidation) remains unchanged to preserve ticket parity. Track it as **Future improvement — post migration** rather than expanding this cutover PR.

Refs #50