### PR TITLE
[Issue - #73] Document accounts and categories

### DIFF
--- a/docs/api/accounts.md
+++ b/docs/api/accounts.md
@@ -1,0 +1,90 @@
+# Accounts API — Technical Reference
+
+Go implementation reference for the accounts domain. Companion to the contract
+(`openapi/nuchi.openapi.json`), which is authoritative for operation shapes and
+status codes; this document covers the behavior the contract cannot express.
+
+The Go account API shipped in
+[#44](https://github.com/GonzaloSecades/nuchi/issues/44). Its six operations are
+mounted inside the `RequireAuth` group in `backend/internal/http/router.go`.
+
+## Ownership model
+
+Every account row carries the authenticated user's internal UUID in `user_id`.
+Handlers obtain that identity only from `UserIDFromContext` and run their SQL
+inside `db.WithUserTx`, which binds the same UUID to `app.user_id` for the RLS
+policy.
+
+SQL still includes `user_id = caller` on every read and mutation. RLS is the
+backstop, not a replacement for explicit ownership predicates or for stable
+user-facing errors.
+
+### Why a foreign account is a 404
+
+Get, update, and delete match `id` and `user_id` in one statement. A missing ID
+and another user's ID therefore produce the same no-row result and the same
+`ACCOUNT_NOT_FOUND` response. This is deliberate non-disclosure: callers cannot
+use the API to confirm that someone else's account exists.
+
+Do not add an unscoped existence check to produce a more specific error. Apart
+from leaking ownership, a check followed by a mutation would introduce a race
+that the current conditional statement avoids.
+
+Bulk delete follows the same privacy rule differently: IDs that are missing or
+unowned are silently ignored, and the response contains only rows the caller
+actually deleted. It never turns a skipped ID into a 404. The ergonomic cost of
+that partial-success contract is recorded in
+[improvement 0004](../../post-migration-improvements/claude-backend-improvements/0004-bulk-delete-silent-ignore.md).
+
+## Case-insensitive names
+
+`accounts.name` is PostgreSQL `citext`, with a unique index on `(user_id,
+name)`. Consequences:
+
+- `Cash` and `cash` collide for the same user.
+- Two different users may each have an account named `Cash`.
+- The database constraint, not an application pre-check, decides conflicts, so
+  concurrent creates and renames cannot both win.
+- Names are stored as submitted. `citext` folds case but does not trim
+  whitespace; adding normalization would be a product and contract change.
+
+Both create and update map PostgreSQL unique violations to
+`DUPLICATE_ACCOUNT_NAME`. Keep that mapping tied to the stable error code and
+constraint, never to human-readable message text.
+
+## Deleting an account deletes its transactions
+
+`transactions.account_id` is required and uses `ON DELETE CASCADE`. Deleting an
+account—singly or in bulk—therefore permanently removes every transaction under
+it. This is enforced by the foreign key, not by a second handler query.
+
+That behavior is load-bearing for ownership: a transaction cannot exist without
+an account, and its owner is derived through that account. Replacing the cascade
+with application cleanup, nulling the account, or soft-deleting only one side
+would break the model.
+
+## Non-negotiables when changing this code
+
+- Use `db.WithUserTx`; a bare `dbgen.New(pool)` has no RLS identity and can
+  silently return zero rows.
+- Derive identity from the verified request context only. Never accept a user
+  ID from a body, path, query parameter, or header.
+- Keep SQL ownership predicates in addition to RLS.
+- Keep single update/delete as conditional statements rather than existence
+  check plus mutation.
+- Preserve database-enforced, per-user `citext` uniqueness and map conflicts by
+  error code.
+- Preserve the cascade when changing account or transaction foreign keys.
+- Serialize empty lists and empty bulk-delete results as `[]`, never `null`.
+- Log driver errors server-side only; never expose database internals.
+
+## Where the code lives
+
+| Concern                                          | File                                        |
+| ------------------------------------------------ | ------------------------------------------- |
+| Handlers, validation, projections, error mapping | `backend/internal/http/accounts.go`         |
+| Queries and ownership predicates                 | `backend/internal/db/queries/accounts.sql`  |
+| Table, unique index, cascade foreign key         | `backend/migrations/00002_finance_base.sql` |
+| RLS policy                                       | `backend/migrations/00003_finance_rls.sql`  |
+| RLS-bound transaction helper                     | `backend/internal/db/rls.go`                |
+| Routes                                           | `backend/internal/http/router.go`           |

--- a/docs/api/categories.md
+++ b/docs/api/categories.md
@@ -1,0 +1,84 @@
+# Categories API — Technical Reference
+
+Go implementation reference for the categories domain. Companion to the
+contract (`openapi/nuchi.openapi.json`), which is authoritative for operation
+shapes and status codes; this document covers the behavior the contract cannot
+express.
+
+The Go category API shipped in
+[#45](https://github.com/GonzaloSecades/nuchi/issues/45). Its six operations are
+mounted inside the `RequireAuth` group in `backend/internal/http/router.go`.
+
+## Ownership model
+
+Every category row carries the authenticated user's internal UUID in `user_id`.
+Handlers take that identity only from `UserIDFromContext` and execute through
+`db.WithUserTx`, which binds the same UUID for PostgreSQL RLS.
+
+Every query also includes an ownership predicate. Get, update, and delete match
+`id` and `user_id` together, so a missing category and a foreign category are
+indistinguishable and both return `CATEGORY_NOT_FOUND`. This is intentional: a
+caller must not be able to discover whether another user's category exists.
+
+Do not replace the conditional update/delete with an unscoped existence check.
+That would both leak information and introduce a check-then-write race.
+
+Bulk delete silently ignores missing and unowned IDs and returns only the
+categories actually deleted. It never 404s for an individual skipped ID. See
+[improvement 0004](../../post-migration-improvements/claude-backend-improvements/0004-bulk-delete-silent-ignore.md)
+for the privacy/ergonomics tradeoff.
+
+## Case-insensitive names
+
+`categories.name` is PostgreSQL `citext`, with a unique index on `(user_id,
+name)`. `Groceries` and `groceries` therefore collide for one user, while
+different users may use the same name.
+
+The unique index is the concurrency-safe decision point. Do not add a preflight
+duplicate query or compare lowercased strings in Go. Names are stored exactly as
+submitted: case comparison is insensitive, but whitespace is not trimmed.
+
+Both create and update map unique violations to
+`DUPLICATE_CATEGORY_NAME`. Update returning a structured duplicate conflict is
+an explicit contract decision rather than a copy of legacy Hono's accidental
+server error; the history is retained in
+[improvement 0005](../../post-migration-improvements/claude-backend-improvements/0005-category-duplicate-update-500.md).
+
+## Deleting a category keeps its transactions
+
+`transactions.category_id` is optional and uses `ON DELETE SET NULL`. Deleting
+a category—singly or in bulk—does not remove transaction history. Referencing
+transactions survive and become uncategorized.
+
+The foreign key performs this transition; the handler does not issue a second
+update. This is deliberately opposite to account deletion, where the required
+account relationship cascades transaction deletion. Any migration changing
+either foreign key must preserve that distinction or make an explicit product
+and contract change.
+
+## Non-negotiables when changing this code
+
+- Use `db.WithUserTx`; a bare `dbgen.New(pool)` has no RLS identity and can
+  silently return zero rows.
+- Derive identity only from the verified request context, never caller input.
+- Keep SQL ownership predicates as well as RLS.
+- Keep single update/delete as conditional statements rather than existence
+  check plus mutation.
+- Preserve database-enforced, per-user `citext` uniqueness and stable error
+  codes on both create and update.
+- Preserve `ON DELETE SET NULL`; deleting a category must not delete its
+  transactions.
+- Serialize empty lists and empty bulk-delete results as `[]`, never `null`.
+- Log driver errors server-side only; never expose database internals.
+
+## Where the code lives
+
+| Concern                                          | File                                                           |
+| ------------------------------------------------ | -------------------------------------------------------------- |
+| Handlers, validation, projections, error mapping | `backend/internal/http/categories.go`                          |
+| Queries and ownership predicates                 | `backend/internal/db/queries/categories.sql`                   |
+| Table, unique index, set-null foreign key        | `backend/migrations/00002_finance_base.sql`                    |
+| Category RLS policy                              | `backend/migrations/00003_finance_rls.sql`                     |
+| Transaction category-ownership RLS check         | `backend/migrations/00004_transactions_category_owner_rls.sql` |
+| RLS-bound transaction helper                     | `backend/internal/db/rls.go`                                   |
+| Routes                                           | `backend/internal/http/router.go`                              |

--- a/docs/product/accounts.md
+++ b/docs/product/accounts.md
@@ -40,8 +40,9 @@ case-insensitive duplicate produces:
 Another user may use the same name—the rule is per person, not global.
 
 Names are not trimmed or otherwise normalized. Leading and trailing spaces are
-significant, so `Cash` and `Cash` are currently different names. The UI should
-not rely on whitespace to create distinctions people cannot see easily.
+significant, so `Cash` and `␠Cash␠` are currently different names (`␠` marks a
+space). The UI should not rely on whitespace to create distinctions people
+cannot see easily.
 
 ## Deleting an account deletes its transaction history
 

--- a/docs/product/accounts.md
+++ b/docs/product/accounts.md
@@ -1,0 +1,93 @@
+# Accounts — Product Behavior
+
+What accounts mean to a user, how naming and privacy work, what deletion does,
+and the messages support will encounter.
+
+Written for product decisions and support answers. For implementation rules see
+[the technical reference](../api/accounts.md).
+
+## What an account is
+
+An account is a named container for transactions: Cash, Checking, Savings, or
+any label the user chooses. Every transaction belongs to exactly one account,
+and that relationship is also how the app decides who owns the transaction.
+
+Accounts do not currently calculate or store a separate opening balance. The
+dashboard and transaction views derive money activity from the transactions
+inside the account.
+
+## Accounts are private to one user
+
+A user can list, view, rename, and delete only their own accounts. Asking for an
+account that does not exist and asking for another user's account produce the
+same response: `"Account not found."`
+
+That ambiguity is deliberate. The app does not confirm that another person's
+account exists.
+
+When a bulk delete contains a stale, missing, or foreign ID, that ID is skipped
+without an error. Owned matches are still deleted. This protects privacy but
+means a bulk action can partially succeed; the response identifies only what
+was actually removed.
+
+## Names are unique without regard to case
+
+One user cannot have both `Cash` and `cash`. Trying to create or rename into a
+case-insensitive duplicate produces:
+
+> You already have an account with this name.
+
+Another user may use the same name—the rule is per person, not global.
+
+Names are not trimmed or otherwise normalized. Leading and trailing spaces are
+significant, so `Cash` and `Cash` are currently different names. The UI should
+not rely on whitespace to create distinctions people cannot see easily.
+
+## Deleting an account deletes its transaction history
+
+Deleting an account permanently deletes every transaction assigned to it. The
+dashboard totals and charts change accordingly. Bulk deletion has the same
+effect for each account it removes.
+
+This is not what category deletion does: deleting a category keeps its
+transactions and makes them uncategorized. For accounts there is no equivalent
+"unassigned" state, because every transaction must have an account.
+
+There is no archive, restore, or automatic reassignment step today. Support
+should treat account deletion as destructive, not as hiding an account from the
+list.
+
+## Messages a user can encounter
+
+| Situation                                                 | Exact message                                       |
+| --------------------------------------------------------- | --------------------------------------------------- |
+| Name missing or empty                                     | `Name is required.`                                 |
+| Name duplicates another, including a case-only difference | `You already have an account with this name.`       |
+| Account missing or owned by someone else                  | `Account not found.`                                |
+| Bulk delete has no selected IDs                           | `At least one id is required.`                      |
+| Bulk delete contains an empty ID                          | `Ids must not be empty.`                            |
+| Database problem                                          | Generic failure notice; details stay in server logs |
+
+## What this deliberately cannot do yet
+
+1. **No safe archive or restore.** Delete is permanent and cascades through all
+   transactions in the account.
+2. **No reassignment during deletion.** Transactions cannot be moved to another
+   account as part of the delete action.
+3. **No bank connection or synchronization.** The account is a manual named
+   container today.
+4. **No account type, institution, opening balance, or per-account currency.**
+5. **No whitespace normalization.** Visually confusing names can differ only by
+   leading or trailing spaces.
+
+The backend hardening and product-decision queue for these gaps is the
+[post-migration improvements registry](../../post-migration-improvements/codex-backend-improvements/README.md),
+especially its [accounts review map](../../post-migration-improvements/codex-backend-improvements/07-module-improvement-map.md#accounts).
+
+## Related
+
+- [Technical reference](../api/accounts.md)
+- [Categories — product behavior](categories.md)
+- [Transactions — product behavior](transactions.md) — why every transaction
+  requires an account
+- [Bulk-delete partial-success history](../../post-migration-improvements/claude-backend-improvements/0004-bulk-delete-silent-ignore.md)

--- a/docs/product/categories.md
+++ b/docs/product/categories.md
@@ -37,8 +37,8 @@ a case-insensitive duplicate produces:
 > You already have a category with this name.
 
 The same name is allowed for different users. Names are stored as submitted and
-are not trimmed, so leading or trailing spaces can still make two names
-different even though case cannot.
+are not trimmed, so `Groceries` and `␠Groceries␠` are different names (`␠`
+marks a space) even though case cannot make them different.
 
 ## Deleting a category keeps the transactions
 

--- a/docs/product/categories.md
+++ b/docs/product/categories.md
@@ -1,0 +1,95 @@
+# Categories — Product Behavior
+
+What categories mean to a user, how naming and privacy work, what deletion does,
+and the messages support will encounter.
+
+Written for product decisions and support answers. For implementation rules see
+[the technical reference](../api/categories.md).
+
+## What a category is
+
+A category is an optional label for grouping transactions, such as Groceries,
+Rent, or Transport. Categories drive the dashboard's spending breakdown, but a
+transaction can exist without one.
+
+Renaming a category changes the label shown the next time transaction and
+summary data are loaded. Transactions keep the category ID; their stored money,
+date, payee, and notes do not change.
+
+## Categories are private to one user
+
+A user can list, view, rename, and delete only their own categories. A missing
+category and another user's category produce the same response:
+`"Category not found."`
+
+The app intentionally does not reveal whether another person's category
+exists.
+
+Bulk delete also avoids that disclosure. Missing, stale, and foreign IDs are
+silently skipped while owned matches are deleted, so a bulk action can partially
+succeed without an error.
+
+## Names are unique without regard to case
+
+One user cannot have both `Groceries` and `groceries`. Creating or renaming into
+a case-insensitive duplicate produces:
+
+> You already have a category with this name.
+
+The same name is allowed for different users. Names are stored as submitted and
+are not trimmed, so leading or trailing spaces can still make two names
+different even though case cannot.
+
+## Deleting a category keeps the transactions
+
+Deleting a category does **not** delete transaction history. Every referencing
+transaction survives and becomes uncategorized. The next transaction list shows
+no category for those rows, and their expenses still count in dashboard totals.
+
+They no longer appear in the named category's spending slice. Because the
+current category chart excludes uncategorized expenses, deleting a heavily used
+category can make the chart total fall below the Expenses figure even though no
+money was removed.
+
+There is no archive or "move these transactions to another category" step
+today. Single and bulk category deletion both use the same uncategorize behavior.
+
+## Messages a user can encounter
+
+| Situation                                                 | Exact message                                       |
+| --------------------------------------------------------- | --------------------------------------------------- |
+| Name missing or empty                                     | `Name is required.`                                 |
+| Name duplicates another, including a case-only difference | `You already have a category with this name.`       |
+| Category missing or owned by someone else                 | `Category not found.`                               |
+| Bulk delete has no selected IDs                           | `At least one id is required.`                      |
+| Bulk delete contains an empty ID                          | `Ids must not be empty.`                            |
+| Database problem                                          | Generic failure notice; details stay in server logs |
+
+Duplicate-name create and rename now use the same message. The old Hono rename
+path reported a generic server failure; the Go contract deliberately corrected
+that inconsistency.
+
+## What this deliberately cannot do yet
+
+1. **No archive or restore.** Delete immediately removes the category label
+   from every transaction that used it.
+2. **No merge or reassignment on delete.** Transactions can only become
+   uncategorized; they cannot be moved to a replacement category in the same
+   action.
+3. **No hierarchy.** There are no parent categories or subcategories.
+4. **No budgets, limits, icons, or colors.** A category is a name only.
+5. **No whitespace normalization.** Visually confusing names can differ only by
+   leading or trailing spaces.
+
+The backend hardening and product-decision queue for these gaps is the
+[post-migration improvements registry](../../post-migration-improvements/codex-backend-improvements/README.md),
+especially its [categories review map](../../post-migration-improvements/codex-backend-improvements/07-module-improvement-map.md#categories).
+
+## Related
+
+- [Technical reference](../api/categories.md)
+- [Accounts — product behavior](accounts.md)
+- [Transactions — product behavior](transactions.md) — optional categories and
+  uncategorized transactions
+- [Duplicate-update decision history](../../post-migration-improvements/claude-backend-improvements/0005-category-duplicate-update-500.md)
+- [Bulk-delete partial-success history](../../post-migration-improvements/claude-backend-improvements/0004-bulk-delete-silent-ignore.md)


### PR DESCRIPTION
## Summary

- add implementation references for accounts and categories covering ownership, non-disclosing 404s, case-insensitive per-user uniqueness, delete effects, and non-negotiables
- add product guides covering user consequences, exact support-facing messages, and explicit cannot-do-yet sections linked to the improvements registry
- follow the existing transactions technical/product register without duplicating OpenAPI shapes or status tables

## Why

Issue #73 ultimately documents every domain after legacy teardown, but its per-domain documents are stable and can land independently. Accounts and categories already have complete Go implementations and a frozen OpenAPI contract.

## Impact

No runtime behavior changes. These four documents explain why account deletion cascades transaction deletion while category deletion keeps transactions and clears their category.

The root `README.md` documentation index is intentionally not changed in this PR: the work order grants ownership only of the four domain docs and says to stop rather than cross that boundary. The index update remains a required follow-up for issue #73.

## Verification

- all local Markdown link targets resolve
- Prettier check — passed
- `bun run lint` — passed
- `bun test` — 70 passed, 0 failed (fresh run)
- `bun run build` with CI Clerk values — passed
- `bunx tsc --noEmit` — not green on current `master`: missing `bun:test` declarations in existing tests and the pre-existing `rewrites.beforeFiles` strictness error
- Copilot iteration 1 — clarity finding fixed and thread resolved

Graphify was queried before writing. No generated graph artifacts are included.

Refs #73