### PR TITLE
[Issue - #83] Gate CI on the test suite and typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,14 @@ jobs:
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' }}
       CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY || 'sk_test_ci_placeholder_not_a_real_key' }}
       DATABASE_URL: postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable
-      NEXT_PUBLIC_API_URL: http://localhost:3000
+      # NEXT_PUBLIC_API_URL is deliberately unset. It is read in exactly one
+      # place — resolveApiBaseUrl in lib/api-base-url.ts — and only on the
+      # server; the browser always uses a relative base so requests stay
+      # same-origin and are proxied to Go. Setting it to an absolute origin made
+      # `bun test` disagree with a developer machine, where it is normally
+      # absent: lib/api/client.test.ts asserts API_BASE_URL is relative, and
+      # under bun there is no `window`, so the server branch is what runs.
+      # Unset is also what a real deployment behind the proxy looks like.
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,4 +115,11 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bun run lint
+      # Until #83 this job ran only lint and build, so the frontend test suite
+      # gated nothing: the refresh-envelope defect fixed in #80 went through CI
+      # green because no job executed a test. Typecheck runs before the tests
+      # and the build because it is the cheapest of the three and localizes a
+      # whole class of failure that `next build` reports one file at a time.
+      - run: bunx tsc --noEmit
+      - run: bun test
       - run: bun run build

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/bun": "^1.3.14",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -517,6 +518,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
 
     "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
@@ -678,6 +681,8 @@
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,13 @@ const eslintConfig = defineConfig([
     'out/**',
     'build/**',
     'next-env.d.ts',
+    // Sibling git worktrees. The documented workflow checks them out inside the
+    // repo, so their build output and vendored code are visible from the root
+    // config — `.next/**` above only covers the root's own build. Without this,
+    // linting master reports tens of thousands of problems that belong to
+    // another branch and takes minutes.
+    '.worktrees/**',
+    '.claude/worktrees/**',
   ]),
   // Disable ESLint rules that conflict with Prettier
   eslintConfigPrettier,

--- a/features/transactions/api/transaction-date.timezone.test.ts
+++ b/features/transactions/api/transaction-date.timezone.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
-// `node:child_process` rather than `Bun.spawnSync`: the repo has `@types/node`
-// but not `@types/bun`, so the Bun global is untyped and would fail `tsc`.
+// `node:child_process` rather than `Bun.spawnSync`. `@types/bun` is present as
+// of #83, so the Bun global does typecheck now, but the Node API is the more
+// portable of the two and nothing here needs a Bun-specific capability.
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
@@ -9,17 +10,30 @@ import { fileURLToPath } from 'node:url';
  * different timezone.
  *
  * A process fixes its timezone at startup, so this spawns the probe under
- * several `TZ` values rather than trying to change it in-process. Offsets of
- * the form `GMT+9` are used instead of IANA names (`Asia/Tokyo`) because Bun on
- * Windows silently ignores IANA names and falls back to the host zone — which
- * would make these tests pass without testing anything.
+ * several `TZ` values rather than trying to change it in-process.
  *
- * On this runtime `GMT+9` resolves to UTC+9 and `GMT-3` to UTC-3, i.e. the sign
- * reads the intuitive way. That is worth stating because strict POSIX defines
- * it the other way round, where `GMT+9` would mean UTC-9. Each case asserts the
- * offset it actually observed before asserting anything else, so a runtime that
- * followed the POSIX reading would fail loudly here rather than quietly test a
- * zone nobody intended.
+ * **No single spelling of a zone works on both platforms**, which is why each
+ * zone carries a list of candidates rather than one string:
+ *
+ * - Bun on Windows resolves only the POSIX-ish `GMT±N` forms and `UTC`. IANA
+ *   names are silently ignored and the process keeps the *host* zone — so
+ *   `TZ=Asia/Tokyo` on a machine in Buenos Aires reports UTC−3, and a test that
+ *   trusted the name would prove nothing.
+ * - Bun on Linux is the mirror image: it reads the system tz database, so IANA
+ *   names work and a bare `GMT-3` resolves to nothing and falls back to the
+ *   host zone (UTC on a CI runner). This is not hypothetical — it is how these
+ *   tests first failed in CI while passing locally.
+ *
+ * So a candidate is *accepted only once the spawned process reports the offset
+ * the case is about*. That check was already here as a guard; it now also does
+ * the selecting, which means a silent fallback can never be mistaken for a
+ * working zone on either platform. If no candidate produces the offset, the
+ * suite fails with everything it tried rather than testing the host zone three
+ * times over.
+ *
+ * Note the two sign conventions in play: `GMT-3` is UTC−3 on this runtime,
+ * while the IANA `Etc/GMT+3` is *also* UTC−3, because the Etc zones invert the
+ * sign. They look contradictory and are both correct.
  */
 
 // `fileURLToPath` rather than `URL.pathname`: on Windows the latter yields a
@@ -54,20 +68,72 @@ function runIn(timezone: string): ProbeResult {
   return JSON.parse(result.stdout) as ProbeResult;
 }
 
+type Zone = {
+  label: string;
+  /** Spellings to try, most portable-per-platform first. */
+  candidates: string[];
+  /** `getTimezoneOffset()` the spawned process must report to be accepted. */
+  expectedOffset: number;
+};
+
 /** West of Greenwich (Argentina), east of it (Japan), and the meridian. */
-const zones: Array<[label: string, tz: string, expectedOffset: number]> = [
-  ['UTC-3, the app default market', 'GMT-3', 180],
-  ['UTC+9, east of Greenwich', 'GMT+9', -540],
-  ['UTC itself', 'UTC', 0],
+const zones: Zone[] = [
+  {
+    label: 'UTC-3, the app default market',
+    candidates: ['GMT-3', 'Etc/GMT+3', 'America/Argentina/Buenos_Aires'],
+    expectedOffset: 180,
+  },
+  {
+    label: 'UTC+9, east of Greenwich',
+    candidates: ['GMT+9', 'Etc/GMT-9', 'Asia/Tokyo'],
+    expectedOffset: -540,
+  },
+  { label: 'UTC itself', candidates: ['UTC'], expectedOffset: 0 },
 ];
 
+/**
+ * Runs the probe in the first candidate spelling that actually puts the process
+ * at the wanted offset.
+ *
+ * Memoized because the probe is a subprocess and the same zone is used by every
+ * assertion in its block plus the cross-zone comparison at the end; without it
+ * this file spawns the same processes nine times over.
+ */
+const resolved = new Map<string, ProbeResult>();
+
+function probeZone({ label, candidates, expectedOffset }: Zone): ProbeResult {
+  const cached = resolved.get(label);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const observed: string[] = [];
+  for (const timezone of candidates) {
+    const probe = runIn(timezone);
+    if (probe.offsetMinutes === expectedOffset) {
+      resolved.set(label, probe);
+      return probe;
+    }
+    observed.push(`${timezone} -> ${probe.offsetMinutes}`);
+  }
+
+  throw new Error(
+    `no TZ spelling put the process at offset ${expectedOffset} for "${label}". ` +
+      `Tried: ${observed.join(', ')}. Every candidate fell back to another ` +
+      `zone, so these tests would have run in the host zone instead.`
+  );
+}
+
 describe('transaction dates across timezones', () => {
-  for (const [label, timezone, expectedOffset] of zones) {
+  for (const zone of zones) {
+    const { label, expectedOffset } = zone;
     describe(label, () => {
-      const probe = runIn(timezone);
+      const probe = probeZone(zone);
 
       // Guards the whole suite: if TZ were ignored, every case would silently
-      // run in the host zone and prove nothing.
+      // run in the host zone and prove nothing. probeZone already enforces
+      // this while selecting; asserting it keeps the requirement visible in the
+      // test output rather than buried in a helper.
       it('really runs in that timezone', () => {
         expect(probe.offsetMinutes).toBe(expectedOffset);
       });
@@ -93,8 +159,9 @@ describe('transaction dates across timezones', () => {
    * elsewhere. The conversion above is the same in all three.
    */
   it('is stable where the previous instant-based reading was not', () => {
-    const naiveDays = zones.map(([, tz]) => runIn(tz).naiveDay);
-    const roundTrips = zones.map(([, tz]) => runIn(tz).roundTrip);
+    const probes = zones.map(probeZone);
+    const naiveDays = probes.map((probe) => probe.naiveDay);
+    const roundTrips = probes.map((probe) => probe.roundTrip);
 
     expect(naiveDays).toEqual([6, 7, 7]);
     expect(new Set(roundTrips).size).toBe(1);

--- a/lib/api/authenticated-fetch.ts
+++ b/lib/api/authenticated-fetch.ts
@@ -16,8 +16,21 @@ const REFRESH_PATH = '/api/auth/refresh';
 const EXPIRED_CODE = 'ACCESS_TOKEN_EXPIRED';
 const UNAUTHORIZED_CODE = 'UNAUTHORIZED';
 
+/**
+ * The callable surface of `fetch`, without the runtime statics that a type
+ * package may hang off `typeof globalThis.fetch` — Bun's types, pulled in for
+ * `bun:test`, declare a `fetch.preconnect`. Only the call signature is ever
+ * used here, and a plain function this module builds cannot supply statics, so
+ * annotating the result as `typeof globalThis.fetch` is both wrong and
+ * unsatisfiable.
+ */
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
 type Dependencies = {
-  fetch?: typeof globalThis.fetch;
+  fetch?: FetchLike;
   getToken?: () => string | null;
   setToken?: (token: string | null) => void;
   clearToken?: () => void;
@@ -63,7 +76,7 @@ export function createAuthenticatedFetch({
   setToken = setAccessToken,
   clearToken = clearAccessToken,
   baseUrl = '',
-}: Dependencies = {}): typeof globalThis.fetch {
+}: Dependencies = {}): FetchLike {
   let inFlightRefresh: Promise<boolean> | null = null;
 
   /**

--- a/lib/go-api-rewrite.test.ts
+++ b/lib/go-api-rewrite.test.ts
@@ -82,7 +82,7 @@ describe('goApiRewrites', () => {
     const rewrites = goApiRewrites({});
     if (Array.isArray(rewrites)) throw new Error('expected phased rewrites');
 
-    expect(rewrites.beforeFiles[0].destination).toBe(
+    expect(rewrites.beforeFiles?.[0]?.destination).toBe(
       `${DEFAULT_GO_API_URL}/api/:path*`
     );
   });
@@ -126,7 +126,7 @@ describe('goApiRewrites', () => {
     const rewrites = goApiRewrites({ USE_GO_API: 'true' });
     if (Array.isArray(rewrites)) throw new Error('expected phased rewrites');
 
-    expect(rewrites.beforeFiles[0].destination).toBe(
+    expect(rewrites.beforeFiles?.[0]?.destination).toBe(
       `${DEFAULT_GO_API_URL}/api/:path*`
     );
   });

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/bun": "^1.3.14",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
Closes #83.

## What this does

Adds `bunx tsc --noEmit` and `bun test` to the `frontend` job. Typecheck runs
first: it is the cheapest of the three checks and reports a whole class of
failure at once, rather than one file per `next build` attempt.

Ignores `.worktrees/**` and `.claude/worktrees/**` in `eslint.config.mjs`.

## The ticket's premise was wrong, and it mattered

The ticket predicted two pre-existing typecheck errors. On a clean worktree with
`bun install --frozen-lockfile` there are **18**:

```
16 x error TS2307: Cannot find module 'bun:test' or its corresponding type declarations.
 2 x error TS18048: 'rewrites.beforeFiles' is possibly 'undefined'.
```

`bun-types` is only an *optional* peer of drizzle-orm, so a frozen-lockfile
install — which is what CI does — does not have it, and every one of the 16 test
files fails to resolve its import. Any environment that happened to have
`bun-types` on disk would see the 2 errors the ticket describes, which is
presumably where that number came from.

### The chain that follows from fixing it

1. `@types/bun` is the fix for the 16. It is now a devDependency.
2. It brings `bun-types` into `node_modules`, and
   `drizzle-orm/sqlite-core/columns/blob.d.ts` carries an unconditional
   `/// <reference types="bun-types" />`. That reference resolves the moment the
   package exists, so **Bun's globals load across the whole program** — this is
   not something `types` or `typeRoots` in tsconfig can prevent; I tried both.
3. Bun's `globals.d.ts` declares `namespace fetch { preconnect }`, so
   `typeof globalThis.fetch` now carries a static that a plain function cannot
   supply. `lib/api/authenticated-fetch.ts` annotated its return that way, and
   this broke **`next build`** as well as the new typecheck.

So this could not be landed green without touching that file. It now declares
the call signature it actually implements:

```ts
type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
```

**Heads-up for the #86 lane:** `lib/api/**` is Codex's during #86, and this
edits `lib/api/authenticated-fetch.ts`. #86's scope is the mutation-error and
path-param helpers and their six call sites, so it should not touch this file —
but flagging it rather than letting it surprise anyone. The drizzle reference
disappears when #85 removes drizzle-orm; the explicit type is correct either
way, so nothing here needs reverting afterwards.

### The two predicted errors

`rewrites.beforeFiles` is optional on Next's phased-rewrites type. Narrowed with
optional chaining rather than a non-null assertion, so a missing entry still
fails the assertion instead of throwing. Kept minimal because #84 rewrites this
file.

## The eslint ignore is load-bearing

Measured at the repo root with sibling worktrees present:

| | problems | time |
|---|---|---|
| before | 32,964 (796 errors, 32,168 warnings) | minutes |
| after | 0 | 41s |

Every reported file was under `.worktrees/`; master's own code is clean.

## Verification

All four run locally, on this branch, fresh (no cache reuse):

| check | result |
|---|---|
| `bunx tsc --noEmit` | clean, exit 0 |
| `bun test` | 207 pass, 8 skip, 0 fail (215 across 22 files) |
| `bun run lint` | 0 problems |
| `bun run build` | compiled, 12/12 static pages |

The 8 skips are `tests/parity/**`, which skip without Postgres and a running Go
API. That matches what its README documents for a no-services run, and that
directory is retired in #90.

Acceptance also requires proving the gate *fails*. Verified on a scratch branch
— see the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
