### PR TITLE
[Issue - #102] Restore sessions and harden CSV imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,10 +69,14 @@ must be exported for `go run ./cmd/api`. Reference:
 
 These described the Hono implementation and were resolved by the Go migration —
 ownership predicates plus RLS, strict date and body validation, and rate
-limiting all live in the Go API now. Two frontend items remain:
+limiting all live in the Go API now. The remaining frontend items are now
+regression-protected too:
 
-- Harden CSV import validation, typing, and empty-state handling.
-- Avoid adding more coupling between header filters and summary loading.
+- CSV import rejects parser errors, empty/header-only files, blank internal
+  rows, and uneven records before column mapping; row values are strictly typed
+  and validated in `lib/transaction-import.ts`.
+- Header filters own URL/account state only. A regression test prevents them
+  from depending on summary query state.
 
 Known backend limitations are tracked as numbered entries in
 `post-migration-improvements/claude-backend-improvements/`, not here.

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2 } from 'lucide-react';
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/form';
 import { authErrorMessage } from '@/lib/auth/errors';
 import { useSession } from '@/lib/auth/session';
-import { safeRedirectTarget } from '@/lib/auth/redirect';
+import { restoredSessionRedirectTarget } from '@/lib/auth/redirect';
 
 const formSchema = z.object({
   email: z.string().email('Enter a valid email address.'),
@@ -37,8 +37,19 @@ type FormValues = z.infer<typeof formSchema>;
 const SignInForm = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { login } = useSession();
+  const { login, status } = useSession();
   const [formError, setFormError] = useState<string | null>(null);
+
+  const restoredTarget = restoredSessionRedirectTarget(
+    status,
+    searchParams.get('redirect')
+  );
+
+  useEffect(() => {
+    if (restoredTarget !== null) {
+      router.replace(restoredTarget);
+    }
+  }, [restoredTarget, router]);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -49,7 +60,6 @@ const SignInForm = () => {
     setFormError(null);
     try {
       await login(values.email, values.password);
-      router.replace(safeRedirectTarget(searchParams.get('redirect')));
     } catch (error) {
       setFormError(
         authErrorMessage(error, {
@@ -61,6 +71,21 @@ const SignInForm = () => {
   };
 
   const disabled = form.formState.isSubmitting;
+
+  // A fresh document has only the httpOnly refresh cookie. Do not show a
+  // sign-in form until bootstrap has decided whether that cookie restores a
+  // session; an authenticated result is redirected by the effect above.
+  if (status !== 'unauthenticated') {
+    return (
+      <div
+        role="status"
+        aria-label="Restoring session"
+        className="flex min-h-40 items-center justify-center"
+      >
+        <Loader2 className="text-muted-foreground size-5 animate-spin" />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -117,7 +142,10 @@ const SignInForm = () => {
       </Form>
       <div className="space-y-2 text-center text-sm text-[#7E8CA0]">
         <p>
-          <Link href="/forgot-password" className="text-blue-600 hover:underline">
+          <Link
+            href="/forgot-password"
+            className="text-blue-600 hover:underline"
+          >
             Forgot your password?
           </Link>
         </p>
@@ -137,7 +165,9 @@ export default function SignInPage() {
   // Next fails the production build rather than degrading at runtime.
   return (
     <Suspense
-      fallback={<Loader2 className="text-muted-foreground mx-auto animate-spin" />}
+      fallback={
+        <Loader2 className="text-muted-foreground mx-auto animate-spin" />
+      }
     >
       <SignInForm />
     </Suspense>

--- a/app/(dashboard)/transactions/import-card.tsx
+++ b/app/(dashboard)/transactions/import-card.tsx
@@ -31,8 +31,9 @@ export const ImportCard = ({ data, onCancel, onSubmit }: Props) => {
     ImportedTransactionRowError[]
   >([]);
 
-  const headers = data[0];
+  const headers = data[0] ?? [];
   const body = data.slice(1);
+  const hasImportRows = headers.length > 0 && body.length > 0;
   const onTableHeadSelectChange = (
     columnIndex: number,
     value: ImportableTransactionField | null
@@ -56,6 +57,10 @@ export const ImportCard = ({ data, onCancel, onSubmit }: Props) => {
   ).length;
 
   const handleContinue = () => {
+    if (!hasImportRows) {
+      return;
+    }
+
     const activeColumns = headers.reduce<
       { index: number; header: ImportableTransactionField }[]
     >((acc, _header, index) => {
@@ -98,7 +103,7 @@ export const ImportCard = ({ data, onCancel, onSubmit }: Props) => {
           <Button
             className="w-full lg:w-auto"
             size="sm"
-            disabled={progress < requiredOptions.length}
+            disabled={!hasImportRows || progress < requiredOptions.length}
             onClick={handleContinue}
           >
             Continue ({progress} / {requiredOptions.length})
@@ -130,12 +135,19 @@ export const ImportCard = ({ data, onCancel, onSubmit }: Props) => {
             )}
           </div>
         )}
-        <ImportTable
-          headers={headers}
-          body={body}
-          selectedColumns={selectedColumns}
-          onTableHeadSelectChange={onTableHeadSelectChange}
-        />
+        {hasImportRows ? (
+          <ImportTable
+            headers={headers}
+            body={body}
+            selectedColumns={selectedColumns}
+            onTableHeadSelectChange={onTableHeadSelectChange}
+          />
+        ) : (
+          <div role="alert" className="rounded-md border p-4 text-sm">
+            This CSV has no transaction rows. Cancel and choose a non-empty
+            file.
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -19,38 +19,42 @@ import { useBulkDeleteTransactions } from '@/features/transactions/api/use-bulk-
 import { useGetTransactions } from '@/features/transactions/api/use-get-transactions';
 import { chunkItems } from '@/lib/chunk-items';
 import { MAX_BULK_CREATE_TRANSACTIONS } from '@/lib/transaction-limits';
+import {
+  prepareCSVImport,
+  type CSVUploadResults,
+} from '@/lib/transaction-import';
 import { toast } from 'sonner';
 import { columns } from './columns';
 import { ImportCard } from './import-card';
 import { UploadButton } from './upload-button';
 import type { ImportedTransactionRow } from './import-card';
-import type { CSVUploadResults } from './upload-button';
 
 enum VARIANTS {
   LIST = 'LIST',
   IMPORT = 'IMPORT',
 }
 
-const INITIAL_IMPORT_RESULTS: CSVUploadResults = {
-  data: [],
-  errors: [],
-  meta: {},
-};
-
 const TransactionsPage = () => {
   const [AccountDialog, confirm] = useSelectAccount();
 
   const [variant, setVariant] = useState<VARIANTS>(VARIANTS.LIST);
 
-  const [importResults, setImportResults] = useState(INITIAL_IMPORT_RESULTS);
+  const [importData, setImportData] = useState<string[][]>([]);
 
   const onUpload = (results: CSVUploadResults) => {
-    setImportResults(results);
+    const prepared = prepareCSVImport(results);
+    if (!prepared.ok) {
+      setImportData([]);
+      toast.error(prepared.message);
+      return;
+    }
+
+    setImportData(prepared.data);
     setVariant(VARIANTS.IMPORT);
   };
 
   const onCancelImport = () => {
-    setImportResults(INITIAL_IMPORT_RESULTS);
+    setImportData([]);
     setVariant(VARIANTS.LIST);
   };
 
@@ -118,7 +122,7 @@ const TransactionsPage = () => {
       <>
         <AccountDialog />
         <ImportCard
-          data={importResults.data}
+          data={importData}
           onCancel={onCancelImport}
           onSubmit={onSubmitImport}
         />

--- a/app/(dashboard)/transactions/upload-button.tsx
+++ b/app/(dashboard)/transactions/upload-button.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import type { CSVUploadResults } from '@/lib/transaction-import';
 import { Upload } from 'lucide-react';
 import type { HTMLAttributes } from 'react';
 import { useCSVReader } from 'react-papaparse';
@@ -11,17 +12,10 @@ type CSVReaderRenderProps = {
   getRootProps: () => HTMLAttributes<HTMLElement>;
 };
 
-export type CSVUploadResults = {
-  data: string[][];
-  errors: unknown[];
-  meta: Record<string, unknown>;
-};
-
 export const UploadButton = ({ onUpload }: Props) => {
   const { CSVReader } = useCSVReader();
-  //Todo add a paywall
   return (
-    <CSVReader onUploadAccepted={onUpload}>
+    <CSVReader config={{ dynamicTyping: false }} onUploadAccepted={onUpload}>
       {({ getRootProps }: CSVReaderRenderProps) => (
         <Button size="sm" className="w-full lg:w-auto" {...getRootProps()}>
           <Upload className="mr-2 size-4" />

--- a/backend/README.md
+++ b/backend/README.md
@@ -313,6 +313,8 @@ Migrations live in `backend/migrations/` and are applied with
 | `00001_auth_base.sql` | `citext` extension; `users`, `email_verification_tokens`, `password_reset_tokens`, `refresh_tokens` tables |
 | `00002_finance_base.sql` | `accounts`, `categories`, `transactions` tables and their indexes |
 | `00003_finance_rls.sql` | Row level security enable/force + ownership policies on `accounts`, `categories`, `transactions` |
+| `00004_transactions_category_owner_rls.sql` | Reject cross-owner transaction/category relationships and repair pre-existing invalid references |
+| `00005_transactions_amount_bigint.sql` | Widen transaction amounts to `bigint` for the JavaScript-safe milliunit range |
 
 Install the pinned CLI version:
 
@@ -324,8 +326,13 @@ Run migrations from `backend/`:
 
 ```bash
 cd backend
-goose -dir migrations postgres "$DATABASE_URL" up
+goose -dir migrations postgres 'postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable' up
 ```
+
+The connection string is explicit because `.env.local` belongs to the Next
+process and does not export `DATABASE_URL` into the shell running goose. If you
+set a different database URL in that shell, pass that exported value here
+instead.
 
 Resetting the local database is destructive and must be explicit — never
 run `goose down`/`reset` as part of routine startup or automation.

--- a/components/date-filter.tsx
+++ b/components/date-filter.tsx
@@ -221,7 +221,6 @@ export const DateFilter = () => {
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>
         <Button
-          disabled={false}
           size="sm"
           variant="outline"
           className="h-9 w-full rounded-md border-none bg-white/10 px-3 font-normal text-white transition outline-none hover:bg-white/20 hover:text-white focus:bg-white/30 focus:ring-transparent focus:ring-offset-0 lg:w-auto"
@@ -325,7 +324,6 @@ export const DateFilter = () => {
                 </Button>
               ) : null}
               <Calendar
-                disabled={false}
                 autoFocus
                 mode="range"
                 month={month}

--- a/components/filters.test.ts
+++ b/components/filters.test.ts
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+const HEADER_FILTER_FILES = [
+  'components/account-filter.tsx',
+  'components/date-filter.tsx',
+  'components/filters.tsx',
+] as const;
+
+describe('header filter architecture', () => {
+  it('does not couple interactive filters to summary query state', async () => {
+    const sources = await Promise.all(
+      HEADER_FILTER_FILES.map((file) =>
+        readFile(path.join(process.cwd(), file), 'utf8')
+      )
+    );
+
+    for (const source of sources) {
+      expect(source).not.toContain('useGetSummary');
+      expect(source).not.toContain('@/features/summary');
+    }
+  });
+});

--- a/components/filters.tsx
+++ b/components/filters.tsx
@@ -2,6 +2,10 @@ import { AccountFilter } from './account-filter';
 import { DateFilter } from './date-filter';
 
 export const Filters = () => {
+  // Filters own URL state and only the data needed to render their controls.
+  // Summary consumers react to those URL changes independently; keeping the
+  // header free of summary loading state leaves it usable on every dashboard
+  // page and while analytics refetches.
   return (
     <div className="flex flex-col items-center gap-y-2 lg:flex-row lg:gap-x-2 lg:gap-y-0">
       <AccountFilter />

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -45,6 +45,13 @@ or a JavaScript-readable cookie. Memory-only storage means a page reload loses
 the access token, so `SessionProvider` starts in `loading` and bootstraps from
 the refresh cookie before deciding whether the user is authenticated.
 
+Both sides of navigation wait for that decision. `SessionGuard` keeps a
+protected route on a loading screen until bootstrap resolves, while the
+sign-in page withholds its form during the same state. If navigation has
+already reached `/sign-in` and bootstrap succeeds, the sign-in page restores
+the validated `redirect` target (or `/`), so a successful refresh cannot leave
+an authenticated user stranded on sign-in.
+
 The `client-only` marker on the store is load-bearing. Module state in a Next
 server bundle could be shared across requests and users.
 

--- a/docs/api/import.md
+++ b/docs/api/import.md
@@ -18,10 +18,12 @@ operation, not a separate server endpoint:
 
 `CSV upload → column mapping → client validation → account selection → payload adaptation → sequential 500-row requests`
 
-`react-papaparse` supplies a two-dimensional string array. The importer treats
-the first row as headers and every later row as data. Users must map exactly
-one column to each required field—`amount`, `date`, and `payee`—before the flow
-can continue. Choosing a field for a second column clears its prior mapping.
+`react-papaparse` supplies a two-dimensional string array plus parse errors and
+metadata. `prepareCSVImport` validates that complete result before import mode
+can render. The importer then treats the first row as headers and every later
+row as data. Users must map exactly one column to each required field—`amount`,
+`date`, and `payee`—before the flow can continue. Choosing a field for a second
+column clears its prior mapping.
 
 After client validation, one selected account id is attached to every row.
 `toBulkTransactionInput` adds the contract-required `ARS` currency and
@@ -29,10 +31,26 @@ normalizes absent notes/category values to `null`.
 
 ## Client validation
 
+Upload preflight fails closed before the mapping UI:
+
+- any Papa Parse error, aborted parse, or truncated parse rejects the file;
+- an empty, blank-header, or header-only file is rejected;
+- at least three columns must exist for the three required mappings;
+- every data record must have the same width as the header;
+- blank records inside the file are rejected, while conventional trailing
+  blank records produced by a final newline are removed; and
+- a UTF-8 BOM is removed from the first header cell and header whitespace is
+  trimmed.
+
+The page stores only the prepared two-dimensional data, not the unchecked
+parser result. `ImportCard` still renders a recoverable empty state if it is
+ever called without rows, rather than indexing `data[0]` and throwing.
+
 `parseImportedTransactionRows` trims all three mapped values and accumulates
 errors across the entire file.
 
-- Amount uses `Number(...)`, must be finite, is converted with
+- Amount must use plain decimal notation (not hexadecimal or exponent syntax),
+  must be finite, is converted with
   `Math.round(amount * 1000)`, and must remain a JavaScript safe integer in
   milliunits.
 - Date must round-trip exactly through date-fns using
@@ -120,6 +138,8 @@ row 504 as row 4 and send the user to the wrong record.
 
 - Column mapping and client parsing complete before account selection or any
   write.
+- Parser errors and structurally incomplete CSV files never reach column
+  mapping.
 - Amounts remain signed integer milliunits and within the browser-safe range.
 - Imported dates become calendar-date strings; never serialize the parsed
   `Date` with `toISOString()`.
@@ -158,7 +178,7 @@ row 504 as row 4 and send the user to the wrong record.
 | -------------------------------------------------------- | ----------------------------------------------------------- |
 | Upload state, sequential submission, row-offset tracking | `app/(dashboard)/transactions/page.tsx`                     |
 | Column mapping and client error display                  | `app/(dashboard)/transactions/import-card.tsx`              |
-| CSV parsing and normalization                            | `lib/transaction-import.ts`                                 |
+| CSV-result preflight, row parsing, and normalization     | `lib/transaction-import.ts`                                 |
 | 500-row splitting                                        | `lib/chunk-items.ts`                                        |
 | Shared limits                                            | `lib/transaction-limits.ts`                                 |
 | Contract payload adaptation                              | `features/transactions/api/transaction-payload.ts`          |

--- a/docs/product/auth.md
+++ b/docs/product/auth.md
@@ -68,7 +68,9 @@ attacker's session rather than leaving it running alongside the new password.
 A session survives closing the tab and reopening it, but it is re-established on
 each page load rather than simply being remembered — which is why the dashboard
 shows a brief spinner before it appears. That moment is the app asking the
-server whether the session is still good.
+server whether the session is still good. The sign-in screen waits for the same
+answer; if the session is valid, the app returns to the requested dashboard
+page instead of showing the sign-in form.
 
 Sessions end when the user signs out, when a password reset revokes them, or
 when the refresh token expires. When one ends mid-session the user is returned

--- a/docs/product/import.md
+++ b/docs/product/import.md
@@ -20,6 +20,12 @@ mapped. After the file passes validation, the user chooses one account; every
 transaction from that import is assigned to it. CSV import does not set notes
 or categories, and imported transactions use ARS.
 
+Before the mapping screen opens, the file itself must be usable. Empty and
+header-only files are rejected, parser errors stop the flow, and every data row
+must contain the same number of columns as the header. A blank line inside the
+data is treated as an error; harmless blank records at the very end of the file
+are ignored.
+
 ## The accepted date format is exact
 
 Dates must use:
@@ -32,9 +38,11 @@ For example, `2026-04-17 13:45:00` is accepted. `17/04/2026`,
 The time is accepted only as part of the CSV format. The saved transaction is
 for the calendar day, so the example above is stored as `2026-04-17`.
 
-Amounts must be valid finite numbers. They are converted to thousandths of a
-peso, so `12.34` becomes `12340` milliunits. Payees cannot be blank. Leading
-and trailing spaces are removed from all three mapped values.
+Amounts must be valid finite numbers written in ordinary decimal notation.
+Hexadecimal (`0x10`) and exponent (`1e3`) forms are rejected rather than
+silently coerced. Amounts are converted to thousandths of a peso, so `12.34`
+becomes `12340` milliunits. Payees cannot be blank. Leading and trailing spaces
+are removed from all three mapped values.
 
 ## Validation happens before anything is saved
 
@@ -92,6 +100,7 @@ save-error toast.
 
 | Situation                                                  | What they see / what it means                                          |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Empty, header-only, malformed, or uneven CSV               | Upload-error toast; the mapping screen does not open                   |
 | Missing or invalid amount                                  | Row-level amount message; no upload starts                             |
 | Date not in the exact format                               | Row-level date message showing `yyyy-MM-dd HH:mm:ss`; no upload starts |
 | Blank payee                                                | Row-level payee message; no upload starts                              |

--- a/lib/auth/redirect.test.ts
+++ b/lib/auth/redirect.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_SIGNED_IN_PATH,
   isAuthPath,
   redirectTargetFromLocation,
+  restoredSessionRedirectTarget,
   safeRedirectTarget,
 } from '@/lib/auth/redirect';
 
@@ -99,5 +100,37 @@ describe('isAuthPath', () => {
     expect(isAuthPath('/transactions')).toBe(false);
     expect(isAuthPath('/sign-in-help')).toBe(false);
     expect(isAuthPath('/')).toBe(false);
+  });
+});
+
+describe('restoredSessionRedirectTarget', () => {
+  it('waits while the refresh-cookie bootstrap is unresolved', () => {
+    expect(
+      restoredSessionRedirectTarget('loading', '/transactions')
+    ).toBeNull();
+  });
+
+  it('does not navigate a signed-out user away from the sign-in form', () => {
+    expect(
+      restoredSessionRedirectTarget('unauthenticated', '/transactions')
+    ).toBeNull();
+  });
+
+  it('restores an authenticated user to the requested protected route', () => {
+    expect(
+      restoredSessionRedirectTarget(
+        'authenticated',
+        '/transactions?accountId=abc'
+      )
+    ).toBe('/transactions?accountId=abc');
+  });
+
+  it('applies the same open-redirect protection as an explicit sign-in', () => {
+    expect(
+      restoredSessionRedirectTarget(
+        'authenticated',
+        'https://evil.example/login'
+      )
+    ).toBe(DEFAULT_SIGNED_IN_PATH);
   });
 });

--- a/lib/auth/redirect.ts
+++ b/lib/auth/redirect.ts
@@ -50,6 +50,23 @@ export function safeRedirectTarget(raw: string | null | undefined): string {
 }
 
 /**
+ * Gives signed-in visitors to the sign-in page a safe route back into the app.
+ *
+ * The session guard normally waits for bootstrap before it can redirect. This
+ * second check is intentional recovery: if navigation has already reached
+ * sign-in while the refresh request is still resolving, a successful refresh
+ * must not leave the user stranded on a form for a session they already have.
+ */
+export function restoredSessionRedirectTarget(
+  status: 'loading' | 'authenticated' | 'unauthenticated',
+  requestedTarget: string | null | undefined
+): string | null {
+  return status === 'authenticated'
+    ? safeRedirectTarget(requestedTarget)
+    : null;
+}
+
+/**
  * The pages that exist only for signed-out users.
  *
  * Used both to reject them as redirect targets and, by the guard, to decide

--- a/lib/transaction-import.test.ts
+++ b/lib/transaction-import.test.ts
@@ -1,20 +1,149 @@
-import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { describe, expect, it } from 'bun:test';
 
-import { parseImportedTransactionRows } from './transaction-import';
+import {
+  parseImportedTransactionRows,
+  prepareCSVImport,
+  type CSVUploadResults,
+} from '@/lib/transaction-import';
+
+function uploadResult(
+  data: string[][],
+  options: Partial<Pick<CSVUploadResults, 'errors' | 'meta'>> = {}
+): CSVUploadResults {
+  return {
+    data,
+    errors: options.errors ?? [],
+    meta: options.meta ?? {},
+  };
+}
+
+describe('prepareCSVImport', () => {
+  it('normalizes headers and removes only trailing blank records', () => {
+    expect(
+      prepareCSVImport(
+        uploadResult([
+          ['\uFEFF Amount ', ' Date ', ' Payee '],
+          ['12.34', '2026-04-17 13:45:00', 'Coffee Shop'],
+          ['', '', ''],
+        ])
+      )
+    ).toEqual({
+      ok: true,
+      data: [
+        ['Amount', 'Date', 'Payee'],
+        ['12.34', '2026-04-17 13:45:00', 'Coffee Shop'],
+      ],
+    });
+  });
+
+  it('rejects an empty file and an empty header', () => {
+    expect(prepareCSVImport(uploadResult([]))).toEqual({
+      ok: false,
+      message: 'The CSV file is empty.',
+    });
+    expect(
+      prepareCSVImport(
+        uploadResult([
+          ['', '  ', ''],
+          ['1', '2', '3'],
+        ])
+      )
+    ).toEqual({
+      ok: false,
+      message: 'The CSV header row is empty.',
+    });
+  });
+
+  it('rejects a header-only file before the mapping screen', () => {
+    expect(
+      prepareCSVImport(uploadResult([['Amount', 'Date', 'Payee']]))
+    ).toEqual({
+      ok: false,
+      message: 'The CSV contains a header but no transaction rows.',
+    });
+  });
+
+  it('rejects parser errors instead of trusting partial parser data', () => {
+    expect(
+      prepareCSVImport(
+        uploadResult(
+          [
+            ['Amount', 'Date', 'Payee'],
+            ['12.34', '2026-04-17 13:45:00', 'Coffee Shop'],
+          ],
+          { errors: [{ row: 1, message: 'Quoted field unterminated' }] }
+        )
+      )
+    ).toEqual({
+      ok: false,
+      message: 'CSV parsing failed near row 2: Quoted field unterminated',
+    });
+  });
+
+  it('rejects aborted and truncated parser results', () => {
+    const data = [
+      ['Amount', 'Date', 'Payee'],
+      ['12.34', '2026-04-17 13:45:00', 'Coffee Shop'],
+    ];
+
+    expect(
+      prepareCSVImport(uploadResult(data, { meta: { aborted: true } }))
+    ).toEqual({ ok: false, message: 'CSV parsing was interrupted.' });
+    expect(
+      prepareCSVImport(uploadResult(data, { meta: { truncated: true } }))
+    ).toEqual({ ok: false, message: 'CSV parsing was truncated.' });
+  });
+
+  it('requires enough columns for every required mapping', () => {
+    expect(
+      prepareCSVImport(
+        uploadResult([
+          ['Amount', 'Date'],
+          ['12.34', '2026-04-17 13:45:00'],
+        ])
+      )
+    ).toEqual({
+      ok: false,
+      message:
+        'The CSV must contain at least three columns to map amount, date, and payee.',
+    });
+  });
+
+  it('fails closed on blank or uneven records inside the file', () => {
+    const header = ['Amount', 'Date', 'Payee'];
+
+    expect(
+      prepareCSVImport(
+        uploadResult([
+          header,
+          ['12.34', '2026-04-17 13:45:00', 'Coffee Shop'],
+          ['', '', ''],
+          ['9.50', '2026-04-18 13:45:00', 'Market'],
+        ])
+      )
+    ).toEqual({ ok: false, message: 'CSV row 3 is empty.' });
+
+    expect(
+      prepareCSVImport(uploadResult([header, ['12.34', '2026-04-17 13:45:00']]))
+    ).toEqual({
+      ok: false,
+      message: 'CSV row 2 has 2 columns; expected 3.',
+    });
+  });
+});
 
 describe('parseImportedTransactionRows', () => {
   it('converts valid imported rows to API transaction rows', () => {
     const result = parseImportedTransactionRows([
       {
-        amount: '12.34',
-        date: '2026-04-17 13:45:00',
-        payee: 'Coffee Shop',
+        amount: ' 12.34 ',
+        date: ' 2026-04-17 13:45:00 ',
+        payee: ' Coffee Shop ',
       },
     ]);
 
-    assert.deepEqual(result.errors, []);
-    assert.deepEqual(result.data, [
+    expect(result.errors).toEqual([]);
+    expect(result.data).toEqual([
       {
         amount: 12340,
         date: '2026-04-17',
@@ -23,20 +152,78 @@ describe('parseImportedTransactionRows', () => {
     ]);
   });
 
-  it('returns row errors instead of throwing for invalid dates and amounts', () => {
+  it('returns one useful field error for each malformed value', () => {
     const result = parseImportedTransactionRows([
       {
-        amount: '',
+        amount: 'not-a-number',
         date: 'not-a-date',
         payee: '',
       },
     ]);
 
-    assert.deepEqual(result.data, []);
-    assert.equal(result.errors.length, 3);
-    assert.deepEqual(
-      result.errors.map((error) => error.field),
-      ['amount', 'date', 'payee']
+    expect(result.data).toEqual([]);
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors.map((error) => error.field)).toEqual([
+      'amount',
+      'date',
+      'payee',
+    ]);
+  });
+
+  it('rejects hexadecimal and exponent notation instead of coercing it', () => {
+    const result = parseImportedTransactionRows([
+      {
+        amount: '0x10',
+        date: '2026-04-17 13:45:00',
+        payee: 'Hex',
+      },
+      {
+        amount: '1e3',
+        date: '2026-04-18 13:45:00',
+        payee: 'Exponent',
+      },
+    ]);
+
+    expect(result.data).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        rowNumber: 2,
+        field: 'amount',
+        message: 'Amount must be a plain decimal number.',
+      },
+      {
+        rowNumber: 3,
+        field: 'amount',
+        message: 'Amount must be a plain decimal number.',
+      },
+    ]);
+  });
+
+  it('reports an out-of-range amount without a duplicate syntax error', () => {
+    const result = parseImportedTransactionRows([
+      {
+        amount: '9007199254741',
+        date: '2026-04-17 13:45:00',
+        payee: 'Large transfer',
+      },
+    ]);
+
+    expect(result.data).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        rowNumber: 2,
+        field: 'amount',
+        message: 'Amount is too large.',
+      },
+    ]);
+  });
+
+  it('supports an explicit physical first-row number', () => {
+    const result = parseImportedTransactionRows(
+      [{ amount: '', date: '', payee: '' }],
+      { firstRowNumber: 8 }
     );
+
+    expect(result.errors.every((error) => error.rowNumber === 8)).toBe(true);
   });
 });

--- a/lib/transaction-import.ts
+++ b/lib/transaction-import.ts
@@ -5,6 +5,26 @@ import { convertAmountToMiliunits, isSafeMiliunitAmount } from '@/lib/utils';
 export const TRANSACTION_IMPORT_DATE_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 export const TRANSACTION_IMPORT_OUTPUT_DATE_FORMAT = 'yyyy-MM-dd';
 
+const DECIMAL_AMOUNT_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
+
+export type CSVParseError = {
+  message: string;
+  row?: number;
+};
+
+export type CSVUploadResults = {
+  data: string[][];
+  errors: CSVParseError[];
+  meta: {
+    aborted?: boolean;
+    truncated?: boolean;
+  };
+};
+
+export type PreparedCSVImport =
+  | { ok: true; data: string[][] }
+  | { ok: false; message: string };
+
 export type ImportedTransactionRow = {
   amount: number;
   date: string;
@@ -20,6 +40,99 @@ export type ImportedTransactionRowError = {
   field: 'amount' | 'date' | 'payee';
   message: string;
 };
+
+function isBlankCSVRow(row: string[]): boolean {
+  return row.every((cell) => cell.trim() === '');
+}
+
+/**
+ * Validates the parser result before the mapping screen can render.
+ *
+ * Papa Parse intentionally returns data and errors together. Treating `data`
+ * as trustworthy while ignoring `errors` can turn a malformed quote or an
+ * uneven record into shifted financial fields. This preflight fails closed,
+ * removes only the conventional trailing blank records produced by a final
+ * newline, and preserves all other row positions for useful error messages.
+ */
+export function prepareCSVImport(results: CSVUploadResults): PreparedCSVImport {
+  if (results.meta.aborted) {
+    return { ok: false, message: 'CSV parsing was interrupted.' };
+  }
+
+  if (results.meta.truncated) {
+    return { ok: false, message: 'CSV parsing was truncated.' };
+  }
+
+  const firstParseError = results.errors[0];
+  if (firstParseError) {
+    const row =
+      firstParseError.row === undefined
+        ? ''
+        : ` near row ${firstParseError.row + 1}`;
+    return {
+      ok: false,
+      message: `CSV parsing failed${row}: ${firstParseError.message}`,
+    };
+  }
+
+  if (
+    !Array.isArray(results.data) ||
+    results.data.some(
+      (row) =>
+        !Array.isArray(row) || row.some((cell) => typeof cell !== 'string')
+    )
+  ) {
+    return { ok: false, message: 'CSV data has an unsupported shape.' };
+  }
+
+  const data = results.data.map((row) => [...row]);
+  while (data.length > 0 && isBlankCSVRow(data[data.length - 1])) {
+    data.pop();
+  }
+
+  if (data.length === 0) {
+    return { ok: false, message: 'The CSV file is empty.' };
+  }
+
+  const headers = data[0].map((cell, index) =>
+    (index === 0 ? cell.replace(/^\uFEFF/, '') : cell).trim()
+  );
+
+  if (headers.every((header) => header === '')) {
+    return { ok: false, message: 'The CSV header row is empty.' };
+  }
+
+  if (headers.length < 3) {
+    return {
+      ok: false,
+      message:
+        'The CSV must contain at least three columns to map amount, date, and payee.',
+    };
+  }
+
+  const body = data.slice(1);
+  if (body.length === 0) {
+    return {
+      ok: false,
+      message: 'The CSV contains a header but no transaction rows.',
+    };
+  }
+
+  for (const [index, row] of body.entries()) {
+    const rowNumber = index + 2;
+    if (isBlankCSVRow(row)) {
+      return { ok: false, message: `CSV row ${rowNumber} is empty.` };
+    }
+    if (row.length !== headers.length) {
+      return {
+        ok: false,
+        message: `CSV row ${rowNumber} has ${row.length} columns; expected ${headers.length}.`,
+      };
+    }
+  }
+
+  return { ok: true, data: [headers, ...body] };
+}
 
 export function parseImportedTransactionRows(
   rows: RawImportedTransactionRow[],
@@ -37,7 +150,10 @@ export function parseImportedTransactionRows(
     const dateText = row.date?.trim() ?? '';
     const payee = row.payee?.trim() ?? '';
 
-    const amount = Number(amountText);
+    const amountIsNumeric =
+      DECIMAL_AMOUNT_PATTERN.test(amountText) &&
+      Number.isFinite(Number(amountText));
+    const amount = amountIsNumeric ? Number(amountText) : Number.NaN;
     const parsedDate = parse(
       dateText,
       TRANSACTION_IMPORT_DATE_FORMAT,
@@ -46,11 +162,11 @@ export function parseImportedTransactionRows(
 
     const rowErrors: ImportedTransactionRowError[] = [];
 
-    if (!amountText || !Number.isFinite(amount)) {
+    if (!amountIsNumeric) {
       rowErrors.push({
         rowNumber,
         field: 'amount',
-        message: 'Amount must be a valid number.',
+        message: 'Amount must be a plain decimal number.',
       });
     }
 
@@ -74,8 +190,10 @@ export function parseImportedTransactionRows(
       });
     }
 
-    const amountInMiliunits = convertAmountToMiliunits(amount);
-    if (!isSafeMiliunitAmount(amountInMiliunits)) {
+    const amountInMiliunits = amountIsNumeric
+      ? convertAmountToMiliunits(amount)
+      : Number.NaN;
+    if (amountIsNumeric && !isSafeMiliunitAmount(amountInMiliunits)) {
       rowErrors.push({
         rowNumber,
         field: 'amount',


### PR DESCRIPTION
## Summary

- recover authenticated sessions that reach the sign-in route during refresh-cookie bootstrap
- fix the documented goose command and add migrations 00004/00005 to the backend migration table
- reject malformed, empty, header-only, truncated, blank-row, and uneven CSV uploads before column mapping
- require plain decimal transaction amounts and add defensive empty-state handling
- keep header filters independent from summary loading and pin that boundary with a regression test
- update the authentication/import product and technical references

## Root causes

The sign-in route rendered independently from session bootstrap, so a successful refresh had no recovery path once navigation reached that page. The CSV flow trusted Papa Parse's partial data, assumed a header existed, and did not validate record shape before rendering the mapper. The backend README also relied on an environment variable that the documented local flow never exports.

## Validation

- `bun run lint`
- `bunx tsc --noEmit`
- `bun test` — 200 passing
- `bun run build`
- `cd backend && go vet ./...`
- `cd backend && go test ./...`

Closes #102
Closes #103