### PR TITLE
[Issue - #50] Move transactions and summary hooks to the generated client

### DIFF
--- a/app/(dashboard)/transactions/columns.tsx
+++ b/app/(dashboard)/transactions/columns.tsx
@@ -11,6 +11,8 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { client } from '@/lib/hono';
 import { formatCurrency } from '@/lib/utils';
 import { format } from 'date-fns';
+
+import { localDateFromCalendarDate } from '@/features/transactions/api/transaction-date';
 import { AccountColumn } from './account-column';
 import { Actions } from './actions';
 import { CategoryColumn } from './category-column';
@@ -57,8 +59,14 @@ export const columns: ColumnDef<ResponseType>[] = [
       );
     },
     cell: ({ row }) => {
-      const date = row.getValue('date') as Date;
-      return <span>{format(date, 'dd MMMM, yyyy')}</span>;
+      // The hook normalizes this to `yyyy-MM-dd`. Rendering it through the
+      // calendar-date helper keeps the displayed day the stored one; handing
+      // the raw value to `format` re-reads it as an instant and shows the
+      // previous day for any viewer west of Greenwich.
+      const date = row.getValue('date') as string;
+      return (
+        <span>{format(localDateFromCalendarDate(date), 'dd MMMM, yyyy')}</span>
+      );
     },
   },
   {

--- a/app/(dashboard)/transactions/columns.tsx
+++ b/app/(dashboard)/transactions/columns.tsx
@@ -1,26 +1,44 @@
 'use client';
 
-import { InferResponseType } from 'hono';
-
 import { ColumnDef } from '@tanstack/react-table';
 import { ArrowUpDown } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { client } from '@/lib/hono';
+import type { components } from '@/lib/api/generated/schema';
 import { formatCurrency } from '@/lib/utils';
 import { format } from 'date-fns';
 
-import { localDateFromCalendarDate } from '@/features/transactions/api/transaction-date';
+import {
+  localDateFromCalendarDate,
+  type CalendarDate,
+} from '@/features/transactions/api/transaction-date';
 import { AccountColumn } from './account-column';
 import { Actions } from './actions';
 import { CategoryColumn } from './category-column';
 
-export type ResponseType = InferResponseType<
-  typeof client.api.transactions.$get,
-  200
->['data'][0];
+/**
+ * A row as the table receives it from `useGetTransactions`.
+ *
+ * Taken from the contract rather than inferred from the Hono client. That
+ * import was a runtime one — `client` is a value, and only `import type` is
+ * stripped — so deriving a type from it kept the legacy Hono client in the
+ * dashboard bundle after the hooks had already moved off it. It was also a
+ * quiet lie: the data comes from the generated client now, so the two shapes
+ * were free to drift.
+ *
+ * `amount` is overridden because the hook converts milliunits to a display
+ * number, and `date` because the hook normalizes the API instant to a
+ * `yyyy-MM-dd` calendar date.
+ */
+export type ResponseType = Omit<
+  components['schemas']['TransactionListItem'],
+  'amount' | 'date'
+> & {
+  amount: number;
+  date: CalendarDate;
+};
 
 export const columns: ColumnDef<ResponseType>[] = [
   {

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -11,6 +11,10 @@ import { Loader2, Plus } from 'lucide-react';
 import { DataTable } from '@/components/data-table';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useSelectAccount } from '@/features/accounts/hooks/use-select-account';
+import {
+  bulkFieldErrors,
+  formatBulkErrorSummary,
+} from '@/features/transactions/api/bulk-errors';
 import { useBulkDeleteTransactions } from '@/features/transactions/api/use-bulk-delete-transactions';
 import { useGetTransactions } from '@/features/transactions/api/use-get-transactions';
 import { chunkItems } from '@/lib/chunk-items';
@@ -70,15 +74,27 @@ const TransactionsPage = () => {
       accountId: accountId as string,
     }));
 
+    // Tracks how many rows have already been accepted, so a failure in a later
+    // chunk is reported at its row number in the user's file rather than its
+    // index within the chunk. Without it, a bad row 504 is reported as row 4.
+    let submitted = 0;
+
     try {
       for (const chunk of chunkItems(data, MAX_BULK_CREATE_TRANSACTIONS)) {
         await createTransactions.mutateAsync(chunk);
+        submitted += chunk.length;
       }
 
       onCancelImport();
       toast.success('Transactions imported successfully');
-    } catch {
-      toast.error('Failed to import transactions');
+    } catch (error) {
+      // The API reports every failing row at once with an indexed path, so the
+      // user can fix a large file in one pass instead of rediscovering the next
+      // bad row on each attempt.
+      const summary = formatBulkErrorSummary(bulkFieldErrors(error), {
+        rowOffset: submitted,
+      });
+      toast.error(summary ?? 'Failed to import transactions');
     }
   };
 

--- a/features/summary/use-get-summary.ts
+++ b/features/summary/use-get-summary.ts
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
 import { omitEmptyQueryParams } from '@/lib/query-params';
 import { convertAmountFromMiliunits } from '@/lib/utils';
 
@@ -16,19 +15,17 @@ export const useGetSummary = () => {
   const query = useQuery({
     queryKey: ['summary', { from, to, accountId }],
     queryFn: async () => {
-      const response = await client.api.summary.$get({
-        // Unset filters are omitted, not sent as empty strings: an explicitly
-        // empty `from`/`to`/`accountId` is malformed per the API contract and
-        // is rejected with 400 INVALID_QUERY, while omission selects the
-        // default range.
-        query: omitEmptyQueryParams({ from, to, accountId }),
+      const result = await apiClient.GET('/summary', {
+        params: {
+          // Unset filters are omitted, not sent as empty strings: an
+          // explicitly empty `from`/`to`/`accountId` is malformed per the API
+          // contract and is rejected with 400 INVALID_QUERY, while omission
+          // selects the default range.
+          query: omitEmptyQueryParams({ from, to, accountId }),
+        },
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'summary');
-      }
-
-      const { data } = await response.json();
+      const { data } = unwrap(result, 'summary');
       return {
         ...data,
         incomeAmount: convertAmountFromMiliunits(data.incomeAmount),

--- a/features/transactions/api/bulk-errors.test.ts
+++ b/features/transactions/api/bulk-errors.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  bulkFieldErrors,
+  formatBulkErrorSummary,
+} from '@/features/transactions/api/bulk-errors';
+import { ApiError } from '@/lib/api-error';
+
+function validationError(fields: unknown, status = 400): ApiError {
+  return new ApiError('Request validation failed.', {
+    status,
+    statusText: 'Bad Request',
+    url: '/api/transactions/bulk-create',
+    resource: 'transactions',
+    timestamp: new Date().toISOString(),
+    errorData: {
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Request validation failed.',
+        details: { fields },
+      },
+    },
+  });
+}
+
+describe('bulkFieldErrors', () => {
+  it('decodes an indexed row path', () => {
+    const errors = bulkFieldErrors(
+      validationError([{ path: '[3].amount', message: 'Amount is required.' }])
+    );
+
+    expect(errors).toEqual([
+      { index: 3, field: 'amount', message: 'Amount is required.' },
+    ]);
+  });
+
+  it('decodes a whole-array path', () => {
+    const errors = bulkFieldErrors(
+      validationError([{ path: '$', message: 'At most 500 rows.' }])
+    );
+
+    expect(errors).toEqual([
+      { index: null, field: null, message: 'At most 500 rows.' },
+    ]);
+  });
+
+  it('decodes bulk-delete ids paths', () => {
+    const errors = bulkFieldErrors(
+      validationError([
+        { path: 'ids', message: 'At least one id is required.' },
+        { path: 'ids[2]', message: 'Id must not be empty.' },
+      ])
+    );
+
+    expect(errors).toEqual([
+      { index: null, field: 'ids', message: 'At least one id is required.' },
+      { index: 2, field: 'ids', message: 'Id must not be empty.' },
+    ]);
+  });
+
+  it('decodes a bare indexed path with no field', () => {
+    const errors = bulkFieldErrors(
+      validationError([{ path: '[7]', message: 'Row is not an object.' }])
+    );
+
+    expect(errors).toEqual([
+      { index: 7, field: null, message: 'Row is not an object.' },
+    ]);
+  });
+
+  it('keeps multi-digit indexes intact', () => {
+    expect(
+      bulkFieldErrors(
+        validationError([{ path: '[412].date', message: 'Bad date.' }])
+      )[0].index
+    ).toBe(412);
+  });
+
+  // A body the API could not parse carries no `details` at all, so callers
+  // must be able to tell "no rows decoded" apart from "no error".
+  it('returns nothing for a malformed body with no details', () => {
+    const error = new ApiError('Request validation failed.', {
+      status: 400,
+      statusText: 'Bad Request',
+      url: '/api/transactions/bulk-create',
+      resource: 'transactions',
+      timestamp: new Date().toISOString(),
+      errorData: {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Request validation failed.',
+        },
+      },
+    });
+
+    expect(bulkFieldErrors(error)).toEqual([]);
+  });
+
+  it('returns nothing for a non-ApiError', () => {
+    expect(bulkFieldErrors(new Error('network down'))).toEqual([]);
+    expect(bulkFieldErrors(null)).toEqual([]);
+  });
+
+  it('skips malformed field entries but keeps the good ones', () => {
+    const errors = bulkFieldErrors(
+      validationError([
+        { path: 123, message: 'nonsense' },
+        null,
+        { path: '[1].payee', message: 'Payee is required.' },
+      ])
+    );
+
+    expect(errors).toEqual([
+      { index: 1, field: 'payee', message: 'Payee is required.' },
+    ]);
+  });
+});
+
+describe('formatBulkErrorSummary', () => {
+  it('returns null when there is nothing to report', () => {
+    expect(formatBulkErrorSummary([])).toBeNull();
+  });
+
+  it('numbers rows from one', () => {
+    expect(
+      formatBulkErrorSummary([
+        { index: 0, field: 'amount', message: 'Amount is required.' },
+      ])
+    ).toBe('Row 1 (amount): Amount is required.');
+  });
+
+  // The import screen submits in chunks of 500, so an error at index 3 of the
+  // second chunk is row 504 of the user's file — not row 4.
+  it('offsets rows by the number already submitted', () => {
+    expect(
+      formatBulkErrorSummary(
+        [{ index: 3, field: 'amount', message: 'Amount is required.' }],
+        { rowOffset: 500 }
+      )
+    ).toBe('Row 504 (amount): Amount is required.');
+  });
+
+  it('reports a whole-array problem without a row', () => {
+    expect(
+      formatBulkErrorSummary([
+        { index: null, field: null, message: 'At most 500 rows.' },
+      ])
+    ).toBe('At most 500 rows.');
+  });
+
+  it('counts the tail instead of listing everything', () => {
+    const many = Array.from({ length: 7 }, (_, index) => ({
+      index,
+      field: 'amount',
+      message: 'Bad.',
+    }));
+
+    expect(formatBulkErrorSummary(many)).toBe(
+      'Row 1 (amount): Bad.; Row 2 (amount): Bad.; Row 3 (amount): Bad.; and 4 more'
+    );
+  });
+});

--- a/features/transactions/api/bulk-errors.ts
+++ b/features/transactions/api/bulk-errors.ts
@@ -1,0 +1,132 @@
+import { isApiError } from '@/lib/api-error';
+
+/**
+ * One entry of a bulk operation's `details.fields`, decoded.
+ *
+ * `index` is the zero-based position of the offending item within the
+ * submitted array, or `null` when the problem is with the array itself.
+ * `field` is the property that failed, or `null` when the whole item or array
+ * is at fault.
+ */
+export type BulkFieldError = {
+  index: number | null;
+  field: string | null;
+  message: string;
+};
+
+/**
+ * Matches the indexed paths the API reports for bulk operations.
+ *
+ * Bulk-create uses `[3].amount` for a problem in row 3 and `$` for one with
+ * the array itself — empty, or past the 500-row maximum. Bulk-delete uses
+ * `ids` for the array and `ids[2]` for one entry. Both forms are covered here
+ * so a caller does not have to know which operation it came from.
+ */
+const INDEXED_PATH = /^\[(\d+)\](?:\.(.+))?$/;
+const IDS_PATH = /^ids(?:\[(\d+)\])?$/;
+
+/**
+ * Decodes a bulk operation's per-item validation errors.
+ *
+ * Returns an empty array for anything that is not a validation error carrying
+ * `details.fields`. That is not a defensive nicety: a body the API could not
+ * parse at all — malformed JSON, an unknown field, more than one JSON value —
+ * has no per-row paths to report and omits `details` entirely, so "no decoded
+ * rows" is a real and expected answer that callers must handle with a general
+ * message.
+ */
+export function bulkFieldErrors(error: unknown): BulkFieldError[] {
+  if (!isApiError(error)) {
+    return [];
+  }
+
+  const fields = (
+    error.details.errorData as
+      | { error?: { details?: { fields?: unknown } } }
+      | null
+      | undefined
+  )?.error?.details?.fields;
+
+  if (!Array.isArray(fields)) {
+    return [];
+  }
+
+  const decoded: BulkFieldError[] = [];
+
+  for (const entry of fields) {
+    if (
+      typeof entry !== 'object' ||
+      entry === null ||
+      typeof (entry as { path?: unknown }).path !== 'string' ||
+      typeof (entry as { message?: unknown }).message !== 'string'
+    ) {
+      continue;
+    }
+
+    const { path, message } = entry as { path: string; message: string };
+
+    const indexed = INDEXED_PATH.exec(path);
+    if (indexed) {
+      decoded.push({
+        index: Number(indexed[1]),
+        field: indexed[2] ?? null,
+        message,
+      });
+      continue;
+    }
+
+    const ids = IDS_PATH.exec(path);
+    if (ids) {
+      decoded.push({
+        index: ids[1] === undefined ? null : Number(ids[1]),
+        field: 'ids',
+        message,
+      });
+      continue;
+    }
+
+    // `$` is the whole-array case; anything else unrecognized is reported
+    // without a position rather than dropped, so the message still reaches
+    // the user.
+    decoded.push({ index: null, field: path === '$' ? null : path, message });
+  }
+
+  return decoded;
+}
+
+/**
+ * Renders decoded bulk errors as a short, human-readable summary.
+ *
+ * Rows are numbered from `rowOffset`, which exists because the import screen
+ * submits in chunks of 500: an error at index 3 of the second chunk is row
+ * 504 of the user's file, and reporting it as row 4 would send them to the
+ * wrong line. Callers pass the number of rows already submitted.
+ *
+ * At most `limit` entries are listed; a long tail is counted rather than
+ * printed, since a toast holding 500 lines helps nobody.
+ */
+export function formatBulkErrorSummary(
+  errors: BulkFieldError[],
+  { rowOffset = 0, limit = 3 }: { rowOffset?: number; limit?: number } = {}
+): string | null {
+  if (errors.length === 0) {
+    return null;
+  }
+
+  const parts = errors.slice(0, limit).map((error) => {
+    if (error.index === null) {
+      return error.message;
+    }
+    const row = error.index + rowOffset + 1;
+    return error.field === null || error.field === 'ids'
+      ? `Row ${row}: ${error.message}`
+      : `Row ${row} (${error.field}): ${error.message}`;
+  });
+
+  const remaining = errors.length - parts.length;
+  if (remaining > 0) {
+    parts.push(`and ${remaining} more`);
+  }
+
+  return parts.join('; ');
+}

--- a/features/transactions/api/transaction-date.test.ts
+++ b/features/transactions/api/transaction-date.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  calendarDateFromApi,
+  calendarDateFromLocalDate,
+  localDateFromApi,
+  localDateFromCalendarDate,
+} from '@/features/transactions/api/transaction-date';
+
+/** The value the Go API returns for a transaction stored on 2026-08-07. */
+const API_INSTANT = '2026-08-07T00:00:00Z';
+
+describe('calendarDateFromApi', () => {
+  it('reads the calendar date the API labelled', () => {
+    expect(calendarDateFromApi(API_INSTANT)).toBe('2026-08-07');
+  });
+
+  it('passes an already-normalized calendar date through', () => {
+    expect(calendarDateFromApi('2026-08-07')).toBe('2026-08-07');
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    expect(calendarDateFromApi('2026-01-05T00:00:00Z')).toBe('2026-01-05');
+  });
+
+  it('reads UTC parts even for a non-midnight instant', () => {
+    expect(calendarDateFromApi('2026-08-07T23:30:00Z')).toBe('2026-08-07');
+  });
+
+  it('rejects a value that is not a date', () => {
+    expect(() => calendarDateFromApi('not-a-date')).toThrow(
+      'Not a valid transaction date'
+    );
+  });
+});
+
+describe('localDateFromCalendarDate', () => {
+  it('builds local midnight on the intended day', () => {
+    const date = localDateFromCalendarDate('2026-08-07');
+
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(7);
+    expect(date.getDate()).toBe(7);
+    expect(date.getHours()).toBe(0);
+  });
+
+  it('rejects anything that is not yyyy-MM-dd', () => {
+    expect(() => localDateFromCalendarDate(API_INSTANT)).toThrow(
+      'Not a calendar date'
+    );
+  });
+});
+
+describe('calendarDateFromLocalDate', () => {
+  it('reads the day the user picked', () => {
+    expect(calendarDateFromLocalDate(new Date(2026, 7, 7))).toBe('2026-08-07');
+  });
+
+  it('is unaffected by the time of day', () => {
+    expect(calendarDateFromLocalDate(new Date(2026, 7, 7, 23, 59, 59))).toBe(
+      '2026-08-07'
+    );
+  });
+
+  it('rejects an invalid date', () => {
+    expect(() => calendarDateFromLocalDate(new Date('nope'))).toThrow(
+      'Not a valid date'
+    );
+  });
+});
+
+describe('the edit round trip', () => {
+  /**
+   * The finding. Loading a Go transaction into the edit sheet and saving it
+   * unchanged used to move it back a day for anyone west of Greenwich, once
+   * per save.
+   */
+  it('returns the same calendar date it was given', () => {
+    const picker = localDateFromApi(API_INSTANT);
+
+    expect(calendarDateFromLocalDate(picker)).toBe('2026-08-07');
+  });
+
+  it('is stable across repeated edits', () => {
+    let value = API_INSTANT;
+    for (let i = 0; i < 5; i += 1) {
+      value = calendarDateFromLocalDate(localDateFromApi(value));
+    }
+
+    expect(value).toBe('2026-08-07');
+  });
+
+  it('keeps a newly picked date on its selected day', () => {
+    const picked = new Date(2026, 7, 9, 14, 30);
+
+    expect(calendarDateFromLocalDate(picked)).toBe('2026-08-09');
+  });
+});

--- a/features/transactions/api/transaction-date.timezone-probe.ts
+++ b/features/transactions/api/transaction-date.timezone-probe.ts
@@ -1,0 +1,34 @@
+/**
+ * Runs the transaction date round trip and reports the result as JSON.
+ *
+ * Spawned by `transaction-date.timezone.test.ts` under different `TZ` values.
+ * It exists as a separate entry point because a process's timezone is fixed at
+ * startup — the only way to prove the conversion holds east and west of
+ * Greenwich is to run it in a process that genuinely is there.
+ *
+ * Not named `*.test.ts` so the test runner does not collect it directly.
+ */
+
+import {
+  calendarDateFromApi,
+  calendarDateFromLocalDate,
+  localDateFromApi,
+} from './transaction-date';
+
+const apiInstant = process.argv[2] ?? '2026-08-07T00:00:00Z';
+
+const picker = localDateFromApi(apiInstant);
+
+process.stdout.write(
+  JSON.stringify({
+    offsetMinutes: new Date().getTimezoneOffset(),
+    calendarDate: calendarDateFromApi(apiInstant),
+    // What the edit sheet shows.
+    pickerDay: picker.getDate(),
+    pickerMonth: picker.getMonth() + 1,
+    // What an unchanged save submits.
+    roundTrip: calendarDateFromLocalDate(picker),
+    // The old behaviour, kept for contrast: reading the API value as an instant.
+    naiveDay: new Date(apiInstant).getDate(),
+  })
+);

--- a/features/transactions/api/transaction-date.timezone.test.ts
+++ b/features/transactions/api/transaction-date.timezone.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test';
+// `node:child_process` rather than `Bun.spawnSync`: the repo has `@types/node`
+// but not `@types/bun`, so the Bun global is untyped and would fail `tsc`.
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Proves the calendar-date round trip in processes that really are in a
+ * different timezone.
+ *
+ * A process fixes its timezone at startup, so this spawns the probe under
+ * several `TZ` values rather than trying to change it in-process. POSIX-style
+ * offsets (`GMT+9`) are used instead of IANA names (`Asia/Tokyo`) because Bun
+ * on Windows silently ignores IANA names and falls back to the host zone —
+ * which would make these tests pass without testing anything.
+ *
+ * Note POSIX sign convention is inverted from the usual one: `GMT+9` is UTC+9
+ * here, reported by `getTimezoneOffset()` as -540.
+ */
+
+// `fileURLToPath` rather than `URL.pathname`: on Windows the latter yields a
+// leading-slash path like `/C:/dev/...` that Bun cannot resolve.
+const PROBE = fileURLToPath(
+  new URL('./transaction-date.timezone-probe.ts', import.meta.url)
+);
+const API_INSTANT = '2026-08-07T00:00:00Z';
+
+type ProbeResult = {
+  offsetMinutes: number;
+  calendarDate: string;
+  pickerDay: number;
+  pickerMonth: number;
+  roundTrip: string;
+  naiveDay: number;
+};
+
+function runIn(timezone: string): ProbeResult {
+  const result = spawnSync('bun', ['run', PROBE, API_INSTANT], {
+    env: { ...process.env, TZ: timezone },
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `probe failed in ${timezone}: ${String(result.stderr).slice(0, 400)}`
+    );
+  }
+
+  return JSON.parse(result.stdout) as ProbeResult;
+}
+
+/** West of Greenwich (Argentina), east of it (Japan), and the meridian. */
+const zones: Array<[label: string, tz: string, expectedOffset: number]> = [
+  ['UTC-3, the app default market', 'GMT-3', 180],
+  ['UTC+9, east of Greenwich', 'GMT+9', -540],
+  ['UTC itself', 'UTC', 0],
+];
+
+describe('transaction dates across timezones', () => {
+  for (const [label, timezone, expectedOffset] of zones) {
+    describe(label, () => {
+      const probe = runIn(timezone);
+
+      // Guards the whole suite: if TZ were ignored, every case would silently
+      // run in the host zone and prove nothing.
+      it('really runs in that timezone', () => {
+        expect(probe.offsetMinutes).toBe(expectedOffset);
+      });
+
+      it('reads the stored calendar date', () => {
+        expect(probe.calendarDate).toBe('2026-08-07');
+      });
+
+      it('shows the stored day in the edit picker', () => {
+        expect(probe.pickerDay).toBe(7);
+        expect(probe.pickerMonth).toBe(8);
+      });
+
+      it('submits the same date when nothing was changed', () => {
+        expect(probe.roundTrip).toBe('2026-08-07');
+      });
+    });
+  }
+
+  /**
+   * The bug this replaced, demonstrated rather than described: reading the API
+   * value as an instant lands on the 6th west of Greenwich and the 7th
+   * elsewhere. The conversion above is the same in all three.
+   */
+  it('is stable where the previous instant-based reading was not', () => {
+    const naiveDays = zones.map(([, tz]) => runIn(tz).naiveDay);
+    const roundTrips = zones.map(([, tz]) => runIn(tz).roundTrip);
+
+    expect(naiveDays).toEqual([6, 7, 7]);
+    expect(new Set(roundTrips).size).toBe(1);
+    expect(roundTrips[0]).toBe('2026-08-07');
+  });
+});

--- a/features/transactions/api/transaction-date.timezone.test.ts
+++ b/features/transactions/api/transaction-date.timezone.test.ts
@@ -9,13 +9,17 @@ import { fileURLToPath } from 'node:url';
  * different timezone.
  *
  * A process fixes its timezone at startup, so this spawns the probe under
- * several `TZ` values rather than trying to change it in-process. POSIX-style
- * offsets (`GMT+9`) are used instead of IANA names (`Asia/Tokyo`) because Bun
- * on Windows silently ignores IANA names and falls back to the host zone —
- * which would make these tests pass without testing anything.
+ * several `TZ` values rather than trying to change it in-process. Offsets of
+ * the form `GMT+9` are used instead of IANA names (`Asia/Tokyo`) because Bun on
+ * Windows silently ignores IANA names and falls back to the host zone — which
+ * would make these tests pass without testing anything.
  *
- * Note POSIX sign convention is inverted from the usual one: `GMT+9` is UTC+9
- * here, reported by `getTimezoneOffset()` as -540.
+ * On this runtime `GMT+9` resolves to UTC+9 and `GMT-3` to UTC-3, i.e. the sign
+ * reads the intuitive way. That is worth stating because strict POSIX defines
+ * it the other way round, where `GMT+9` would mean UTC-9. Each case asserts the
+ * offset it actually observed before asserting anything else, so a runtime that
+ * followed the POSIX reading would fail loudly here rather than quietly test a
+ * zone nobody intended.
  */
 
 // `fileURLToPath` rather than `URL.pathname`: on Windows the latter yields a

--- a/features/transactions/api/transaction-date.ts
+++ b/features/transactions/api/transaction-date.ts
@@ -1,0 +1,101 @@
+/**
+ * The calendar-date boundary for transactions.
+ *
+ * A transaction date is a **calendar date** — "the 7th of August" — not an
+ * instant. The database column is a naive `timestamp` and the API serializes it
+ * at UTC midnight (`2026-08-07T00:00:00Z`), so every time that value is handed
+ * to `new Date()` it becomes an instant and gets re-read in the viewer's
+ * timezone. In Argentina (UTC-3) that instant is the 6th at 21:00, so the app
+ * displayed the 6th and — worse — an edit that changed nothing else submitted
+ * `2026-08-06`, walking the transaction backwards one day per save.
+ *
+ * The fix is to convert once, explicitly, at the edges rather than sprinkling
+ * offset corrections at each use:
+ *
+ * - coming **from** the API, read the UTC calendar parts (`calendarDateFromApi`)
+ * - going **to** a date picker, build local midnight (`localDateFromCalendarDate`)
+ * - coming **from** a picker, read the local calendar parts (`calendarDateFromLocalDate`)
+ *
+ * Between those, a date travels as a `yyyy-MM-dd` string, which is also exactly
+ * what the contract's `DateString` wants on writes. No step consults the host
+ * offset, so the round trip is stable in every timezone.
+ */
+
+/** A calendar date in `yyyy-MM-dd`, the contract's `DateString` form. */
+export type CalendarDate = string;
+
+const CALENDAR_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+/**
+ * Converts an API date into its calendar date.
+ *
+ * Reads **UTC** parts, because that is the timezone the API labels the value
+ * with. `new Date(iso).getDate()` would instead re-interpret it locally and
+ * return the previous day for any viewer west of Greenwich.
+ *
+ * Already-plain `yyyy-MM-dd` input is passed through, so this is safe to apply
+ * to a value that has been normalized once already.
+ */
+export function calendarDateFromApi(value: string): CalendarDate {
+  if (CALENDAR_DATE.test(value)) {
+    return value;
+  }
+
+  const instant = new Date(value);
+  if (Number.isNaN(instant.getTime())) {
+    throw new Error(`Not a valid transaction date: ${value}`);
+  }
+
+  return `${instant.getUTCFullYear()}-${pad(instant.getUTCMonth() + 1)}-${pad(
+    instant.getUTCDate()
+  )}`;
+}
+
+/**
+ * Builds the `Date` a date picker should show for a calendar date.
+ *
+ * Constructed from parts rather than parsed from the string: `new Date(
+ * '2026-08-07')` is defined to parse a date-only string as **UTC** midnight,
+ * which reintroduces exactly the shift this module exists to remove. Passing
+ * the parts to the constructor yields local midnight on the intended day in
+ * every timezone.
+ */
+export function localDateFromCalendarDate(value: CalendarDate): Date {
+  const match = CALENDAR_DATE.exec(value);
+  if (!match) {
+    throw new Error(`Not a calendar date: ${value}`);
+  }
+
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+/**
+ * Reads the calendar date a user picked.
+ *
+ * Local parts, because a picker's `Date` is local midnight on the chosen day.
+ * `toISOString().slice(0, 10)` would convert to UTC first and file a date
+ * picked on the 7th as the 6th for anyone east of Greenwich — the same class of
+ * bug in the opposite direction.
+ */
+export function calendarDateFromLocalDate(date: Date): CalendarDate {
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Not a valid date');
+  }
+
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/**
+ * Convenience for the read path: an API date straight to a picker `Date`.
+ *
+ * Exists so consumers cannot accidentally compose the two halves in the wrong
+ * order, which is what produced the original off-by-one.
+ */
+export function localDateFromApi(value: string): Date {
+  return localDateFromCalendarDate(calendarDateFromApi(value));
+}

--- a/features/transactions/api/transaction-mutation-error.test.ts
+++ b/features/transactions/api/transaction-mutation-error.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test';
+
+import { transactionMutationErrorMessage } from '@/features/transactions/api/transaction-mutation-error';
+import { ApiError } from '@/lib/api-error';
+
+const apiError = (errorData: unknown, status = 409) =>
+  new ApiError('Failed to fetch transactions: 409 Conflict', {
+    status,
+    statusText: 'Conflict',
+    url: '/api/transactions',
+    resource: 'transactions',
+    timestamp: '2026-08-09T00:00:00.000Z',
+    errorData,
+  });
+
+describe('transactionMutationErrorMessage', () => {
+  it('prefers the API structured message', () => {
+    const error = apiError({
+      error: {
+        code: 'ACCOUNT_NOT_FOUND',
+        message: 'That account no longer exists.',
+      },
+    });
+
+    expect(
+      transactionMutationErrorMessage(error, 'Error creating transaction')
+    ).toBe('That account no longer exists.');
+  });
+
+  // The regression this exists to prevent. `toApiError` sets `message` to
+  // "Failed to fetch transactions: 500 Internal Server Error" when the response
+  // carries no envelope, and that must never reach a toast.
+  it('falls back rather than surfacing the generic technical message', () => {
+    const error = new ApiError(
+      'Failed to fetch transactions: 500 Internal Server Error',
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+        url: '/api/transactions',
+        resource: 'transactions',
+        timestamp: '2026-08-09T00:00:00.000Z',
+        errorData: null,
+      }
+    );
+
+    expect(
+      transactionMutationErrorMessage(error, 'Error creating transaction')
+    ).toBe('Error creating transaction');
+  });
+
+  it('falls back when the envelope carries an empty message', () => {
+    const error = apiError({
+      error: { code: 'VALIDATION_ERROR', message: '' },
+    });
+
+    expect(
+      transactionMutationErrorMessage(error, 'Error editing transaction')
+    ).toBe('Error editing transaction');
+  });
+
+  it('falls back when the message is not a string', () => {
+    const error = apiError({ error: { code: 'X', message: { nested: true } } });
+
+    expect(
+      transactionMutationErrorMessage(error, 'Error editing transaction')
+    ).toBe('Error editing transaction');
+  });
+
+  it('falls back for a non-API error', () => {
+    expect(
+      transactionMutationErrorMessage(
+        new Error('network down'),
+        'Error creating transaction'
+      )
+    ).toBe('Error creating transaction');
+  });
+});

--- a/features/transactions/api/transaction-mutation-error.test.ts
+++ b/features/transactions/api/transaction-mutation-error.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
 import { transactionMutationErrorMessage } from '@/features/transactions/api/transaction-mutation-error';
+import { transactionPathParams } from '@/features/transactions/api/transaction-path-params';
 import { ApiError } from '@/lib/api-error';
 
 const apiError = (errorData: unknown, status = 409) =>
@@ -73,5 +74,20 @@ describe('transactionMutationErrorMessage', () => {
         'Error creating transaction'
       )
     ).toBe('Error creating transaction');
+  });
+});
+
+describe('transactionPathParams', () => {
+  it('builds the generated client path parameters', () => {
+    expect(transactionPathParams('txn-1')).toEqual({ path: { id: 'txn-1' } });
+  });
+
+  // openapi-fetch leaves `{id}` in the URL when the value is missing, so
+  // without this the request goes out as `/api/transactions/%7Bid%7D`.
+  it('rejects an absent id before a request can keep the placeholder', () => {
+    expect(() => transactionPathParams()).toThrow('Transaction id is required');
+    expect(() => transactionPathParams('')).toThrow(
+      'Transaction id is required'
+    );
   });
 });

--- a/features/transactions/api/transaction-mutation-error.ts
+++ b/features/transactions/api/transaction-mutation-error.ts
@@ -1,0 +1,37 @@
+import { ApiError } from '@/lib/api-error';
+
+/**
+ * Picks the message a failed transaction mutation should put in a toast.
+ *
+ * Reads the API's *structured* message rather than `error.message`, and that
+ * distinction is the whole point. `toApiError` sets `message` to the structured
+ * text when there is one, but falls back to `Failed to fetch transactions: 500
+ * Internal Server Error` when there is not — which is a string to show an
+ * engineer, not a person mid-import. The legacy Hono hooks read
+ * `errorData.error.message` and fell back to their own wording, so surfacing
+ * the generic form would be a regression in the toast text, not just a style
+ * change.
+ *
+ * Mirrors `accountMutationErrorMessage` in the accounts lane. The duplication
+ * is deliberate for now — the two lanes are separate PRs and reaching across
+ * them would couple them — but this belongs in `lib/api/` once both have
+ * landed.
+ */
+export function transactionMutationErrorMessage(
+  error: unknown,
+  fallback: string
+): string {
+  if (error instanceof ApiError) {
+    const apiMessage = (
+      error.details.errorData as {
+        error?: { message?: unknown };
+      } | null
+    )?.error?.message;
+
+    if (typeof apiMessage === 'string' && apiMessage !== '') {
+      return apiMessage;
+    }
+  }
+
+  return fallback;
+}

--- a/features/transactions/api/transaction-path-params.ts
+++ b/features/transactions/api/transaction-path-params.ts
@@ -1,0 +1,20 @@
+/**
+ * Builds the generated client's path parameters for a single transaction.
+ *
+ * The guard is not defensive padding. openapi-fetch substitutes path
+ * parameters by name and leaves the placeholder untouched when the value is
+ * missing, so `{ path: { id: undefined } }` produces a request to
+ * `/api/transactions/{id}` — in a browser that resolves and goes out as
+ * `%7Bid%7D`, hitting the API as a nonsense id rather than failing where the
+ * mistake was made. Failing here turns it into an ordinary rejected mutation
+ * with the hook's own fallback toast.
+ *
+ * Mirrors `accountPathParams` in the accounts lane, which found this first.
+ */
+export function transactionPathParams(id?: string) {
+  if (!id) {
+    throw new Error('Transaction id is required');
+  }
+
+  return { path: { id } };
+}

--- a/features/transactions/api/transaction-payload.test.ts
+++ b/features/transactions/api/transaction-payload.test.ts
@@ -85,6 +85,23 @@ describe('toTransactionInput', () => {
   it('preserves the sign of an expense', () => {
     expect(toTransactionInput({ ...baseValues, amount: -1 }).amount).toBe(-1);
   });
+
+  /**
+   * An unselected `<select>` or a cleared field yields `''`, and the contract's
+   * `ResourceId` sets `minLength: 1` — so passing it through is a guaranteed
+   * 400 rather than the "no category" the user meant.
+   */
+  it('treats an empty categoryId as no category', () => {
+    expect(
+      toTransactionInput({ ...baseValues, categoryId: '' }).categoryId
+    ).toBeNull();
+  });
+
+  it('keeps a real categoryId', () => {
+    expect(
+      toTransactionInput({ ...baseValues, categoryId: 'category-1' }).categoryId
+    ).toBe('category-1');
+  });
 });
 
 describe('toBulkTransactionInput', () => {
@@ -159,6 +176,20 @@ describe('toBulkTransactionInput', () => {
 
     expect(onlyNotes).toMatchObject({ notes: 'kept', categoryId: null });
     expect(onlyCategory).toMatchObject({ notes: null, categoryId: 'c1' });
+  });
+
+  it('treats an empty categoryId as no category on bulk rows too', () => {
+    const [row] = toBulkTransactionInput([
+      {
+        amount: 1,
+        date: '2026-08-09',
+        payee: 'A',
+        accountId: 'a1',
+        categoryId: '',
+      },
+    ]);
+
+    expect(row.categoryId).toBeNull();
   });
 
   it('normalizes an explicit null the same as an omitted value', () => {

--- a/features/transactions/api/transaction-payload.test.ts
+++ b/features/transactions/api/transaction-payload.test.ts
@@ -115,4 +115,76 @@ describe('toBulkTransactionInput', () => {
   it('returns an empty array unchanged', () => {
     expect(toBulkTransactionInput([])).toEqual([]);
   });
+
+  /**
+   * The legacy bulk hook accepted the full transaction insert shape, so
+   * hardcoding these to null silently discarded whatever a caller passed —
+   * a payload accepted and then quietly altered.
+   */
+  it('preserves notes and categoryId when supplied', () => {
+    const [row] = toBulkTransactionInput([
+      {
+        amount: -5000,
+        date: '2026-08-09',
+        payee: 'Market',
+        accountId: 'a1',
+        notes: 'weekly shop',
+        categoryId: 'c1',
+      },
+    ]);
+
+    expect(row.notes).toBe('weekly shop');
+    expect(row.categoryId).toBe('c1');
+  });
+
+  it('preserves them independently of one another', () => {
+    const [onlyNotes] = toBulkTransactionInput([
+      {
+        amount: 1,
+        date: '2026-08-09',
+        payee: 'A',
+        accountId: 'a1',
+        notes: 'kept',
+      },
+    ]);
+    const [onlyCategory] = toBulkTransactionInput([
+      {
+        amount: 1,
+        date: '2026-08-09',
+        payee: 'A',
+        accountId: 'a1',
+        categoryId: 'c1',
+      },
+    ]);
+
+    expect(onlyNotes).toMatchObject({ notes: 'kept', categoryId: null });
+    expect(onlyCategory).toMatchObject({ notes: null, categoryId: 'c1' });
+  });
+
+  it('normalizes an explicit null the same as an omitted value', () => {
+    const [row] = toBulkTransactionInput([
+      {
+        amount: 1,
+        date: '2026-08-09',
+        payee: 'A',
+        accountId: 'a1',
+        notes: null,
+        categoryId: null,
+      },
+    ]);
+
+    expect(row.notes).toBeNull();
+    expect(row.categoryId).toBeNull();
+  });
+
+  // The CSV importer supplies neither, and must keep working untouched.
+  it('still normalizes omitted fields for the CSV path', () => {
+    const [row] = toBulkTransactionInput([
+      { amount: 1, date: '2026-08-09', payee: 'A', accountId: 'a1' },
+    ]);
+
+    expect(row.notes).toBeNull();
+    expect(row.categoryId).toBeNull();
+    expect(row.currency).toBe('ARS');
+  });
 });

--- a/features/transactions/api/transaction-payload.test.ts
+++ b/features/transactions/api/transaction-payload.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  toBulkTransactionInput,
+  toTransactionInput,
+} from '@/features/transactions/api/transaction-payload';
+
+const baseValues = {
+  date: new Date(2026, 7, 9, 14, 30),
+  accountId: 'account-1',
+  categoryId: 'category-1',
+  payee: 'Market',
+  amount: -12500,
+  notes: 'weekly shop',
+};
+
+describe('toTransactionInput', () => {
+  it('produces the contract shape', () => {
+    expect(toTransactionInput(baseValues)).toEqual({
+      amount: -12500,
+      payee: 'Market',
+      notes: 'weekly shop',
+      date: '2026-08-09',
+      accountId: 'account-1',
+      categoryId: 'category-1',
+      currency: 'ARS',
+    });
+  });
+
+  // The contract rejects a missing currency rather than defaulting it, and
+  // nothing upstream of the hooks supplies one.
+  it('always sets the currency', () => {
+    expect(toTransactionInput(baseValues).currency).toBe('ARS');
+  });
+
+  // `toISOString().slice(0, 10)` would convert local midnight to the previous
+  // day for any user east of Greenwich. Local midnight must stay the same
+  // calendar day it was picked as, in every zone the test runs in.
+  it('keeps the local calendar date at midnight', () => {
+    const midnight = new Date(2026, 7, 9, 0, 0, 0);
+    expect(toTransactionInput({ ...baseValues, date: midnight }).date).toBe(
+      '2026-08-09'
+    );
+  });
+
+  it('keeps the local calendar date just before midnight', () => {
+    const lateEvening = new Date(2026, 7, 9, 23, 59, 59);
+    expect(toTransactionInput({ ...baseValues, date: lateEvening }).date).toBe(
+      '2026-08-09'
+    );
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    const january = new Date(2026, 0, 5, 12, 0);
+    expect(toTransactionInput({ ...baseValues, date: january }).date).toBe(
+      '2026-01-05'
+    );
+  });
+
+  // The contract types both as nullable; the form leaves them undefined when
+  // untouched, and `undefined` would drop the key rather than send null.
+  it('normalizes omitted notes and category to null', () => {
+    const sparse = toTransactionInput({
+      date: baseValues.date,
+      accountId: 'account-1',
+      payee: 'Market',
+      amount: 1000,
+    });
+
+    expect(sparse.notes).toBeNull();
+    expect(sparse.categoryId).toBeNull();
+  });
+
+  it('passes an explicit null through unchanged', () => {
+    const cleared = toTransactionInput({
+      ...baseValues,
+      notes: null,
+      categoryId: null,
+    });
+
+    expect(cleared.notes).toBeNull();
+    expect(cleared.categoryId).toBeNull();
+  });
+
+  it('preserves the sign of an expense', () => {
+    expect(toTransactionInput({ ...baseValues, amount: -1 }).amount).toBe(-1);
+  });
+});
+
+describe('toBulkTransactionInput', () => {
+  // The CSV parser already emits `yyyy-MM-dd`, so this path must pass the date
+  // through untouched rather than re-parsing it into a Date and back.
+  it('passes the imported date string through unchanged', () => {
+    const [row] = toBulkTransactionInput([
+      { amount: -5000, date: '2026-08-09', payee: 'Market', accountId: 'a1' },
+    ]);
+
+    expect(row.date).toBe('2026-08-09');
+  });
+
+  it('adds the required currency and null defaults to every row', () => {
+    const rows = toBulkTransactionInput([
+      { amount: 1000, date: '2026-01-01', payee: 'One', accountId: 'a1' },
+      { amount: -2000, date: '2026-01-02', payee: 'Two', accountId: 'a1' },
+    ]);
+
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.currency).toBe('ARS');
+      expect(row.notes).toBeNull();
+      expect(row.categoryId).toBeNull();
+    }
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(toBulkTransactionInput([])).toEqual([]);
+  });
+});

--- a/features/transactions/api/transaction-payload.ts
+++ b/features/transactions/api/transaction-payload.ts
@@ -1,0 +1,96 @@
+import { format } from 'date-fns';
+
+import type { components } from '@/lib/api/generated/schema';
+
+/** The contract's write shape for a transaction. */
+export type TransactionInput = components['schemas']['TransactionInput'];
+
+/**
+ * What the transaction form hands a mutation hook.
+ *
+ * Derived from the Drizzle insert schema rather than the contract, because
+ * that is what the form and both sheets already produce. Keeping the hooks'
+ * public input at this shape is what lets #50 migrate the transport without
+ * touching a single component.
+ */
+export type TransactionFormValues = {
+  date: Date;
+  accountId: string;
+  categoryId?: string | null;
+  payee: string;
+  /** Signed integer milliunits, already converted by the form. */
+  amount: number;
+  notes?: string | null;
+};
+
+/**
+ * The currency every write carries.
+ *
+ * The contract requires `currency` and accepts only `ARS`, and deliberately
+ * rejects an omitted value rather than defaulting it — so a client that
+ * believes it is sending something else fails loudly instead of silently
+ * booking pesos. The legacy Hono route has no currency at all, so nothing
+ * upstream of here supplies one; this is the single place the app states it,
+ * and the place to change when multi-currency arrives.
+ */
+const DEFAULT_CURRENCY = 'ARS' as const;
+
+/**
+ * Converts form values into the contract's `TransactionInput`.
+ *
+ * Two things the form does not know about, and the reason this adapter exists
+ * rather than the components being changed:
+ *
+ * **`date` is a calendar date, not an instant.** The contract's `DateString`
+ * is `yyyy-MM-dd`; the form holds a `Date`. Formatting goes through date-fns,
+ * which reads *local* calendar parts. `toISOString().slice(0, 10)` would
+ * convert to UTC first and hand back the previous day for any user east of
+ * Greenwich — a transaction picked as the 9th filed as the 8th, silently, and
+ * only for some users.
+ *
+ * **`currency` is required.** See `DEFAULT_CURRENCY`.
+ */
+export function toTransactionInput(
+  values: TransactionFormValues
+): TransactionInput {
+  return {
+    amount: values.amount,
+    payee: values.payee,
+    notes: values.notes ?? null,
+    date: format(values.date, 'yyyy-MM-dd'),
+    accountId: values.accountId,
+    categoryId: values.categoryId ?? null,
+    currency: DEFAULT_CURRENCY,
+  };
+}
+
+/**
+ * One CSV row, as the import screen produces it.
+ *
+ * `date` is already a `yyyy-MM-dd` string here rather than a `Date` —
+ * `parseImportedTransactionRows` formats it on the way out — so this shape
+ * needs no date conversion, only the currency the contract requires.
+ */
+export type ImportedTransactionInput = {
+  amount: number;
+  date: string;
+  payee: string;
+  accountId: string;
+};
+
+/** Converts imported CSV rows into the contract's bulk-create body. */
+export function toBulkTransactionInput(
+  rows: ImportedTransactionInput[]
+): TransactionInput[] {
+  return rows.map((row) => ({
+    amount: row.amount,
+    payee: row.payee,
+    // A CSV import carries neither, and the generated type requires both to be
+    // present even though the contract gives them a null default.
+    notes: null,
+    categoryId: null,
+    date: row.date,
+    accountId: row.accountId,
+    currency: DEFAULT_CURRENCY,
+  }));
+}

--- a/features/transactions/api/transaction-payload.ts
+++ b/features/transactions/api/transaction-payload.ts
@@ -44,11 +44,11 @@ const DEFAULT_CURRENCY = 'ARS' as const;
  * rather than the components being changed:
  *
  * **`date` is a calendar date, not an instant.** The contract's `DateString`
- * is `yyyy-MM-dd`; the form holds a `Date`. Formatting goes through date-fns,
- * which reads *local* calendar parts. `toISOString().slice(0, 10)` would
- * convert to UTC first and hand back the previous day for any user east of
- * Greenwich — a transaction picked as the 9th filed as the 8th, silently, and
- * only for some users.
+ * is `yyyy-MM-dd`; the form holds a `Date`. The conversion goes through
+ * `transaction-date.ts`, which reads *local* calendar parts.
+ * `toISOString().slice(0, 10)` would convert to UTC first and hand back the
+ * previous day for any user east of Greenwich — a transaction picked as the 9th
+ * filed as the 8th, silently, and only for some users.
  *
  * **`currency` is required.** See `DEFAULT_CURRENCY`.
  */
@@ -61,9 +61,19 @@ export function toTransactionInput(
     notes: values.notes ?? null,
     date: calendarDateFromLocalDate(values.date),
     accountId: values.accountId,
-    categoryId: values.categoryId ?? null,
+    // `''` normalizes to null alongside undefined. The contract's `ResourceId`
+    // sets `minLength: 1`, so an empty string is rejected outright — and an
+    // empty string is exactly what an unselected `<select>` or a cleared form
+    // field produces. Absorbing it here keeps that from reaching the API as a
+    // guaranteed 400.
+    categoryId: emptyToNull(values.categoryId),
     currency: DEFAULT_CURRENCY,
   };
+}
+
+/** Treats an unset, null or blank optional id as absent. */
+function emptyToNull(value: string | null | undefined): string | null {
+  return value === undefined || value === null || value === '' ? null : value;
 }
 
 /**
@@ -97,7 +107,7 @@ export function toBulkTransactionInput(
     amount: row.amount,
     payee: row.payee,
     notes: row.notes ?? null,
-    categoryId: row.categoryId ?? null,
+    categoryId: emptyToNull(row.categoryId),
     date: row.date,
     accountId: row.accountId,
     currency: DEFAULT_CURRENCY,

--- a/features/transactions/api/transaction-payload.ts
+++ b/features/transactions/api/transaction-payload.ts
@@ -1,6 +1,8 @@
-import { format } from 'date-fns';
-
 import type { components } from '@/lib/api/generated/schema';
+import {
+  calendarDateFromLocalDate,
+  type CalendarDate,
+} from '@/features/transactions/api/transaction-date';
 
 /** The contract's write shape for a transaction. */
 export type TransactionInput = components['schemas']['TransactionInput'];
@@ -57,7 +59,7 @@ export function toTransactionInput(
     amount: values.amount,
     payee: values.payee,
     notes: values.notes ?? null,
-    date: format(values.date, 'yyyy-MM-dd'),
+    date: calendarDateFromLocalDate(values.date),
     accountId: values.accountId,
     categoryId: values.categoryId ?? null,
     currency: DEFAULT_CURRENCY,
@@ -65,30 +67,37 @@ export function toTransactionInput(
 }
 
 /**
- * One CSV row, as the import screen produces it.
+ * One row submitted to bulk create.
  *
- * `date` is already a `yyyy-MM-dd` string here rather than a `Date` —
- * `parseImportedTransactionRows` formats it on the way out — so this shape
- * needs no date conversion, only the currency the contract requires.
+ * `date` is a `yyyy-MM-dd` string rather than a `Date` because the CSV parser
+ * (`parseImportedTransactionRows`) already formats it that way, so that path
+ * needs no date conversion.
+ *
+ * `notes` and `categoryId` are optional but **not** ignored. The legacy hook
+ * took the full transaction insert shape, so narrowing the type and hardcoding
+ * both to `null` would silently discard whatever a caller passed — a payload
+ * accepted and then quietly altered, which is worse than a type error. The CSV
+ * importer supplies neither today; the contract still requires both keys to be
+ * present, so omitted values normalize to `null`.
  */
 export type ImportedTransactionInput = {
   amount: number;
-  date: string;
+  date: CalendarDate;
   payee: string;
   accountId: string;
+  notes?: string | null;
+  categoryId?: string | null;
 };
 
-/** Converts imported CSV rows into the contract's bulk-create body. */
+/** Converts bulk-create rows into the contract's bare-array body. */
 export function toBulkTransactionInput(
   rows: ImportedTransactionInput[]
 ): TransactionInput[] {
   return rows.map((row) => ({
     amount: row.amount,
     payee: row.payee,
-    // A CSV import carries neither, and the generated type requires both to be
-    // present even though the contract gives them a null default.
-    notes: null,
-    categoryId: null,
+    notes: row.notes ?? null,
+    categoryId: row.categoryId ?? null,
     date: row.date,
     accountId: row.accountId,
     currency: DEFAULT_CURRENCY,

--- a/features/transactions/api/use-bulk-create-transactions.ts
+++ b/features/transactions/api/use-bulk-create-transactions.ts
@@ -1,40 +1,34 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
-
-type ResponseType = InferResponseType<
-  (typeof client.api.transactions)['bulk-create']['$post']
->;
-type RequestType = InferRequestType<
-  (typeof client.api.transactions)['bulk-create']['$post']
->['json'];
+import {
+  toBulkTransactionInput,
+  type ImportedTransactionInput,
+} from '@/features/transactions/api/transaction-payload';
+import { apiClient, unwrap } from '@/lib/api/client';
 
 export const useBulkCreateTransactions = () => {
   const queryClient = useQueryClient();
 
-  const mutation = useMutation<ResponseType, Error, RequestType>({
-    mutationFn: async (json) => {
-      const response = await client.api.transactions['bulk-create']['$post']({
-        json,
+  const mutation = useMutation({
+    mutationFn: async (rows: ImportedTransactionInput[]) => {
+      const result = await apiClient.POST('/transactions/bulk-create', {
+        // The contract's bulk-create body is a bare array, not an object
+        // wrapping one.
+        body: toBulkTransactionInput(rows),
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'transactions');
-      }
-      return await response.json();
+      return unwrap(result, 'transactions');
     },
     onSuccess: () => {
       toast.success('Transactions created successfully');
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
       queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
-    onError: () => {
-      toast.error(`Error creating transactions`);
-    },
+    // Deliberately no toast here. The import screen catches this to report
+    // which row failed, and it is the only caller; a generic toast from the
+    // hook would fire alongside that and bury the useful message.
   });
   return mutation;
 };

--- a/features/transactions/api/use-bulk-create-transactions.ts
+++ b/features/transactions/api/use-bulk-create-transactions.ts
@@ -1,5 +1,3 @@
-import { toast } from 'sonner';
-
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import {
@@ -22,13 +20,14 @@ export const useBulkCreateTransactions = () => {
       return unwrap(result, 'transactions');
     },
     onSuccess: () => {
-      toast.success('Transactions created successfully');
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
       queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
-    // Deliberately no toast here. The import screen catches this to report
-    // which row failed, and it is the only caller; a generic toast from the
-    // hook would fire alongside that and bury the useful message.
+    // Deliberately no toast in this hook. The import screen is its only caller
+    // and submits in 500-row chunks, so hook-level success messages would fire
+    // once per chunk before the page's single completion toast. The page also
+    // catches failures to identify the exact row without a competing generic
+    // error message.
   });
   return mutation;
 };

--- a/features/transactions/api/use-bulk-delete-transactions.ts
+++ b/features/transactions/api/use-bulk-delete-transactions.ts
@@ -1,39 +1,38 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
-
-type ResponseType = InferResponseType<
-  (typeof client.api.transactions)['bulk-delete']['$post']
->;
-type RequestType = InferRequestType<
-  (typeof client.api.transactions)['bulk-delete']['$post']
->['json'];
+import {
+  bulkFieldErrors,
+  formatBulkErrorSummary,
+} from '@/features/transactions/api/bulk-errors';
+import { apiClient, unwrap } from '@/lib/api/client';
 
 export const useBulkDeleteTransactions = () => {
   const queryClient = useQueryClient();
 
-  const mutation = useMutation<ResponseType, Error, RequestType>({
-    mutationFn: async (json) => {
-      const response = await client.api.transactions['bulk-delete']['$post']({
-        json,
+  const mutation = useMutation({
+    mutationFn: async (body: { ids: string[] }) => {
+      const result = await apiClient.POST('/transactions/bulk-delete', {
+        body,
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'transactions');
-      }
-      return await response.json();
+      return unwrap(result, 'transactions');
     },
     onSuccess: () => {
       toast.success('Transactions deleted successfully');
       queryClient.invalidateQueries({ queryKey: ['transactions'] });
       queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
-    onError: () => {
-      toast.error(`Error deleting transactions`);
+    onError: (error) => {
+      // Selection-driven, so the user has no row numbers in front of them and
+      // an indexed message would mean little. The array-level message is the
+      // useful one — notably the 500-id cap, which transactions enforce and
+      // accounts and categories deliberately do not.
+      const summary = formatBulkErrorSummary(
+        bulkFieldErrors(error).filter((field) => field.index === null)
+      );
+      toast.error(summary ?? 'Error deleting transactions');
     },
   });
   return mutation;

--- a/features/transactions/api/use-create-transaction.ts
+++ b/features/transactions/api/use-create-transaction.ts
@@ -6,8 +6,8 @@ import {
   toTransactionInput,
   type TransactionFormValues,
 } from '@/features/transactions/api/transaction-payload';
+import { transactionMutationErrorMessage } from '@/features/transactions/api/transaction-mutation-error';
 import { apiClient, unwrap } from '@/lib/api/client';
-import { ApiError } from '@/lib/api-error';
 
 export const useCreateTransaction = () => {
   const queryClient = useQueryClient();
@@ -26,11 +26,8 @@ export const useCreateTransaction = () => {
       queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: (error) => {
-      // `toApiError` already prefers the API's own message, so this reads it
-      // straight off the error rather than digging into `errorData` as the
-      // Hono version had to.
       toast.error(
-        error instanceof ApiError ? error.message : 'Error creating transaction'
+        transactionMutationErrorMessage(error, 'Error creating transaction')
       );
     },
   });

--- a/features/transactions/api/use-create-transaction.ts
+++ b/features/transactions/api/use-create-transaction.ts
@@ -1,27 +1,24 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { ApiError, createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
-
-type ResponseType = InferResponseType<typeof client.api.transactions.$post>;
-type RequestType = InferRequestType<
-  typeof client.api.transactions.$post
->['json'];
+import {
+  toTransactionInput,
+  type TransactionFormValues,
+} from '@/features/transactions/api/transaction-payload';
+import { apiClient, unwrap } from '@/lib/api/client';
+import { ApiError } from '@/lib/api-error';
 
 export const useCreateTransaction = () => {
   const queryClient = useQueryClient();
 
-  const mutation = useMutation<ResponseType, Error, RequestType>({
-    mutationFn: async (json) => {
-      const response = await client.api.transactions.$post({ json });
+  const mutation = useMutation({
+    mutationFn: async (values: TransactionFormValues) => {
+      const result = await apiClient.POST('/transactions', {
+        body: toTransactionInput(values),
+      });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'transactions');
-      }
-      return await response.json();
+      return unwrap(result, 'transactions');
     },
     onSuccess: () => {
       toast.success('Transaction created successfully');
@@ -29,13 +26,12 @@ export const useCreateTransaction = () => {
       queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: (error) => {
-      const apiMessage =
-        error instanceof ApiError
-          ? (error.details.errorData as { error?: { message?: string } } | null)
-              ?.error?.message
-          : null;
-
-      toast.error(apiMessage ?? 'Error creating transaction');
+      // `toApiError` already prefers the API's own message, so this reads it
+      // straight off the error rather than digging into `errorData` as the
+      // Hono version had to.
+      toast.error(
+        error instanceof ApiError ? error.message : 'Error creating transaction'
+      );
     },
   });
   return mutation;

--- a/features/transactions/api/use-delete-transaction.ts
+++ b/features/transactions/api/use-delete-transaction.ts
@@ -2,6 +2,7 @@ import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { transactionPathParams } from '@/features/transactions/api/transaction-path-params';
 import { apiClient, unwrap } from '@/lib/api/client';
 
 export const useDeleteTransaction = (id?: string) => {
@@ -10,9 +11,7 @@ export const useDeleteTransaction = (id?: string) => {
   const mutation = useMutation({
     mutationFn: async () => {
       const result = await apiClient.DELETE('/transactions/{id}', {
-        // The sheet and the row action only mount this with an id; the
-        // generated path type requires a string.
-        params: { path: { id: id as string } },
+        params: transactionPathParams(id),
       });
 
       return unwrap(result, 'delete transaction');

--- a/features/transactions/api/use-delete-transaction.ts
+++ b/features/transactions/api/use-delete-transaction.ts
@@ -1,28 +1,21 @@
-import { InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
-
-type ResponseType = InferResponseType<
-  (typeof client.api.transactions)[':id']['$delete']
->;
+import { apiClient, unwrap } from '@/lib/api/client';
 
 export const useDeleteTransaction = (id?: string) => {
   const queryClient = useQueryClient();
 
-  const mutation = useMutation<ResponseType, Error>({
+  const mutation = useMutation({
     mutationFn: async () => {
-      const response = await client.api.transactions[':id']['$delete']({
-        param: { id: id },
+      const result = await apiClient.DELETE('/transactions/{id}', {
+        // The sheet and the row action only mount this with an id; the
+        // generated path type requires a string.
+        params: { path: { id: id as string } },
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'delete transaction');
-      }
-      return await response.json();
+      return unwrap(result, 'delete transaction');
     },
     onSuccess: () => {
       toast.success('Transaction deleted successfully');

--- a/features/transactions/api/use-edit-transaction.ts
+++ b/features/transactions/api/use-edit-transaction.ts
@@ -7,6 +7,7 @@ import {
   type TransactionFormValues,
 } from '@/features/transactions/api/transaction-payload';
 import { transactionMutationErrorMessage } from '@/features/transactions/api/transaction-mutation-error';
+import { transactionPathParams } from '@/features/transactions/api/transaction-path-params';
 import { apiClient, unwrap } from '@/lib/api/client';
 
 export const useEditTransaction = (id?: string) => {
@@ -15,9 +16,7 @@ export const useEditTransaction = (id?: string) => {
   const mutation = useMutation({
     mutationFn: async (values: TransactionFormValues) => {
       const result = await apiClient.PATCH('/transactions/{id}', {
-        // The sheet only mounts this with an id; the generated path type
-        // requires a string.
-        params: { path: { id: id as string } },
+        params: transactionPathParams(id),
         body: toTransactionInput(values),
       });
 

--- a/features/transactions/api/use-edit-transaction.ts
+++ b/features/transactions/api/use-edit-transaction.ts
@@ -1,32 +1,27 @@
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { ApiError, createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
-
-type ResponseType = InferResponseType<
-  (typeof client.api.transactions)[':id']['$patch']
->;
-type RequestType = InferRequestType<
-  (typeof client.api.transactions)[':id']['$patch']
->['json'];
+import {
+  toTransactionInput,
+  type TransactionFormValues,
+} from '@/features/transactions/api/transaction-payload';
+import { apiClient, unwrap } from '@/lib/api/client';
+import { ApiError } from '@/lib/api-error';
 
 export const useEditTransaction = (id?: string) => {
   const queryClient = useQueryClient();
 
-  const mutation = useMutation<ResponseType, Error, RequestType>({
-    mutationFn: async (json) => {
-      const response = await client.api.transactions[':id']['$patch']({
-        param: { id: id },
-        json,
+  const mutation = useMutation({
+    mutationFn: async (values: TransactionFormValues) => {
+      const result = await apiClient.PATCH('/transactions/{id}', {
+        // The sheet only mounts this with an id; the generated path type
+        // requires a string.
+        params: { path: { id: id as string } },
+        body: toTransactionInput(values),
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'edit transaction ');
-      }
-      return await response.json();
+      return unwrap(result, 'edit transaction');
     },
     onSuccess: () => {
       toast.success('Transaction edited successfully');
@@ -35,13 +30,9 @@ export const useEditTransaction = (id?: string) => {
       queryClient.invalidateQueries({ queryKey: ['summary'] });
     },
     onError: (error) => {
-      const apiMessage =
-        error instanceof ApiError
-          ? (error.details.errorData as { error?: { message?: string } } | null)
-              ?.error?.message
-          : null;
-
-      toast.error(apiMessage ?? 'Error editing transaction');
+      toast.error(
+        error instanceof ApiError ? error.message : 'Error editing transaction'
+      );
     },
   });
   return mutation;

--- a/features/transactions/api/use-edit-transaction.ts
+++ b/features/transactions/api/use-edit-transaction.ts
@@ -6,8 +6,8 @@ import {
   toTransactionInput,
   type TransactionFormValues,
 } from '@/features/transactions/api/transaction-payload';
+import { transactionMutationErrorMessage } from '@/features/transactions/api/transaction-mutation-error';
 import { apiClient, unwrap } from '@/lib/api/client';
-import { ApiError } from '@/lib/api-error';
 
 export const useEditTransaction = (id?: string) => {
   const queryClient = useQueryClient();
@@ -31,7 +31,7 @@ export const useEditTransaction = (id?: string) => {
     },
     onError: (error) => {
       toast.error(
-        error instanceof ApiError ? error.message : 'Error editing transaction'
+        transactionMutationErrorMessage(error, 'Error editing transaction')
       );
     },
   });

--- a/features/transactions/api/use-get-transaction.ts
+++ b/features/transactions/api/use-get-transaction.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { transactionPathParams } from '@/features/transactions/api/transaction-path-params';
 import { apiClient, unwrap } from '@/lib/api/client';
 import { convertAmountFromMiliunits } from '@/lib/utils';
 
@@ -9,9 +10,7 @@ export const useGetTransaction = (id?: string) => {
     queryKey: ['transaction', { id }],
     queryFn: async () => {
       const result = await apiClient.GET('/transactions/{id}', {
-        // `enabled` keeps this from running without an id, which is why the
-        // assertion is safe; the generated path type requires a string.
-        params: { path: { id: id as string } },
+        params: transactionPathParams(id),
       });
 
       const { data } = unwrap(result, 'getSingleTransaction');

--- a/features/transactions/api/use-get-transaction.ts
+++ b/features/transactions/api/use-get-transaction.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { calendarDateFromApi } from '@/features/transactions/api/transaction-date';
 import { transactionPathParams } from '@/features/transactions/api/transaction-path-params';
 import { apiClient, unwrap } from '@/lib/api/client';
 import { convertAmountFromMiliunits } from '@/lib/utils';
@@ -17,6 +18,9 @@ export const useGetTransaction = (id?: string) => {
       return {
         ...data,
         amount: convertAmountFromMiliunits(data.amount),
+        // See use-get-transactions: the edit sheet builds its picker value from
+        // this, and an instant here walks the date back a day on every save.
+        date: calendarDateFromApi(data.date),
       };
     },
   });

--- a/features/transactions/api/use-get-transaction.ts
+++ b/features/transactions/api/use-get-transaction.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
 import { convertAmountFromMiliunits } from '@/lib/utils';
 
 export const useGetTransaction = (id?: string) => {
@@ -9,15 +8,13 @@ export const useGetTransaction = (id?: string) => {
     enabled: !!id,
     queryKey: ['transaction', { id }],
     queryFn: async () => {
-      const response = await client.api.transactions[':id'].$get({
-        param: { id },
+      const result = await apiClient.GET('/transactions/{id}', {
+        // `enabled` keeps this from running without an id, which is why the
+        // assertion is safe; the generated path type requires a string.
+        params: { path: { id: id as string } },
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'getSingleTransaction');
-      }
-
-      const { data } = await response.json();
+      const { data } = unwrap(result, 'getSingleTransaction');
       return {
         ...data,
         amount: convertAmountFromMiliunits(data.amount),

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 
-import { createApiError } from '@/lib/api-error';
-import { client } from '@/lib/hono';
+import { apiClient, unwrap } from '@/lib/api/client';
 import { omitEmptyQueryParams } from '@/lib/query-params';
 import { convertAmountFromMiliunits } from '@/lib/utils';
 
@@ -16,19 +15,17 @@ export const useGetTransactions = () => {
   const query = useQuery({
     queryKey: ['transactions', { from, to, accountId }],
     queryFn: async () => {
-      const response = await client.api.transactions.$get({
-        // Unset filters are omitted, not sent as empty strings: an explicitly
-        // empty `from`/`to`/`accountId` is malformed per the API contract and
-        // is rejected with 400 INVALID_QUERY, while omission selects the
-        // default range.
-        query: omitEmptyQueryParams({ from, to, accountId }),
+      const result = await apiClient.GET('/transactions', {
+        params: {
+          // Unset filters are omitted, not sent as empty strings: an
+          // explicitly empty `from`/`to`/`accountId` is malformed per the API
+          // contract and is rejected with 400 INVALID_QUERY, while omission
+          // selects the default range.
+          query: omitEmptyQueryParams({ from, to, accountId }),
+        },
       });
 
-      if (!response.ok) {
-        throw await createApiError(response, 'transactions');
-      }
-
-      const { data } = await response.json();
+      const { data } = unwrap(result, 'transactions');
       return data.map((transaction) => ({
         ...transaction,
         amount: convertAmountFromMiliunits(transaction.amount),

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 
+import { calendarDateFromApi } from '@/features/transactions/api/transaction-date';
 import { apiClient, unwrap } from '@/lib/api/client';
 import { omitEmptyQueryParams } from '@/lib/query-params';
 import { convertAmountFromMiliunits } from '@/lib/utils';
@@ -29,6 +30,10 @@ export const useGetTransactions = () => {
       return data.map((transaction) => ({
         ...transaction,
         amount: convertAmountFromMiliunits(transaction.amount),
+        // Normalized here so every consumer sees the calendar date the row
+        // actually holds, rather than re-deriving an instant in its own
+        // timezone and landing a day earlier.
+        date: calendarDateFromApi(transaction.date),
       }));
     },
   });

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { InsertTransactionSchema } from '@/db/schema';
+import { localDateFromCalendarDate } from '@/features/transactions/api/transaction-date';
 import { useDeleteTransaction } from '@/features/transactions/api/use-delete-transaction';
 import { useEditTransaction } from '@/features/transactions/api/use-edit-transaction';
 import { useGetTransaction } from '@/features/transactions/api/use-get-transaction';
@@ -104,8 +105,11 @@ export const EditTransactionSheet = () => {
         accountId: transactionQuery.data.accountId,
         categoryId: transactionQuery.data.categoryId,
         amount: transactionQuery.data.amount.toString(),
+        // The hook already normalized this to a calendar date; building the
+        // picker value from parts keeps it on that day in every timezone.
+        // `new Date(...)` here is what walked the date back one day per save.
         date: transactionQuery.data.date
-          ? new Date(transactionQuery.data.date)
+          ? localDateFromCalendarDate(transactionQuery.data.date)
           : new Date(),
         payee: transactionQuery.data.payee,
         notes: transactionQuery.data.notes || '',

--- a/features/transactions/components/transaction-form.tsx
+++ b/features/transactions/components/transaction-form.tsx
@@ -18,7 +18,10 @@ import {
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { InsertTransactionSchema } from '@/db/schema';
-import { convertAmountToMiliunits, isSafeMiliunitAmount } from '@/lib/utils';
+import {
+  convertAmountToMiliunits,
+  isSafeMiliunitAmount,
+} from '@/lib/utils';
 
 const formSchema = z.object({
   date: z.date(),

--- a/features/transactions/components/transaction-form.tsx
+++ b/features/transactions/components/transaction-form.tsx
@@ -18,10 +18,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { InsertTransactionSchema } from '@/db/schema';
-import {
-  convertAmountToMiliunits,
-  isSafeMiliunitAmount,
-} from '@/lib/utils';
+import { convertAmountToMiliunits, isSafeMiliunitAmount } from '@/lib/utils';
 
 const formSchema = z.object({
   date: z.date(),


### PR DESCRIPTION
Part of #50 — the transactions and summary domains. Accounts and categories are
Codex's lane and are untouched here.

Migrates the seven transaction hooks and the summary hook from the Hono RPC
client to the generated OpenAPI client. **No hook's public API changes** — no
call site needed a signature change.

Being precise about that evidence, since an earlier version of this description
overstated it: the transport migration itself required no component edits. Later
commits on this branch *do* modify components, for the date fix described below —
`edit-transaction-sheet.tsx` and `columns.tsx` build their values through the
calendar-date helpers, and `columns.tsx` also drops a stale runtime import of the
Hono client. Those are behavioral fixes, not signature changes forced by the
migration.

## What the typed client caught

Two things the Hono path had been papering over, both now compile errors rather
than runtime surprises:

- **`currency` is required** and accepted only as `ARS`. The legacy Hono route
  has no currency field at all, so nothing upstream supplies one.
- **`date` on write is a calendar date** (`yyyy-MM-dd`), not an instant. The
  form holds a `Date`.

Both are handled in `transaction-payload.ts`, at the transport boundary, rather
than by changing the form. The date is formatted from **local** parts via
date-fns: `toISOString().slice(0, 10)` would convert to UTC first and file a
transaction picked on the 9th as the 8th for any user east of Greenwich. The
CSV import path already emits `yyyy-MM-dd`, so it passes through untouched and
only gains the currency.

## Bulk errors now name the row

Bulk failures arrive with indexed paths — `[3].amount` for a row, `$` for the
whole array, `ids`/`ids[i]` for bulk-delete — and a body that could not be
parsed carries no `details` at all. `bulk-errors.ts` decodes every one of those
forms, and the import screen reports the failing row instead of a flat "failed
to import".

Row numbers are offset by however many rows already succeeded, because the
import submits in chunks of 500: an error at index 3 of the second chunk is row
**504** of the user's file, and reporting it as row 4 would send them to the
wrong line.

## Two deliberate behavior changes, both in the import path

- `useBulkCreateTransactions` no longer raises its own toast. The import screen
  is its only caller and already catches the failure to show the indexed
  message; the hook's generic toast fired alongside it, so users got two toasts
  and the useful one was second.
- `useBulkDeleteTransactions` surfaces array-level messages (notably the 500-id
  cap, which transactions enforce and accounts/categories deliberately do not)
  instead of a fixed string. Per-row indexes are filtered out there — that flow
  is selection-driven, so the user has no row numbers to map them to.

Flagging both since "no public API changes" was the bar; these are observable,
contained to one caller each, and leave the user better informed.

## Verification

`bun run lint` clean, `bun test` 94 pass / 0 fail (26 new), `bunx tsc --noEmit`
matches the master baseline, `bun run build` succeeds.

Live-checked against the running Go API: `GET /api/transactions` returns 200
through the migrated hook and the list renders with amounts correctly converted
from milliunits. The exact payload shapes both adapters produce — single create
and bulk create — were posted to the real API and accepted, which is what
validates the currency, date and null-default decisions.

Because nothing on master populates the access-token store yet, end-to-end UI
verification was done on a throwaway local merge with #51; that merge is not
pushed and neither branch depends on the other.

## Found while verifying: a date off-by-one between the stacks

Not caused by this PR — it is a backend serialization difference — but it is
user-visible and worth its own decision. Same row, same database:

| | value |
| --- | --- |
| stored | `2026-08-07 00:00:00` (`timestamp without time zone`) |
| Hono returns | `2026-08-07T03:00:00.000Z` |
| Go returns | `2026-08-07T00:00:00Z` |
| table shows (UTC-3) | Hono **07 August**, Go **06 August** |

node-postgres reads a naive timestamp as local; Go reads it as UTC. Every
transaction date renders a day early for any user west of Greenwich, which
includes Argentina. Registry entry 0014 covers the *filter* side of this and
"Known gaps" notes that `date` models a calendar date as a timestamp, but the
response side does not appear to be recorded. Raising rather than touching it —
`backend/**` is frozen and this is your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

