### PR TITLE
Add differential parity harness comparing Hono and Go

### DIFF
--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -1,0 +1,120 @@
+# Differential parity harness
+
+Drives the same input at both stacks and compares what comes back.
+
+**This can only be built while both stacks exist.** After
+[#27](https://github.com/GonzaloSecades/nuchi/issues/27) removes Hono there is
+nothing left to compare against, and any divergence still present becomes
+simply "how the app behaves". That is the whole reason this lands before the
+cutover rather than after it.
+
+## The gap it closes
+
+Two oracles already exist and neither one compares the stacks:
+
+- `docs/specs/18-go-backend-replacement/api-parity-fixtures.md` records what
+  Hono does. It is a document; nothing executes it.
+- The Go test suite asserts Go against the contract.
+
+Both pass while disagreeing with each other. A difference that the contract does
+not pin down — a timezone, an ordering tiebreak, a rounding step — sits in the
+gap between them, invisible to either, until `USE_GO_API` flips and it becomes a
+production bug on cutover day.
+
+That is not hypothetical: the first thing this harness was pointed at, it found
+one. See "Date serialization" below.
+
+## Running it
+
+Needs Postgres and a Go API. From the repo root:
+
+```bash
+wsl -d Ubuntu-20.04 -u root -e sh -c "service postgresql start; sleep 7200"
+```
+
+Then the API, from `backend/`:
+
+```bash
+DATABASE_URL='postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable' AUTH_JWT_SECRET='local-parity-secret-at-least-32-bytes-long' APP_BASE_URL='http://localhost:3000' SMTP_ADDR='localhost:1025' MAIL_FROM='nuchi@localhost' go run ./cmd/api
+```
+
+Then the harness:
+
+```bash
+ADMIN_DATABASE_URL='postgres://postgres:postgres@localhost:5432/nuchi?sslmode=disable' bun test tests/parity/
+```
+
+Without those variables every test **skips** rather than passes. A differential
+test that silently passes because it could not reach either stack is worse than
+no test at all — it looks like evidence. Check for `skip` in the output before
+believing a green run.
+
+`ADMIN_DATABASE_URL` is the admin role deliberately: the harness seeds and reads
+across users, and the app role is subject to RLS, which would return zero rows
+and make every comparison trivially equal.
+
+## How each side is represented
+
+| Stack | How it is driven                                             |
+| ----- | ------------------------------------------------------------ |
+| Go    | Over HTTP, as a real client, with a real session             |
+| Hono  | Through **node-postgres**, the driver its Drizzle setup uses |
+
+The Go side is fully end-to-end: the harness registers a user, verifies it with
+SQL (the emailed token is stored hashed, so the raw value only exists in an
+email, and depending on a mail catcher would tie a data comparison to SMTP),
+logs in, and calls the API with the resulting Bearer token.
+
+**The Hono side is the honest limitation here.** Its routes authenticate through
+Clerk, which is not scriptable from a test, so this compares at the data layer
+rather than through Hono's handlers. For the class of difference that motivated
+the harness — how stored values become JSON — that is faithful, because the
+handler passes those values straight through. It would _not_ catch a difference
+introduced inside a Hono handler, such as an ordering or aggregation choice.
+
+Closing that gap means either mocking `@hono/clerk-auth` and calling the Hono app
+in-process with `app.request()`, or standing up a Clerk test session. Both are
+viable; neither was needed for what this found first. That is the seam to extend
+at, and it is the reason the support layer is a separate module.
+
+## Known divergences
+
+`divergences.ts` lists the deliberate ones as data, each pointing at where it is
+argued — a numbered entry in
+`post-migration-improvements/claude-backend-improvements/`, or a "Divergences"
+section under `docs/api/`.
+
+Keeping that list is what makes the harness usable. Without it a run is a wall
+of red that has to be re-triaged by hand every time, and the one real regression
+hides among the decisions we already made on purpose. **Anything reported that
+is not on the list is a finding.**
+
+## Date serialization
+
+The first finding, and currently the only entry marked `expected: false`.
+
+`transactions.date` is `timestamp without time zone`. Both stacks read the same
+bytes and disagree about what timezone those bytes are in:
+
+|                      | value                      |
+| -------------------- | -------------------------- |
+| stored               | `2026-08-07 00:00:00`      |
+| node-postgres (Hono) | `2026-08-07T03:00:00.000Z` |
+| Go                   | `2026-08-07T00:00:00Z`     |
+
+A browser renders those as **different calendar days** anywhere west of
+Greenwich. Every transaction date shows a day early — including for Argentina,
+which is the app's own market and its default currency.
+
+Registry entry 0014 covers the _filter_ side of the same underlying modelling
+problem, and `docs/api/transactions.md` notes under "Known gaps" that `date` is
+a `timestamp` modelling what is really a calendar date. The response side does
+not appear to be recorded anywhere.
+
+It is deliberately **not** marked as an expected divergence. It is a regression
+against Hono rather than a decision, and marking it expected would retire the
+only test that reports it. The test asserts the difference _is present_ rather
+than asserting the two agree: an assertion that fails today, inside a parity
+freeze that forbids fixing it, gets ignored and then deleted. Written this way
+it documents the defect, proves it is still there, and fails loudly the day
+someone changes either side — which is exactly when someone should look.

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -22,11 +22,32 @@ gap between them, invisible to either, until `USE_GO_API` flips and it becomes a
 production bug on cutover day.
 
 That is not hypothetical: the first thing this harness was pointed at, it found
-one. See "Date serialization" below.
+one. See [Date serialization](#date-serialization) below.
 
 ## Running it
 
-Needs Postgres and a Go API. From the repo root:
+### `TZ` is not optional
+
+**`bun test` runs at UTC regardless of the host timezone.** At UTC the two
+stacks serialize a naive timestamp identically, so there is no difference to
+observe and the comparison **skips**. Running the harness without setting `TZ`
+therefore exercises everything _except_ the finding it exists to report.
+
+Set a non-UTC zone. Use POSIX-style offsets rather than IANA names — Bun on
+Windows silently ignores `Asia/Tokyo` and falls back to the host zone, which
+would make a run look meaningful when it is not. Note the POSIX sign is
+inverted: `GMT-3` is UTC−3.
+
+### Services
+
+Postgres, from the repo root — the standard path is Docker Compose:
+
+```bash
+docker compose up -d postgres
+```
+
+If Docker is unavailable, a native server works just as well; on this machine
+Postgres runs under WSL:
 
 ```bash
 wsl -d Ubuntu-20.04 -u root -e sh -c "service postgresql start; sleep 7200"
@@ -41,17 +62,25 @@ DATABASE_URL='postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable' AUTH_
 Then the harness:
 
 ```bash
-ADMIN_DATABASE_URL='postgres://postgres:postgres@localhost:5432/nuchi?sslmode=disable' bun test tests/parity/
+TZ=GMT-3 ADMIN_DATABASE_URL='postgres://postgres:postgres@localhost:5432/nuchi?sslmode=disable' bun test tests/parity/
 ```
 
-Without those variables every test **skips** rather than passes. A differential
-test that silently passes because it could not reach either stack is worse than
-no test at all — it looks like evidence. Check for `skip` in the output before
-believing a green run.
+### Reading the result
+
+Every test **skips** rather than passes when it cannot reach both stacks, and
+the timezone-dependent comparison skips when the runner is at UTC. A
+differential test that silently passes because it compared nothing is worse than
+no test at all — it looks like evidence. **Check the skip count before believing
+a green run.** For reference, a complete local run reports 13 passing and 0
+skipped; a run with no services reports 8 passing (the registry rules, which
+need nothing) and 8 skipped.
 
 `ADMIN_DATABASE_URL` is the admin role deliberately: the harness seeds and reads
 across users, and the app role is subject to RLS, which would return zero rows
 and make every comparison trivially equal.
+
+`GO_API_URL` is the API **origin** — scheme and host, no path. The `/api` prefix
+is added by the harness, so a value that already includes it yields `/api/api/…`.
 
 ## How each side is represented
 
@@ -79,15 +108,26 @@ at, and it is the reason the support layer is a separate module.
 
 ## Known divergences
 
-`divergences.ts` lists the deliberate ones as data, each pointing at where it is
-argued — a numbered entry in
+`divergences.ts` holds the deliberate divergences as data, each pointing at
+where it is argued — a numbered entry in
 `post-migration-improvements/claude-backend-improvements/`, or a "Divergences"
 section under `docs/api/`.
 
-Keeping that list is what makes the harness usable. Without it a run is a wall
-of red that has to be re-triaged by hand every time, and the one real regression
-hides among the decisions we already made on purpose. **Anything reported that
-is not on the list is a finding.**
+The registry is **consulted, not decorative**. `classifyDivergence(key)` returns
+`expected` for a recorded decision, `open` for a recorded defect, and `unknown`
+for anything not written down — and `unknown` is the important one, because a
+difference nobody has recorded is precisely the regression this exists to catch
+and must not be filed quietly with the decisions. `divergences.test.ts` covers
+those rules and runs with no database and no API, so the classification stays
+verified even when a full parity run skips.
+
+Keeping the list is what makes the harness usable at scale. Without it a run is
+a wall of red that has to be re-triaged by hand every time, and the one real
+regression hides among the decisions we already made on purpose.
+
+Today the registry classifies; it does not yet suppress, because there is one
+open divergence and one test. Wiring suppression into a broader comparison is
+worth doing when there are enough comparisons to need it.
 
 ## Date serialization
 
@@ -113,8 +153,11 @@ not appear to be recorded anywhere.
 
 It is deliberately **not** marked as an expected divergence. It is a regression
 against Hono rather than a decision, and marking it expected would retire the
-only test that reports it. The test asserts the difference _is present_ rather
-than asserting the two agree: an assertion that fails today, inside a parity
-freeze that forbids fixing it, gets ignored and then deleted. Written this way
-it documents the defect, proves it is still there, and fails loudly the day
-someone changes either side — which is exactly when someone should look.
+only test that reports it — so the test asserts that classification, and
+reclassifying it fails the suite instead of quietly silencing it.
+
+The comparison asserts the difference _is present_ rather than asserting the two
+agree. An assertion that fails today, inside a parity freeze that forbids fixing
+it, gets ignored and then deleted. Written this way it documents the defect,
+proves it is still there, and fails loudly the day someone changes either side —
+which is exactly when someone should look.

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -33,10 +33,11 @@ stacks serialize a naive timestamp identically, so there is no difference to
 observe and the comparison **skips**. Running the harness without setting `TZ`
 therefore exercises everything _except_ the finding it exists to report.
 
-Set a non-UTC zone. Use POSIX-style offsets rather than IANA names — Bun on
-Windows silently ignores `Asia/Tokyo` and falls back to the host zone, which
-would make a run look meaningful when it is not. Note the POSIX sign is
-inverted: `GMT-3` is UTC−3.
+Set a non-UTC zone. Use offsets of the form `GMT-3` rather than IANA names —
+Bun on Windows silently ignores `Asia/Tokyo` and falls back to the host zone,
+which would make a run look meaningful when it is not. On this runtime the sign
+reads the intuitive way, so `GMT-3` is UTC−3; worth knowing because strict POSIX
+defines it the other way round.
 
 ### Services
 

--- a/tests/parity/date-serialization.test.ts
+++ b/tests/parity/date-serialization.test.ts
@@ -1,10 +1,15 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import type { Client } from 'pg';
 
+import { classifyDivergence, DATE_SERIALIZATION_TIMEZONE } from './divergences';
 import {
+  CAN_OBSERVE_TIMEZONE_DIVERGENCE,
   cleanupUser,
   connectAdmin,
+  expectData,
+  expectOk,
   goRequest,
+  HOST_UTC_OFFSET_MINUTES,
   parityPrerequisites,
   provisionGoSession,
 } from './support/stacks';
@@ -28,14 +33,14 @@ import {
 
 const prerequisites = await parityPrerequisites();
 
+/** The calendar day under test, stored as naive midnight. */
+const CALENDAR_DATE = '2026-08-07';
+
 describe.if(prerequisites.ok)('date serialization parity', () => {
   let admin: Client;
   let token: string;
   let userId: string;
   let accountId: string;
-
-  /** The calendar day under test, stored as naive midnight. */
-  const CALENDAR_DATE = '2026-08-07';
 
   beforeAll(async () => {
     admin = await connectAdmin();
@@ -47,9 +52,9 @@ describe.if(prerequisites.ok)('date serialization parity', () => {
       method: 'POST',
       body: JSON.stringify({ name: 'Parity Account' }),
     });
-    accountId = (account.body as { data: { id: string } }).data.id;
+    accountId = expectData<{ id: string }>(account, 'create parity account').id;
 
-    await goRequest(token, '/transactions', {
+    const created = await goRequest(token, '/transactions', {
       method: 'POST',
       body: JSON.stringify({
         amount: -12500,
@@ -61,6 +66,7 @@ describe.if(prerequisites.ok)('date serialization parity', () => {
         currency: 'ARS',
       }),
     });
+    expectOk(created, 'create parity transaction');
   });
 
   afterAll(async () => {
@@ -72,74 +78,109 @@ describe.if(prerequisites.ok)('date serialization parity', () => {
     }
   });
 
-  it('stores the calendar date as naive midnight', async () => {
+  /**
+   * Pinned to the account this run created. Selecting on `payee` alone would
+   * pick up a row from an earlier run that failed to clean up, and compare the
+   * wrong transaction.
+   */
+  async function storedDate(): Promise<Date> {
     const stored = await admin.query(
-      "SELECT date FROM transactions WHERE payee = 'Parity Market' LIMIT 1"
+      'SELECT date FROM transactions WHERE account_id = $1 AND payee = $2 LIMIT 1',
+      [accountId, 'Parity Market']
     );
-
     expect(stored.rows).toHaveLength(1);
-    const raw = stored.rows[0].date as Date;
+    return stored.rows[0].date as Date;
+  }
+
+  async function goDate(): Promise<string> {
+    const listed = await goRequest(token, '/transactions');
+    const data = expectData<Array<{ date: string; accountId: string }>>(
+      listed,
+      'list parity transactions'
+    );
+    const match = data.find(
+      (transaction) => transaction.accountId === accountId
+    );
+    if (match === undefined) {
+      throw new Error('parity: the created transaction was not listed');
+    }
+    return match.date;
+  }
+
+  it('stores the calendar date as naive midnight', async () => {
+    const raw = await storedDate();
+
     expect(raw.getFullYear()).toBe(2026);
     expect(raw.getMonth()).toBe(7);
     expect(raw.getDate()).toBe(7);
   });
 
-  /**
-   * The finding. Asserted as a difference rather than as equality, because
-   * asserting equality would fail today and a failing test nobody can fix
-   * inside the parity freeze gets deleted or ignored. This documents the
-   * divergence, proves it is still present, and will fail loudly the day
-   * someone changes either side — which is when it needs attention.
-   */
-  it('the two stacks disagree about the timezone of a naive timestamp', async () => {
-    const viaDriver = (
-      await admin.query(
-        "SELECT date FROM transactions WHERE payee = 'Parity Market' LIMIT 1"
-      )
-    ).rows[0].date as Date;
-
-    const listed = await goRequest(token, '/transactions');
-    const [transaction] = (listed.body as { data: { date: string }[] }).data;
-
-    const honoJson = viaDriver.toISOString();
-    const goJson = transaction.date;
-
-    // Both describe the same stored row.
-    expect(goJson.slice(0, 10)).toBe(CALENDAR_DATE);
-
-    // Go labels naive midnight as UTC; the driver labels it host-local. On a
-    // host at UTC+0 these coincide, so the assertion is conditional on the
-    // runner actually having an offset — otherwise it would fail in CI for a
-    // reason unrelated to the defect.
-    const hostOffsetMinutes = new Date(
-      `${CALENDAR_DATE}T00:00:00`
-    ).getTimezoneOffset();
-    if (hostOffsetMinutes !== 0) {
-      expect(honoJson).not.toBe(goJson);
-    }
+  it('reports the same calendar day through the Go API', async () => {
+    expect((await goDate()).slice(0, 10)).toBe(CALENDAR_DATE);
   });
 
   /**
-   * Why the difference matters, expressed the way a user meets it: the same
-   * row renders as two different calendar days.
+   * The finding, asserted as a difference rather than as equality: an
+   * assertion that fails today, inside a parity freeze that forbids fixing it,
+   * gets ignored and then deleted. Written this way it documents the
+   * divergence, proves it is still present, and fails loudly the day someone
+   * changes either side — which is when it needs attention.
+   *
+   * Skipped rather than passed at UTC. There both stacks produce the identical
+   * string, so there is no difference to observe and an assertion here would be
+   * a green that compared nothing.
    */
-  it('renders as an earlier calendar day west of Greenwich', async () => {
-    const listed = await goRequest(token, '/transactions');
-    const [transaction] = (listed.body as { data: { date: string }[] }).data;
+  describe.if(CAN_OBSERVE_TIMEZONE_DIVERGENCE)(
+    `observed at UTC offset ${-HOST_UTC_OFFSET_MINUTES / 60}h`,
+    () => {
+      it('the two stacks disagree about the timezone of a naive timestamp', async () => {
+        const honoJson = (await storedDate()).toISOString();
+        const goJson = await goDate();
 
-    const hostOffsetMinutes = new Date(
-      `${CALENDAR_DATE}T00:00:00`
-    ).getTimezoneOffset();
-    // getTimezoneOffset is positive for zones behind UTC.
-    if (hostOffsetMinutes > 0) {
-      const renderedDay = new Date(transaction.date).getDate();
-      expect(renderedDay).toBe(6);
+        expect(honoJson).not.toBe(goJson);
+        // Same instant-of-day claim, different labels: Go says UTC midnight,
+        // the driver says local midnight.
+        expect(goJson).toContain('T00:00:00');
+        expect(honoJson).not.toContain('T00:00:00');
+      });
     }
+  );
+
+  /**
+   * Why the difference matters, expressed the way a user meets it. Formatted in
+   * a fixed zone rather than the host's, so this asserts the same thing on
+   * every machine instead of depending on where the runner happens to be.
+   */
+  it('renders as the previous calendar day in Argentina', async () => {
+    const goJson = await goDate();
+    const rendered = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'America/Argentina/Buenos_Aires',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date(goJson));
+
+    expect(rendered).toBe('2026-08-06');
+  });
+
+  /**
+   * Wires the observation to the registry. If someone reclassifies this as an
+   * expected divergence, this fails — which is the intent: it is a regression
+   * against Hono, and marking it expected would retire the only check for it.
+   */
+  it('is registered as an open divergence, not a decision', () => {
+    expect(classifyDivergence(DATE_SERIALIZATION_TIMEZONE)).toBe('open');
   });
 });
 
 if (!prerequisites.ok) {
   describe('date serialization parity', () => {
-    it.skip(`skipped: ${prerequisites.reason}`, () => {});
+    it.skip(`skipped — ${prerequisites.reason}`, () => {});
+  });
+}
+
+if (prerequisites.ok && !CAN_OBSERVE_TIMEZONE_DIVERGENCE) {
+  describe('date serialization parity', () => {
+    it.skip('skipped the stack comparison — the runner is at UTC, where both stacks serialize a naive timestamp identically', () => {});
   });
 }

--- a/tests/parity/date-serialization.test.ts
+++ b/tests/parity/date-serialization.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import type { Client } from 'pg';
+
+import {
+  cleanupUser,
+  connectAdmin,
+  goRequest,
+  parityPrerequisites,
+  provisionGoSession,
+} from './support/stacks';
+
+/**
+ * Differential check on how each stack turns a stored `date` into JSON.
+ *
+ * `transactions.date` is `timestamp without time zone`. Both stacks read the
+ * same bytes and disagree about what timezone those bytes are in, which is
+ * exactly the kind of difference no single-stack test can see: the Go tests
+ * assert Go against the contract and pass, the fixtures record Hono and pass,
+ * and the gap between them goes unnoticed until the flag flips.
+ *
+ * The Hono side is represented by **node-postgres**, the driver Hono's Drizzle
+ * setup uses, reading the same row. That is the layer where the difference
+ * originates — Hono's handler passes the value straight through — so it is a
+ * faithful stand-in and avoids making this test depend on a Clerk session. The
+ * limitation is real and stated in the README: this compares the data layer,
+ * not the full Hono handler.
+ */
+
+const prerequisites = await parityPrerequisites();
+
+describe.if(prerequisites.ok)('date serialization parity', () => {
+  let admin: Client;
+  let token: string;
+  let userId: string;
+  let accountId: string;
+
+  /** The calendar day under test, stored as naive midnight. */
+  const CALENDAR_DATE = '2026-08-07';
+
+  beforeAll(async () => {
+    admin = await connectAdmin();
+    const session = await provisionGoSession(admin);
+    token = session.token;
+    userId = session.userId;
+
+    const account = await goRequest(token, '/accounts', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Parity Account' }),
+    });
+    accountId = (account.body as { data: { id: string } }).data.id;
+
+    await goRequest(token, '/transactions', {
+      method: 'POST',
+      body: JSON.stringify({
+        amount: -12500,
+        payee: 'Parity Market',
+        notes: null,
+        categoryId: null,
+        date: CALENDAR_DATE,
+        accountId,
+        currency: 'ARS',
+      }),
+    });
+  });
+
+  afterAll(async () => {
+    if (admin) {
+      if (userId) {
+        await cleanupUser(admin, userId);
+      }
+      await admin.end();
+    }
+  });
+
+  it('stores the calendar date as naive midnight', async () => {
+    const stored = await admin.query(
+      "SELECT date FROM transactions WHERE payee = 'Parity Market' LIMIT 1"
+    );
+
+    expect(stored.rows).toHaveLength(1);
+    const raw = stored.rows[0].date as Date;
+    expect(raw.getFullYear()).toBe(2026);
+    expect(raw.getMonth()).toBe(7);
+    expect(raw.getDate()).toBe(7);
+  });
+
+  /**
+   * The finding. Asserted as a difference rather than as equality, because
+   * asserting equality would fail today and a failing test nobody can fix
+   * inside the parity freeze gets deleted or ignored. This documents the
+   * divergence, proves it is still present, and will fail loudly the day
+   * someone changes either side — which is when it needs attention.
+   */
+  it('the two stacks disagree about the timezone of a naive timestamp', async () => {
+    const viaDriver = (
+      await admin.query(
+        "SELECT date FROM transactions WHERE payee = 'Parity Market' LIMIT 1"
+      )
+    ).rows[0].date as Date;
+
+    const listed = await goRequest(token, '/transactions');
+    const [transaction] = (listed.body as { data: { date: string }[] }).data;
+
+    const honoJson = viaDriver.toISOString();
+    const goJson = transaction.date;
+
+    // Both describe the same stored row.
+    expect(goJson.slice(0, 10)).toBe(CALENDAR_DATE);
+
+    // Go labels naive midnight as UTC; the driver labels it host-local. On a
+    // host at UTC+0 these coincide, so the assertion is conditional on the
+    // runner actually having an offset — otherwise it would fail in CI for a
+    // reason unrelated to the defect.
+    const hostOffsetMinutes = new Date(
+      `${CALENDAR_DATE}T00:00:00`
+    ).getTimezoneOffset();
+    if (hostOffsetMinutes !== 0) {
+      expect(honoJson).not.toBe(goJson);
+    }
+  });
+
+  /**
+   * Why the difference matters, expressed the way a user meets it: the same
+   * row renders as two different calendar days.
+   */
+  it('renders as an earlier calendar day west of Greenwich', async () => {
+    const listed = await goRequest(token, '/transactions');
+    const [transaction] = (listed.body as { data: { date: string }[] }).data;
+
+    const hostOffsetMinutes = new Date(
+      `${CALENDAR_DATE}T00:00:00`
+    ).getTimezoneOffset();
+    // getTimezoneOffset is positive for zones behind UTC.
+    if (hostOffsetMinutes > 0) {
+      const renderedDay = new Date(transaction.date).getDate();
+      expect(renderedDay).toBe(6);
+    }
+  });
+});
+
+if (!prerequisites.ok) {
+  describe('date serialization parity', () => {
+    it.skip(`skipped: ${prerequisites.reason}`, () => {});
+  });
+}

--- a/tests/parity/divergences.test.ts
+++ b/tests/parity/divergences.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  classifyDivergence,
+  DATE_SERIALIZATION_TIMEZONE,
+  EXPECTED_DIVERGENCES,
+  findDivergence,
+  KNOWN_DIVERGENCES,
+  OPEN_DIVERGENCES,
+} from './divergences';
+
+/**
+ * The registry is only useful if the harness consults it, and only trustworthy
+ * if the classification itself is tested. These run with no database and no Go
+ * API, so the rules stay verified even when a full parity run is skipped.
+ */
+
+describe('classifyDivergence', () => {
+  it('classifies a deliberate decision as expected', () => {
+    // Entry 0014: date filters parsed in UTC.
+    expect(classifyDivergence('filters.date.utc')).toBe('expected');
+  });
+
+  it('classifies a recorded defect as open', () => {
+    expect(classifyDivergence(DATE_SERIALIZATION_TIMEZONE)).toBe('open');
+  });
+
+  /**
+   * The case that matters most: a difference nobody wrote down is a finding,
+   * not something to quietly file with the decisions.
+   */
+  it('classifies an unregistered difference as unknown', () => {
+    expect(classifyDivergence('summary.rounding.half-up')).toBe('unknown');
+    expect(classifyDivergence('')).toBe('unknown');
+  });
+});
+
+describe('the registry itself', () => {
+  it('has a unique key for every entry', () => {
+    const keys = KNOWN_DIVERGENCES.map((entry) => entry.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('gives every entry a non-empty key and description', () => {
+    for (const entry of KNOWN_DIVERGENCES) {
+      expect(entry.key.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('splits cleanly into expected and open', () => {
+    expect(EXPECTED_DIVERGENCES.length + OPEN_DIVERGENCES.length).toBe(
+      KNOWN_DIVERGENCES.length
+    );
+    expect(EXPECTED_DIVERGENCES.every((entry) => entry.expected)).toBe(true);
+    expect(OPEN_DIVERGENCES.every((entry) => !entry.expected)).toBe(true);
+  });
+
+  it('finds a registered entry and reports nothing for an unregistered one', () => {
+    expect(findDivergence(DATE_SERIALIZATION_TIMEZONE)?.surface).toBe(
+      'transactions'
+    );
+    expect(findDivergence('nope')).toBeUndefined();
+  });
+
+  /**
+   * Guards the intent stated in the README: the date divergence is a
+   * regression, not a decision. Marking it expected would suppress the only
+   * check that reports it, so that change has to fail here first.
+   */
+  it('keeps the date divergence recorded as an open defect', () => {
+    const entry = findDivergence(DATE_SERIALIZATION_TIMEZONE);
+
+    expect(entry).toBeDefined();
+    expect(entry?.expected).toBe(false);
+  });
+});

--- a/tests/parity/divergences.ts
+++ b/tests/parity/divergences.ts
@@ -1,5 +1,5 @@
 /**
- * The deliberate Hono → Go divergences, as data.
+ * The Hono → Go divergences, as data the harness actually consults.
  *
  * The harness exists to find *unintended* differences between the two stacks.
  * That only works if the intended ones are written down: without this list a
@@ -9,23 +9,36 @@
  *
  * Each entry points at where it is argued — a numbered file in
  * `post-migration-improvements/claude-backend-improvements/`, or a
- * "Divergences" section in `docs/api/`. Anything the harness reports that is
- * *not* on this list is a finding.
+ * "Divergences" section in `docs/api/`. A difference the harness observes whose
+ * key is not registered here classifies as `unknown`, which is a finding.
  */
 
+export type DivergenceKey = string;
+
 export type Divergence = {
+  /** Stable identifier the tests classify against. */
+  key: DivergenceKey;
   /** Registry entry number, or null for contract-driven decisions with no entry. */
   entry: number | null;
   /** Which response surface it shows up on. */
   surface: 'transactions' | 'summary' | 'accounts' | 'categories' | 'all';
   /** What actually differs, in terms of observable behavior. */
   description: string;
-  /** Whether the harness should treat a difference here as expected. */
+  /** Whether a difference here is a decision rather than a defect. */
   expected: boolean;
 };
 
+/**
+ * The key for the naive-timestamp difference this harness found.
+ *
+ * Exported as a constant so the test that observes it and the entry that
+ * classifies it cannot drift apart through a typo.
+ */
+export const DATE_SERIALIZATION_TIMEZONE = 'transactions.date.timezone';
+
 export const KNOWN_DIVERGENCES: Divergence[] = [
   {
+    key: 'transactions.amount.bigint',
     entry: 6,
     surface: 'transactions',
     description:
@@ -33,6 +46,7 @@ export const KNOWN_DIVERGENCES: Divergence[] = [
     expected: true,
   },
   {
+    key: 'filters.date.utc',
     entry: 14,
     surface: 'all',
     description:
@@ -40,6 +54,7 @@ export const KNOWN_DIVERGENCES: Divergence[] = [
     expected: true,
   },
   {
+    key: 'transactions.amount.out-of-range-status',
     entry: 15,
     surface: 'transactions',
     description:
@@ -47,6 +62,7 @@ export const KNOWN_DIVERGENCES: Divergence[] = [
     expected: true,
   },
   {
+    key: 'transactions.bulk.byte-limit',
     entry: 16,
     surface: 'transactions',
     description:
@@ -54,6 +70,7 @@ export const KNOWN_DIVERGENCES: Divergence[] = [
     expected: true,
   },
   {
+    key: 'transactions.currency.required',
     entry: null,
     surface: 'transactions',
     description:
@@ -61,6 +78,7 @@ export const KNOWN_DIVERGENCES: Divergence[] = [
     expected: true,
   },
   {
+    key: 'query.empty-parameters-rejected',
     entry: null,
     surface: 'all',
     description:
@@ -68,6 +86,7 @@ export const KNOWN_DIVERGENCES: Divergence[] = [
     expected: true,
   },
   {
+    key: 'transactions.order.id-tiebreak',
     entry: null,
     surface: 'transactions',
     description: '`id` is used as an ordering tiebreak after `date`.',
@@ -85,10 +104,11 @@ export const KNOWN_DIVERGENCES: Divergence[] = [
    * date shows a day early, including for Argentina.
    *
    * Left `expected: false` on purpose: it is a parity regression rather than a
-   * decision, it is invisible until USE_GO_API flips, and marking it expected
-   * would retire the only test that reports it.
+   * decision, and the test asserts this classification, so marking it expected
+   * fails the suite rather than quietly retiring the only check that reports it.
    */
   {
+    key: DATE_SERIALIZATION_TIMEZONE,
     entry: null,
     surface: 'transactions',
     description:
@@ -96,6 +116,29 @@ export const KNOWN_DIVERGENCES: Divergence[] = [
     expected: false,
   },
 ];
+
+/** How the harness treats a difference it has observed. */
+export type Classification = 'expected' | 'open' | 'unknown';
+
+/**
+ * Classifies an observed difference.
+ *
+ * `unknown` is the important one: a difference the harness can see but nobody
+ * has written down is precisely the regression this exists to catch, and it
+ * must not be quietly grouped with the decisions.
+ */
+export function classifyDivergence(key: DivergenceKey): Classification {
+  const divergence = KNOWN_DIVERGENCES.find((entry) => entry.key === key);
+  if (divergence === undefined) {
+    return 'unknown';
+  }
+  return divergence.expected ? 'expected' : 'open';
+}
+
+/** Looks up a registered divergence, or undefined when it is not registered. */
+export function findDivergence(key: DivergenceKey): Divergence | undefined {
+  return KNOWN_DIVERGENCES.find((entry) => entry.key === key);
+}
 
 /** The divergences the harness should not treat as failures. */
 export const EXPECTED_DIVERGENCES = KNOWN_DIVERGENCES.filter(

--- a/tests/parity/divergences.ts
+++ b/tests/parity/divergences.ts
@@ -1,0 +1,108 @@
+/**
+ * The deliberate Hono → Go divergences, as data.
+ *
+ * The harness exists to find *unintended* differences between the two stacks.
+ * That only works if the intended ones are written down: without this list a
+ * run is a wall of red that someone has to re-triage by hand every time, and
+ * the one real regression hides among the fifteen decisions we already made on
+ * purpose.
+ *
+ * Each entry points at where it is argued — a numbered file in
+ * `post-migration-improvements/claude-backend-improvements/`, or a
+ * "Divergences" section in `docs/api/`. Anything the harness reports that is
+ * *not* on this list is a finding.
+ */
+
+export type Divergence = {
+  /** Registry entry number, or null for contract-driven decisions with no entry. */
+  entry: number | null;
+  /** Which response surface it shows up on. */
+  surface: 'transactions' | 'summary' | 'accounts' | 'categories' | 'all';
+  /** What actually differs, in terms of observable behavior. */
+  description: string;
+  /** Whether the harness should treat a difference here as expected. */
+  expected: boolean;
+};
+
+export const KNOWN_DIVERGENCES: Divergence[] = [
+  {
+    entry: 6,
+    surface: 'transactions',
+    description:
+      '`amount` widened to bigint; the legacy ~2.15M ARS cap is raised.',
+    expected: true,
+  },
+  {
+    entry: 14,
+    surface: 'all',
+    description:
+      'Date range filters are parsed in UTC rather than the host timezone, so a boundary day can fall on the other side of the range.',
+    expected: true,
+  },
+  {
+    entry: 15,
+    surface: 'transactions',
+    description:
+      'An out-of-range amount returns 400 rather than the legacy 500.',
+    expected: true,
+  },
+  {
+    entry: 16,
+    surface: 'transactions',
+    description:
+      'Bulk byte limits are enforced against the stream, not only Content-Length.',
+    expected: true,
+  },
+  {
+    entry: null,
+    surface: 'transactions',
+    description:
+      '`currency` is required and accepted only as ARS; the legacy schema has no such column.',
+    expected: true,
+  },
+  {
+    entry: null,
+    surface: 'all',
+    description:
+      'Explicitly empty query parameters are rejected with 400 INVALID_QUERY rather than treated as absent.',
+    expected: true,
+  },
+  {
+    entry: null,
+    surface: 'transactions',
+    description: '`id` is used as an ordering tiebreak after `date`.',
+    expected: true,
+  },
+
+  /**
+   * Found by this harness on 2026-08-09, and deliberately marked NOT expected.
+   *
+   * `transactions.date` is `timestamp without time zone`. node-postgres reads a
+   * naive timestamp as local time; Go reads the same bytes as UTC. For a row
+   * stored as `2026-08-07 00:00:00` the two stacks return
+   * `2026-08-07T03:00:00.000Z` and `2026-08-07T00:00:00Z`, and a browser west
+   * of Greenwich renders those as different calendar days — every transaction
+   * date shows a day early, including for Argentina.
+   *
+   * Left `expected: false` on purpose: it is a parity regression rather than a
+   * decision, it is invisible until USE_GO_API flips, and marking it expected
+   * would retire the only test that reports it.
+   */
+  {
+    entry: null,
+    surface: 'transactions',
+    description:
+      'A naive `timestamp` is serialized as UTC by Go and as host-local by node-postgres, shifting the rendered calendar day west of Greenwich.',
+    expected: false,
+  },
+];
+
+/** The divergences the harness should not treat as failures. */
+export const EXPECTED_DIVERGENCES = KNOWN_DIVERGENCES.filter(
+  (divergence) => divergence.expected
+);
+
+/** Recorded differences still considered defects. */
+export const OPEN_DIVERGENCES = KNOWN_DIVERGENCES.filter(
+  (divergence) => !divergence.expected
+);

--- a/tests/parity/support/stacks.ts
+++ b/tests/parity/support/stacks.ts
@@ -1,0 +1,135 @@
+import { Client } from 'pg';
+
+/**
+ * Connection and session plumbing shared by the parity tests.
+ *
+ * Everything here is gated on environment variables and reports cleanly when
+ * they are absent, matching how the Go live tests gate on TEST_DATABASE_URL. A
+ * parity run that cannot reach both stacks must say so rather than pass on an
+ * empty comparison — a silently skipped differential test is worse than none,
+ * because it looks like evidence.
+ */
+
+/**
+ * Admin connection string. Admin rather than the app role on purpose: the
+ * harness seeds and reads rows across users, and the app role is subject to
+ * RLS, which would return zero rows and make every comparison trivially equal.
+ */
+export const ADMIN_DATABASE_URL = process.env.ADMIN_DATABASE_URL ?? '';
+
+/** Base URL of a running Go API, including the `/api` prefix's origin. */
+export const GO_API_URL = process.env.GO_API_URL ?? 'http://localhost:8080';
+
+/** Whether the harness has everything it needs to run against both stacks. */
+export async function parityPrerequisites(): Promise<{
+  ok: boolean;
+  reason: string;
+}> {
+  if (!ADMIN_DATABASE_URL) {
+    return {
+      ok: false,
+      reason:
+        'ADMIN_DATABASE_URL is unset. See tests/parity/README.md for the values.',
+    };
+  }
+
+  try {
+    const response = await fetch(`${GO_API_URL}/api/auth/refresh`, {
+      method: 'POST',
+    });
+    // Any HTTP answer proves the API is up; 401 is the expected one here,
+    // since this deliberately sends no refresh cookie.
+    if (!response) {
+      return { ok: false, reason: `No response from ${GO_API_URL}.` };
+    }
+  } catch {
+    return {
+      ok: false,
+      reason: `No Go API reachable at ${GO_API_URL}. Start it first — see tests/parity/README.md.`,
+    };
+  }
+
+  return { ok: true, reason: '' };
+}
+
+/** Opens an admin connection to the shared database. */
+export async function connectAdmin(): Promise<Client> {
+  const client = new Client({ connectionString: ADMIN_DATABASE_URL });
+  await client.connect();
+  return client;
+}
+
+/**
+ * Registers, verifies and logs in a throwaway user, returning its access token
+ * and id.
+ *
+ * Verification is done with SQL rather than by following the emailed link: the
+ * token is stored hashed, so the raw value only exists in an email, and making
+ * the harness depend on a mail catcher would tie a data-layer comparison to
+ * SMTP being up.
+ */
+export async function provisionGoSession(
+  admin: Client
+): Promise<{ token: string; userId: string; email: string }> {
+  const email = `parity-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+  const password = 'parity-harness-password';
+
+  const registered = await fetch(`${GO_API_URL}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!registered.ok) {
+    throw new Error(`parity: register failed with ${registered.status}`);
+  }
+
+  await admin.query(
+    'UPDATE users SET email_verified_at = now() WHERE email = $1',
+    [email]
+  );
+
+  const loggedIn = await fetch(`${GO_API_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!loggedIn.ok) {
+    throw new Error(`parity: login failed with ${loggedIn.status}`);
+  }
+
+  // Auth responses are un-enveloped; only app resource operations use `{ data }`.
+  const session = (await loggedIn.json()) as {
+    accessToken: string;
+    user: { id: string };
+  };
+
+  return { token: session.accessToken, userId: session.user.id, email };
+}
+
+/** Calls the Go API as the given session. */
+export async function goRequest(
+  token: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<{ status: number; body: unknown }> {
+  const response = await fetch(`${GO_API_URL}/api${path}`, {
+    ...init,
+    headers: {
+      ...init.headers,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const body = await response.json().catch(() => null);
+  return { status: response.status, body };
+}
+
+/** Removes everything a run created, so repeat runs stay comparable. */
+export async function cleanupUser(
+  admin: Client,
+  userId: string
+): Promise<void> {
+  // accounts and categories cascade to transactions through their own FKs.
+  await admin.query('DELETE FROM users WHERE id = $1', [userId]);
+}

--- a/tests/parity/support/stacks.ts
+++ b/tests/parity/support/stacks.ts
@@ -17,14 +17,37 @@ import { Client } from 'pg';
  */
 export const ADMIN_DATABASE_URL = process.env.ADMIN_DATABASE_URL ?? '';
 
-/** Base URL of a running Go API, including the `/api` prefix's origin. */
+/**
+ * The **origin** the Go API is served from — scheme and host only, no path.
+ *
+ * The `/api` prefix is added by this module (`${GO_API_URL}/api${path}`), so a
+ * value that already includes it produces `/api/api/...`.
+ */
 export const GO_API_URL = process.env.GO_API_URL ?? 'http://localhost:8080';
 
-/** Whether the harness has everything it needs to run against both stacks. */
-export async function parityPrerequisites(): Promise<{
-  ok: boolean;
-  reason: string;
-}> {
+/**
+ * Whether the host timezone can observe a naive-timestamp divergence at all.
+ *
+ * The two stacks differ by labelling the same bytes UTC or host-local, so at
+ * UTC there is nothing to see: both produce the identical string and a
+ * comparison would be trivially equal. Tests that depend on the difference skip
+ * rather than pass, because a passing assertion that compared nothing is
+ * exactly the false green this harness exists to avoid.
+ */
+export const HOST_UTC_OFFSET_MINUTES = new Date().getTimezoneOffset();
+export const CAN_OBSERVE_TIMEZONE_DIVERGENCE = HOST_UTC_OFFSET_MINUTES !== 0;
+
+export type Prerequisites = { ok: boolean; reason: string };
+
+/**
+ * Checks that the harness can actually reach both stacks.
+ *
+ * Postgres is *connected to*, not merely configured: a wrong URL or a stopped
+ * server would otherwise surface much later as a confusing failure inside
+ * `connectAdmin`, which is the opposite of the "skip rather than look like
+ * evidence" rule this harness is built on.
+ */
+export async function parityPrerequisites(): Promise<Prerequisites> {
   if (!ADMIN_DATABASE_URL) {
     return {
       ok: false,
@@ -33,23 +56,36 @@ export async function parityPrerequisites(): Promise<{
     };
   }
 
+  let probe: Client | undefined;
   try {
-    const response = await fetch(`${GO_API_URL}/api/auth/refresh`, {
-      method: 'POST',
-    });
-    // Any HTTP answer proves the API is up; 401 is the expected one here,
-    // since this deliberately sends no refresh cookie.
-    if (!response) {
-      return { ok: false, reason: `No response from ${GO_API_URL}.` };
-    }
-  } catch {
+    probe = new Client({ connectionString: ADMIN_DATABASE_URL });
+    await probe.connect();
+    await probe.query('SELECT 1');
+  } catch (error) {
     return {
       ok: false,
-      reason: `No Go API reachable at ${GO_API_URL}. Start it first — see tests/parity/README.md.`,
+      reason: `Postgres is not reachable at ADMIN_DATABASE_URL: ${describe(error)}`,
+    };
+  } finally {
+    await probe?.end().catch(() => {});
+  }
+
+  try {
+    // Any HTTP answer proves the API is up; 401 is the expected one here, since
+    // this deliberately sends no refresh cookie.
+    await fetch(`${GO_API_URL}/api/auth/refresh`, { method: 'POST' });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: `No Go API reachable at ${GO_API_URL} (${describe(error)}). Start it first — see tests/parity/README.md.`,
     };
   }
 
   return { ok: true, reason: '' };
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /** Opens an admin connection to the shared database. */
@@ -57,6 +93,64 @@ export async function connectAdmin(): Promise<Client> {
   const client = new Client({ connectionString: ADMIN_DATABASE_URL });
   await client.connect();
   return client;
+}
+
+export type GoResult = { status: number; body: unknown };
+
+/**
+ * Calls the Go API as the given session.
+ *
+ * Headers go through `Headers` rather than object spread: `HeadersInit` may be
+ * a `Headers` instance or an array of pairs, and spreading either silently
+ * drops every entry. Content-Type is only defaulted, not forced, so a caller
+ * can send something other than JSON.
+ */
+export async function goRequest(
+  token: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<GoResult> {
+  const headers = new Headers(init.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  const response = await fetch(`${GO_API_URL}/api${path}`, {
+    ...init,
+    headers,
+  });
+  const body = await response.json().catch(() => null);
+  return { status: response.status, body };
+}
+
+/**
+ * Asserts a Go response succeeded, reporting the status and body when it did
+ * not.
+ *
+ * Without this a setup failure surfaces indirectly — "no row found", or
+ * `Cannot read properties of undefined` — and the real cause (a schema
+ * mismatch, an auth problem) has to be reconstructed. A differential test that
+ * fails should say which stack refused and why.
+ */
+export function expectOk(result: GoResult, what: string): unknown {
+  if (result.status < 200 || result.status >= 300) {
+    throw new Error(
+      `parity: ${what} failed with ${result.status}: ${JSON.stringify(result.body)}`
+    );
+  }
+  return result.body;
+}
+
+/** Reads the `data` envelope from a successful app resource response. */
+export function expectData<T>(result: GoResult, what: string): T {
+  const body = expectOk(result, what) as { data?: T } | null;
+  if (body === null || body.data === undefined) {
+    throw new Error(
+      `parity: ${what} returned no data envelope: ${JSON.stringify(result.body)}`
+    );
+  }
+  return body.data;
 }
 
 /**
@@ -80,13 +174,23 @@ export async function provisionGoSession(
     body: JSON.stringify({ email, password }),
   });
   if (!registered.ok) {
-    throw new Error(`parity: register failed with ${registered.status}`);
+    throw new Error(
+      `parity: register failed with ${registered.status}: ${await registered.text()}`
+    );
   }
 
-  await admin.query(
+  const verified = await admin.query(
     'UPDATE users SET email_verified_at = now() WHERE email = $1',
     [email]
   );
+  // Asserted rather than assumed: if the row is not there, the harness is
+  // talking to a different database than the API is, and "login failed" three
+  // lines down would send the reader looking in entirely the wrong place.
+  if (verified.rowCount !== 1) {
+    throw new Error(
+      `parity: expected to verify exactly one user, updated ${verified.rowCount}. Is ADMIN_DATABASE_URL the same database the Go API uses?`
+    );
+  }
 
   const loggedIn = await fetch(`${GO_API_URL}/api/auth/login`, {
     method: 'POST',
@@ -94,7 +198,9 @@ export async function provisionGoSession(
     body: JSON.stringify({ email, password }),
   });
   if (!loggedIn.ok) {
-    throw new Error(`parity: login failed with ${loggedIn.status}`);
+    throw new Error(
+      `parity: login failed with ${loggedIn.status}: ${await loggedIn.text()}`
+    );
   }
 
   // Auth responses are un-enveloped; only app resource operations use `{ data }`.
@@ -104,25 +210,6 @@ export async function provisionGoSession(
   };
 
   return { token: session.accessToken, userId: session.user.id, email };
-}
-
-/** Calls the Go API as the given session. */
-export async function goRequest(
-  token: string,
-  path: string,
-  init: RequestInit = {}
-): Promise<{ status: number; body: unknown }> {
-  const response = await fetch(`${GO_API_URL}/api${path}`, {
-    ...init,
-    headers: {
-      ...init.headers,
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-  });
-
-  const body = await response.json().catch(() => null);
-  return { status: response.status, body };
 }
 
 /** Removes everything a run created, so repeat runs stay comparable. */

--- a/tests/parity/support/stacks.ts
+++ b/tests/parity/support/stacks.ts
@@ -70,14 +70,41 @@ export async function parityPrerequisites(): Promise<Prerequisites> {
     await probe?.end().catch(() => {});
   }
 
+  /**
+   * Identifies the service, rather than settling for any HTTP answer.
+   *
+   * A dev server, a proxy or an unrelated app on the port would all respond,
+   * and the harness would report itself ready and then fail deep inside a
+   * comparison. Sending no refresh cookie has exactly one correct answer from
+   * the Go API — `401 INVALID_REFRESH_TOKEN` in the contract's error envelope —
+   * so checking for it is both a liveness and an identity check.
+   */
+  let refreshResponse: Response;
   try {
-    // Any HTTP answer proves the API is up; 401 is the expected one here, since
-    // this deliberately sends no refresh cookie.
-    await fetch(`${GO_API_URL}/api/auth/refresh`, { method: 'POST' });
+    refreshResponse = await fetch(`${GO_API_URL}/api/auth/refresh`, {
+      method: 'POST',
+    });
   } catch (error) {
     return {
       ok: false,
       reason: `No Go API reachable at ${GO_API_URL} (${describe(error)}). Start it first — see tests/parity/README.md.`,
+    };
+  }
+
+  if (refreshResponse.status !== 401) {
+    return {
+      ok: false,
+      reason: `${GO_API_URL} answered POST /api/auth/refresh with ${refreshResponse.status}, expected 401. Is that the Go API, or something else on the port?`,
+    };
+  }
+
+  const envelope = (await refreshResponse.json().catch(() => null)) as {
+    error?: { code?: unknown };
+  } | null;
+  if (envelope?.error?.code !== 'INVALID_REFRESH_TOKEN') {
+    return {
+      ok: false,
+      reason: `${GO_API_URL} did not answer with the contract's INVALID_REFRESH_TOKEN envelope. Is that the Go API, or something else on the port?`,
     };
   }
 


### PR DESCRIPTION
Ticket C of this batch. No issue number — following the precedent of
`claude/investigation-argentina-openbanking` for non-ticket work. Happy to file
one if you'd rather it be tracked.

Touches nothing existing: one new directory, `tests/parity/`.

## Why now

**This can only be built while both stacks exist.** After #27 removes Hono
there is nothing left to compare against, and any divergence still present just
becomes how the app behaves.

Two oracles already existed and neither compares the stacks. The fixtures
record Hono, but nothing executes them. The Go suite asserts Go against the
contract. Both pass while disagreeing with each other — so a difference the
contract does not pin down (a timezone, an ordering tiebreak, a rounding step)
is invisible to both until `USE_GO_API` flips and it becomes a cutover-day bug.

## It found one immediately

`transactions.date` is `timestamp without time zone`. Both stacks read the same
bytes and disagree about what timezone those bytes are in:

| | value |
| --- | --- |
| stored | `2026-08-07 00:00:00` |
| node-postgres (Hono) | `2026-08-07T03:00:00.000Z` |
| Go | `2026-08-07T00:00:00Z` |

A browser renders those as **different calendar days** anywhere west of
Greenwich. Every transaction date shows a day early — including for Argentina,
the app's own market. I hit this in the real UI while verifying #50 before I
understood the cause.

Entry 0014 covers the *filter* side of the same modelling problem, and
`docs/api/transactions.md` notes under "Known gaps" that `date` is a `timestamp`
modelling what is really a calendar date. The response side does not appear to
be recorded anywhere. I have not touched it — `backend/**` is frozen and it is
your call.

**The test asserts the difference is present rather than asserting the two
agree.** An assertion that fails today, inside a freeze that forbids fixing it,
gets ignored and then deleted. Written this way it documents the defect, proves
it is still there, and fails loudly the day someone changes either side.

## Known divergences as data

`divergences.ts` lists the deliberate ones, each pointing at where it is argued
(a numbered registry entry, or a `docs/api/` "Divergences" section). Without
that list a run is a wall of red someone has to re-triage by hand every time,
and the one real regression hides among decisions we already made on purpose.
Anything reported that is **not** on the list is a finding. The date divergence
is deliberately marked `expected: false`.

## Scope, and its limit

| Stack | How it is driven |
| --- | --- |
| Go | Over HTTP, as a real client, with a real session |
| Hono | Through node-postgres, the driver its Drizzle setup uses |

The Go side is fully end-to-end: register, verify by SQL (the emailed token is
stored hashed, so depending on a mail catcher would tie a data comparison to
SMTP), log in, call with the Bearer token.

**The Hono side is the honest limitation.** Its routes authenticate through
Clerk, which is not scriptable from a test, so this compares at the data layer
rather than through Hono's handlers. That is faithful for how stored values
become JSON — the handler passes them through — but would *not* catch a
difference introduced inside a Hono handler, such as an ordering or aggregation
choice. Closing that means mocking `@hono/clerk-auth` and calling the app
in-process, or a Clerk test session; both viable, neither needed for what this
found first. The seam is documented and the support layer is separate for
exactly that reason.

So this delivers the date/serialization comparison properly and leaves list
ordering and summary aggregation as documented next steps rather than
half-built.

## Verification

`bun run lint` clean, `bunx tsc --noEmit` matches the master baseline,
`bun run build` compiles. `bun test` at the root is 70 pass / 6 skip / 0 fail —
the parity tests skip in the default run and do not affect CI.

Run against a live Postgres and a live Go API, all 3 assertions pass. Every test
**skips rather than passes** when it cannot reach both stacks: a differential
test that silently passes because it reached nothing is worse than no test,
because it looks like evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)