### PR TITLE
Add one-command local dev stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Local PostgreSQL connection string, read by the Go API. The frontend does not
 # connect to Postgres.
-# Docker Compose default: postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable
-DATABASE_URL=postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable
+# Docker Compose host default: 54329 -> container 5432
+DATABASE_URL=postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable
 
 # Public base URL used by the frontend API client.
 # Local Next.js default: http://localhost:3000
@@ -38,6 +38,7 @@ AUTH_COOKIE_SECURE=false
 # Local app/runtime flags.
 # APP_ENV is informational for local tooling.
 APP_ENV=local
+POSTGRES_PORT=54329
 
 # Go backend scaffold configuration.
 # Defaults from backend/README.md: 0.0.0.0:8080

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,16 +13,19 @@
 
 ## Commands
 
-- `bun dev`
+- `bun dev` — starts Docker Postgres/Mailpit, applies goose migrations, builds
+  and starts the Go API, waits for `/api/health`, then starts Next.
+- `bun run dev:next` — Next-only manual debugging when Docker, migrations, and
+  the Go API are already running.
 - `bun run lint`
 - `bun run build`
 
 ## Env
 
-`bun run build` and `bun dev` need no environment variables at all. The list
-splits by which process reads them, and **nothing bridges the two**:
-`.env.local` is loaded by Bun for the Next process, while the Go API reads
-`os.Getenv` only, so its values must be exported in the shell that starts it.
+`bun run build` needs no environment variables. `bun dev` reads `.env.local`
+through Bun, supplies local defaults, and passes that environment to the Go API
+child process. If you run `go run ./cmd/api` manually, export backend variables
+in that shell; the Go API itself still reads only `os.Getenv`.
 
 Read by **Next**:
 
@@ -31,24 +34,27 @@ Read by **Next**:
 - `NEXT_PUBLIC_API_URL` — optional origin for the API client. Read only on the
   server (`lib/api-base-url.ts`); in the browser the base is always relative so
   requests stay same-origin. Leaving it unset is correct behind the proxy.
+- `POSTGRES_PORT` — host port published by Docker Compose for local Postgres.
+  Defaults to `54329`.
 
 Read by the **Go API**:
 
-- `AUTH_JWT_SECRET` — required, no default. The API exits at startup if it is
-  unset or shorter than 32 bytes. Generate with `openssl rand -base64 48`;
-  never commit a value.
+- `AUTH_JWT_SECRET` — required by the Go API, no backend default. `bun dev`
+  generates an ephemeral local value when it is unset; manual API runs must
+  export one. Generate with `openssl rand -base64 48`; never commit a value.
 - `AUTH_COOKIE_SECURE` — `false` locally; must be `true` anywhere deployed,
   which requires HTTPS.
 - `DATABASE_URL` — the Go API's connection string. The frontend does not connect
-  to Postgres.
+  to Postgres. Local default:
+  `postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable`.
 - `APP_BASE_URL` — origin used to build links in verification and reset mail;
   origin-only and validated at backend startup.
 - `SMTP_ADDR`, `MAIL_FROM` — outgoing mail. `SMTP_ADDR` is one `host:port`.
 
-`AUTH_JWT_SECRET` is the only one with no default, so it is the only one that
-must be exported for `go run ./cmd/api`. Reference:
-[`.env.example`](.env.example), and the full backend table in
-[`backend/README.md`](backend/README.md).
+`bun dev` fails fast if local `DATABASE_URL` and `POSTGRES_PORT` disagree, to
+avoid running migrations against a stale `localhost:5432` database from an old
+`.env.local`. Reference: [`.env.example`](.env.example), and the full backend
+table in [`backend/README.md`](backend/README.md).
 
 ## Repo Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,16 @@ Read by **Next**:
 - `NEXT_PUBLIC_API_URL` — optional origin for the API client. Read only on the
   server (`lib/api-base-url.ts`); in the browser the base is always relative so
   requests stay same-origin. Leaving it unset is correct behind the proxy.
-- `POSTGRES_PORT` — host port published by Docker Compose for local Postgres.
-  Defaults to `54329`.
+
+Read by **`bun dev` and Docker Compose** (neither Next nor the Go API reads
+these):
+
+- `POSTGRES_PORT` — host port Compose publishes for local Postgres. Defaults to
+  `54329`. `docker compose` interpolates it from `.env`, while `bun dev` picks
+  it up from `.env.local`.
+- `COMPOSE_PROJECT_NAME` — Compose project the local services belong to.
+  `bun dev` defaults it to `nuchi` so a worktree reuses the same containers
+  instead of standing up a second set named after its directory.
 
 Read by the **Go API**:
 
@@ -51,10 +59,13 @@ Read by the **Go API**:
   origin-only and validated at backend startup.
 - `SMTP_ADDR`, `MAIL_FROM` — outgoing mail. `SMTP_ADDR` is one `host:port`.
 
-`bun dev` fails fast if local `DATABASE_URL` and `POSTGRES_PORT` disagree, to
-avoid running migrations against a stale `localhost:5432` database from an old
-`.env.local`. Reference: [`.env.example`](.env.example), and the full backend
-table in [`backend/README.md`](backend/README.md).
+`bun dev` runs `goose up` unattended, so it checks `DATABASE_URL` before doing
+anything: it refuses a non-local host outright, and fails fast when a local host
+disagrees with `POSTGRES_PORT`. Both cases come from a stale `.env.local` — a
+Neon URL left over from before #85, or `localhost:5432` from before the Compose
+port moved — and both would otherwise migrate a database that never asked for
+it. Reference: [`.env.example`](.env.example), and the full backend table in
+[`backend/README.md`](backend/README.md).
 
 ## Repo Rules
 

--- a/README.md
+++ b/README.md
@@ -118,10 +118,16 @@ inside verification and reset emails. Full backend table:
 
 Do not commit `.env.local`. `bun run build` needs no credentials of any kind — that requirement disappeared with Clerk in #85. `AUTH_JWT_SECRET` is required by the Go API at startup, not by the frontend build; `bun dev` supplies a temporary local value, and manual API shells can generate one with `openssl rand -base64 48`.
 
-If your existing `.env.local` was copied before the local Postgres port changed,
-update `DATABASE_URL` from `localhost:5432` to `localhost:54329`. `bun dev`
-fails fast when local `DATABASE_URL` and `POSTGRES_PORT` disagree, before it can
-run migrations against the wrong database.
+**Check `DATABASE_URL` in an `.env.local` that predates this setup.** `bun dev`
+applies the goose migrations unattended, so it validates the target first and
+refuses to start otherwise:
+
+- A **remote** host — a Neon URL left over from before #85 — is rejected
+  outright. `bun dev` only ever drives the local Docker Postgres; migrate a
+  remote database by hand, deliberately.
+- A **local** host whose port disagrees with `POSTGRES_PORT` is rejected too.
+  Update `DATABASE_URL` from `localhost:5432` to `localhost:54329`; the old port
+  lands on whatever host Postgres is listening there.
 
 ## Docker And Local Services
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ inside verification and reset emails. Full backend table:
 
 Do not commit `.env.local`. `bun run build` needs no credentials of any kind — that requirement disappeared with Clerk in #85. `AUTH_JWT_SECRET` is required by the Go API at startup, not by the frontend build; `bun dev` supplies a temporary local value, and manual API shells can generate one with `openssl rand -base64 48`.
 
+If your existing `.env.local` was copied before the local Postgres port changed,
+update `DATABASE_URL` from `localhost:5432` to `localhost:54329`. `bun dev`
+fails fast when local `DATABASE_URL` and `POSTGRES_PORT` disagree, before it can
+run migrations against the wrong database.
+
 ## Docker And Local Services
 
 Start local Postgres and Mailpit:
@@ -137,6 +142,11 @@ Local service defaults:
 - Postgres: `postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable`.
 - Mailpit UI: `http://localhost:8025`.
 - Mailpit SMTP: `localhost:1025`.
+
+`POSTGRES_PORT` defaults to `54329`. `bun dev` reads overrides from
+`.env.local`; plain `docker compose up` reads Compose variables from `.env`
+instead, so keep `DATABASE_URL` and `POSTGRES_PORT` aligned when overriding the
+port manually.
 
 ### Postgres roles
 
@@ -187,11 +197,11 @@ bun test
 
 `bun dev` starts the full local stack: Docker Compose `postgres` and `mailpit`,
 Postgres readiness, backend goose migrations, the Go API, and the Next dev
-server. It leaves Docker volumes running when you stop the dev servers, so your
-local database persists between sessions. `bun run build` validates the Next.js
-production build and needs no environment variables. `bun run dev:next` is only
-for manual debugging when you are already running Docker, migrations, and the Go
-API yourself.
+server. It leaves Docker containers running when you stop the dev servers, so
+your local database persists between sessions. `bun run build` validates the
+Next.js production build and needs no environment variables. `bun run dev:next`
+is only for manual debugging when you are already running Docker, migrations,
+and the Go API yourself.
 
 ## Backend Commands
 
@@ -216,7 +226,7 @@ bun dev
 ```
 
 It starts Postgres and Mailpit with Docker Compose, waits for Postgres, applies
-`backend/migrations/` with goose, starts `go run ./cmd/api`, waits for
+`backend/migrations/` with goose, builds and starts the Go API, waits for
 `/api/health`, and then starts the Next dev server. Stop it with `Ctrl-C`; the
 Go and Next processes stop, while Docker Compose services stay up for the next
 session. The script defaults `COMPOSE_PROJECT_NAME` to `nuchi` and

--- a/README.md
+++ b/README.md
@@ -93,14 +93,13 @@ bun install
 Copy `.env.example` to `.env.local` and fill local values.
 
 **`.env.local` is read by the Next process only.** Bun loads it; the Go API does
-not — `backend/internal/config/config.go` reads `os.Getenv` and nothing else, so
-the backend variables below are documented here for reference and must be
-*exported* in the shell that runs the API. In practice only `AUTH_JWT_SECRET`
-needs exporting, because it is the sole value with no default; see
-[Running Next and Go Together](#running-next-and-go-together).
+not — `backend/internal/config/config.go` reads `os.Getenv` and nothing else.
+For normal local dev, `bun dev` exports the local defaults below to the Go API
+process and generates an in-memory `AUTH_JWT_SECRET` when you have not set one.
+If you run `go run ./cmd/api` manually, export backend variables in that shell.
 
 ```bash
-DATABASE_URL=postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable
+DATABASE_URL=postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable
 NEXT_PUBLIC_API_URL=http://localhost:3000
 SMTP_ADDR=localhost:1025
 MAILPIT_WEB_URL=http://localhost:8025
@@ -117,7 +116,7 @@ userinfo) — it is validated at startup, because it becomes a clickable link
 inside verification and reset emails. Full backend table:
 [`backend/README.md`](backend/README.md).
 
-Do not commit `.env.local`. `bun run build` needs no credentials of any kind — that requirement disappeared with Clerk in #85. `AUTH_JWT_SECRET` is required by the Go API at startup, not by the frontend build; generate one with `openssl rand -base64 48` and never commit it.
+Do not commit `.env.local`. `bun run build` needs no credentials of any kind — that requirement disappeared with Clerk in #85. `AUTH_JWT_SECRET` is required by the Go API at startup, not by the frontend build; `bun dev` supplies a temporary local value, and manual API shells can generate one with `openssl rand -base64 48`.
 
 ## Docker And Local Services
 
@@ -135,7 +134,7 @@ docker compose ps
 
 Local service defaults:
 
-- Postgres: `postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable`.
+- Postgres: `postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable`.
 - Mailpit UI: `http://localhost:8025`.
 - Mailpit SMTP: `localhost:1025`.
 
@@ -180,12 +179,19 @@ docker compose down --volumes
 
 ```bash
 bun dev
+bun run dev:next
 bun run lint
 bun run build
 bun test
 ```
 
-`bun dev` starts the Docker Compose `postgres` and `mailpit` services, waits for Postgres, then runs the Next dev server. It does not run migrations — goose owns those, from `backend/` — and it does not start the Go API, which you run separately with `cd backend && go run ./cmd/api`. `bun run build` validates the Next.js production build and needs no environment variables.
+`bun dev` starts the full local stack: Docker Compose `postgres` and `mailpit`,
+Postgres readiness, backend goose migrations, the Go API, and the Next dev
+server. It leaves Docker volumes running when you stop the dev servers, so your
+local database persists between sessions. `bun run build` validates the Next.js
+production build and needs no environment variables. `bun run dev:next` is only
+for manual debugging when you are already running Docker, migrations, and the Go
+API yourself.
 
 ## Backend Commands
 
@@ -203,24 +209,39 @@ The two run as separate processes: Next serves the UI, Go serves the API. Next
 proxies `/api/*` to Go by default, so the browser only talks to the Next origin,
 cookies stay same-origin, and no CORS setup is required.
 
-Start Postgres:
+The normal local command is:
+
+```bash
+bun dev
+```
+
+It starts Postgres and Mailpit with Docker Compose, waits for Postgres, applies
+`backend/migrations/` with goose, starts `go run ./cmd/api`, waits for
+`/api/health`, and then starts the Next dev server. Stop it with `Ctrl-C`; the
+Go and Next processes stop, while Docker Compose services stay up for the next
+session. The script defaults `COMPOSE_PROJECT_NAME` to `nuchi` and
+`POSTGRES_PORT` to `54329`, so this worktree reuses the same local Compose
+services without fighting a host Postgres already bound to `5432`.
+
+Manual flow, useful when debugging one process at a time:
 
 ```bash
 docker compose up -d postgres
 ```
 
-**Apply the migrations before starting the API.** This is not optional on a
-fresh checkout, and nothing does it for you: a new Compose volume runs only
+**Apply the migrations before starting the API.** This is not optional in the
+manual flow: a new Compose volume runs only
 `docker/postgres/init/01-app-role.sql`, which creates the `nuchi` role and the
 `citext` extension and no tables at all. The Go API does not migrate on startup
 — it calls `VerifyRLSActive` first and refuses to serve unless row level
 security is active on `accounts`, `categories` and `transactions`, so against an
-unmigrated database it exits immediately rather than starting.
+unmigrated database it exits immediately rather than starting. `bun dev` does
+run this goose step for you.
 
 ```bash
 cd backend
 go install github.com/pressly/goose/v3/cmd/goose@v3.27.2   # once
-goose -dir migrations postgres 'postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable' up
+goose -dir migrations postgres 'postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable' up
 ```
 
 The connection string is spelled out rather than `"$DATABASE_URL"` because
@@ -238,17 +259,15 @@ go run ./cmd/api
 ```
 
 ```bash
-bun dev
+bun run dev:next
 ```
 
-`AUTH_JWT_SECRET` is the one value with no default: the API exits at startup
-unless it is set and at least 32 bytes. Everything else the API needs —
+`AUTH_JWT_SECRET` is the one value with no backend default: the API exits at
+startup unless it is set and at least 32 bytes. `bun dev` generates a temporary
+local value for the process it starts. Everything else the API needs —
 including `DATABASE_URL`, `SMTP_ADDR`, `MAIL_FROM` and `APP_BASE_URL` — already
-defaults to the local values above, so this is the whole of it. See
-[`backend/README.md`](backend/README.md) for the full table.
-
-`bun dev` deliberately does not run migrations. Schema ownership belongs to the
-backend, and the frontend does not connect to Postgres at all.
+defaults to the local values above. See [`backend/README.md`](backend/README.md)
+for the full table.
 
 ### Go API proxy configuration
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,8 +20,8 @@ bun dev
 ```
 
 That starts Docker Compose Postgres and Mailpit, applies the goose migrations,
-starts this Go API, waits for `/api/health`, and then starts the Next dev
-server.
+builds and starts this Go API, waits for `/api/health`, and then starts the
+Next dev server.
 
 Manual backend-only run:
 
@@ -39,6 +39,10 @@ go run ./cmd/api
 ```
 
 The API listens on `0.0.0.0:8080` by default.
+
+If your existing `.env.local` was copied before the local Compose Postgres port
+changed, update `DATABASE_URL` from `localhost:5432` to `localhost:54329`.
+`bun dev` fails fast when local `DATABASE_URL` and `POSTGRES_PORT` disagree.
 
 ## Configuration
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -42,7 +42,9 @@ The API listens on `0.0.0.0:8080` by default.
 
 If your existing `.env.local` was copied before the local Compose Postgres port
 changed, update `DATABASE_URL` from `localhost:5432` to `localhost:54329`.
-`bun dev` fails fast when local `DATABASE_URL` and `POSTGRES_PORT` disagree.
+`bun dev` validates the migration target before running goose: it refuses a
+non-local host outright, and fails fast when a local host disagrees with
+`POSTGRES_PORT`.
 
 ## Configuration
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,14 +13,27 @@ intentionally left to their own issue (#43+).
 
 ## Local Run
 
+From the repo root, the normal local development command is:
+
+```bash
+bun dev
+```
+
+That starts Docker Compose Postgres and Mailpit, applies the goose migrations,
+starts this Go API, waits for `/api/health`, and then starts the Next dev
+server.
+
+Manual backend-only run:
+
 The API connects to PostgreSQL at startup and exits if it cannot, and it
 requires `AUTH_JWT_SECRET` to be set (also fail-fast — see Auth below), so
-start the database (and Mailpit, for the email flows) and export a secret
-first:
+start the database (and Mailpit, for the email flows), run migrations, and
+export a secret first:
 
 ```bash
 docker compose up -d postgres mailpit
 cd backend
+go run github.com/pressly/goose/v3/cmd/goose@v3.27.2 -dir migrations postgres 'postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable' up
 export AUTH_JWT_SECRET="$(openssl rand -base64 48)"
 go run ./cmd/api
 ```
@@ -33,7 +46,7 @@ The API listens on `0.0.0.0:8080` by default.
 | --- | --- | --- |
 | `BACKEND_HOST` | `0.0.0.0` | HTTP listen host |
 | `BACKEND_PORT` | `8080` | HTTP listen port |
-| `DATABASE_URL` | `postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable` | PostgreSQL connection string |
+| `DATABASE_URL` | `postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable` | PostgreSQL connection string |
 | `AUTH_JWT_SECRET` | *(none — required)* | HMAC key for signing/verifying access tokens. Startup exits with a clear error if unset or shorter than 32 bytes. Generate one with `openssl rand -base64 48`. |
 | `AUTH_ACCESS_TOKEN_TTL` | `30m` | Access-token lifetime, as a Go duration (e.g. `30m`, `1h`) |
 | `AUTH_REFRESH_TOKEN_TTL` | `720h` (30 days) | Refresh-token lifetime, as a Go duration |
@@ -316,23 +329,24 @@ Migrations live in `backend/migrations/` and are applied with
 | `00004_transactions_category_owner_rls.sql` | Reject cross-owner transaction/category relationships and repair pre-existing invalid references |
 | `00005_transactions_amount_bigint.sql` | Widen transaction amounts to `bigint` for the JavaScript-safe milliunit range |
 
-Install the pinned CLI version:
+Install the pinned CLI version if you want a `goose` binary:
 
 ```bash
 go install github.com/pressly/goose/v3/cmd/goose@v3.27.2
 ```
 
-Run migrations from `backend/`:
+Or run the pinned version directly from `backend/`:
 
 ```bash
 cd backend
-goose -dir migrations postgres 'postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable' up
+go run github.com/pressly/goose/v3/cmd/goose@v3.27.2 -dir migrations postgres 'postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable' up
 ```
 
 The connection string is explicit because `.env.local` belongs to the Next
 process and does not export `DATABASE_URL` into the shell running goose. If you
 set a different database URL in that shell, pass that exported value here
-instead.
+instead. The root `bun dev` script runs this migration step before starting the
+API.
 
 Resetting the local database is destructive and must be explicit — never
 run `goose down`/`reset` as part of routine startup or automation.
@@ -456,8 +470,9 @@ changes that produced them.
 Most tests run without a database and without `AUTH_JWT_SECRET` set (the
 config package's own fail-fast test sets it per-test). Running the API
 requires PostgreSQL to be up (see Database above) and `AUTH_JWT_SECRET` set
-(see Auth above): startup pings the database and validates configuration,
-exiting with status 1 if either fails.
+(see Auth above): startup pings the database, verifies RLS, and validates
+configuration, exiting with status 1 if any step fails. The root `bun dev`
+command supplies a temporary local secret automatically.
 
 ```bash
 cd backend
@@ -480,7 +495,7 @@ token usable), and the sqlc round-trip / RLS tests in `internal/db`:
 
 ```bash
 cd backend
-TEST_DATABASE_URL="postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable" go test ./...
+TEST_DATABASE_URL="postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable" go test ./...
 ```
 
 `internal/mail`'s tests (`SMTPMailer` against a local fake SMTP listener,

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -14,7 +14,7 @@ import (
 const (
 	defaultHost        = "0.0.0.0"
 	defaultPort        = "8080"
-	defaultDatabaseURL = "postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable"
+	defaultDatabaseURL = "postgres://nuchi:nuchi@localhost:54329/nuchi?sslmode=disable"
 
 	// defaultAccessTokenTTL is the dev default lifetime of a signed JWT
 	// access token (spec: "Initial dev access-token lifetime is 30 minutes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "5432:5432"
+      - '${POSTGRES_PORT:-54329}:5432'
     volumes:
       - nuchi-postgres-data:/var/lib/postgresql/data
       # Init scripts run only on first initialization of an empty data
@@ -21,7 +21,7 @@ services:
       # `docker compose down --volumes` to pick this up.
       - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d nuchi"]
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d nuchi']
       interval: 2s
       timeout: 5s
       retries: 20
@@ -29,8 +29,8 @@ services:
   mailpit:
     image: axllent/mailpit:latest
     ports:
-      - "1025:1025"
-      - "8025:8025"
+      - '1025:1025'
+      - '8025:8025'
 
 volumes:
   nuchi-postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       # `docker compose down --volumes` to pick this up.
       - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres -d nuchi']
+      test: ["CMD-SHELL", "pg_isready -U postgres -d nuchi"]
       interval: 2s
       timeout: 5s
       retries: 20
@@ -29,8 +29,8 @@ services:
   mailpit:
     image: axllent/mailpit:latest
     ports:
-      - '1025:1025'
-      - '8025:8025'
+      - "1025:1025"
+      - "8025:8025"
 
 volumes:
   nuchi-postgres-data:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "bun ./scripts/dev-local.ts",
+    "dev:next": "next dev",
     "build": "next build",
     "start": "next start",
     "test": "bun test",

--- a/scripts/dev-local.ts
+++ b/scripts/dev-local.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'node:crypto';
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 /**
@@ -20,6 +21,8 @@ const HEALTH_RETRIES = 30;
 const HEALTH_DELAY_MS = 1000;
 const API_HEALTH_RETRIES = 30;
 const API_HEALTH_DELAY_MS = 1000;
+// Keep this aligned with .github/workflows/ci.yml's installed goose version.
+const GOOSE_VERSION = 'v3.27.2';
 const POSTGRES_PORT = process.env.POSTGRES_PORT ?? '54329';
 const DATABASE_URL =
   process.env.DATABASE_URL ??
@@ -27,20 +30,24 @@ const DATABASE_URL =
 const GO_API_URL =
   process.env.GO_API_URL ??
   `http://localhost:${process.env.BACKEND_PORT ?? '8080'}`;
+const GENERATED_AUTH_SECRET = process.env.AUTH_JWT_SECRET === undefined;
+const AUTH_JWT_SECRET =
+  process.env.AUTH_JWT_SECRET ?? randomBytes(48).toString('base64');
+const API_BIN = join(
+  tmpdir(),
+  `nuchi-api-dev-${process.pid}${process.platform === 'win32' ? '.exe' : ''}`
+);
 
 const baseEnv = {
   ...process.env,
   APP_ENV: process.env.APP_ENV ?? 'local',
   APP_BASE_URL: process.env.APP_BASE_URL ?? 'http://localhost:3000',
   AUTH_COOKIE_SECURE: process.env.AUTH_COOKIE_SECURE ?? 'false',
-  AUTH_JWT_SECRET:
-    process.env.AUTH_JWT_SECRET ?? randomBytes(48).toString('base64'),
+  AUTH_JWT_SECRET,
   COMPOSE_PROJECT_NAME: process.env.COMPOSE_PROJECT_NAME ?? 'nuchi',
   DATABASE_URL,
   GO_API_URL,
   MAIL_FROM: process.env.MAIL_FROM ?? 'nuchi@localhost',
-  NEXT_PUBLIC_API_URL:
-    process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000',
   POSTGRES_PORT,
   SMTP_ADDR: process.env.SMTP_ADDR ?? 'localhost:1025',
 };
@@ -58,41 +65,20 @@ function log(message: string) {
 
 function spawnLogged(
   command: [string, ...string[]],
-  label: string,
   options: { cwd?: string } = {}
 ) {
   const proc = spawn(command[0], command.slice(1), {
     cwd: options.cwd,
     env: baseEnv,
-    stdio: ['inherit', 'pipe', 'pipe'],
+    stdio: 'inherit',
   });
 
   children.add(proc);
-
-  proc.stdout?.on('data', (chunk) => {
-    process.stdout.write(prefixLines(label, chunk));
-  });
-  proc.stderr?.on('data', (chunk) => {
-    process.stderr.write(prefixLines(label, chunk));
-  });
   proc.once('exit', () => {
     children.delete(proc);
   });
 
   return proc;
-}
-
-function prefixLines(label: string, chunk: Buffer) {
-  return chunk
-    .toString()
-    .split(/\n/)
-    .map((line, index, lines) => {
-      if (index === lines.length - 1 && line === '') {
-        return '';
-      }
-      return `[${label}] ${line}`;
-    })
-    .join('\n');
 }
 
 async function run(
@@ -113,6 +99,41 @@ async function run(
   if (code !== 0) {
     throw new Error(`Command failed (${code}): ${command.join(' ')}`);
   }
+}
+
+function validateDatabaseUrlPort() {
+  let parsed: URL;
+  try {
+    parsed = new URL(DATABASE_URL);
+  } catch {
+    throw new Error(
+      `DATABASE_URL must be an absolute Postgres URL, got: ${DATABASE_URL}`
+    );
+  }
+
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1']);
+  if (!localHosts.has(parsed.hostname)) {
+    return;
+  }
+
+  const databasePort = parsed.port || '5432';
+  if (databasePort !== POSTGRES_PORT) {
+    throw new Error(
+      [
+        `DATABASE_URL points at localhost:${databasePort}, but POSTGRES_PORT is ${POSTGRES_PORT}.`,
+        'Update your local DATABASE_URL to match POSTGRES_PORT before running migrations.',
+        `Expected local default: postgres://nuchi:nuchi@localhost:${POSTGRES_PORT}/nuchi?sslmode=disable`,
+      ].join('\n')
+    );
+  }
+}
+
+function databaseTarget() {
+  const parsed = new URL(DATABASE_URL);
+  const databaseName =
+    parsed.pathname.replace(/^\//, '') || '(default database)';
+
+  return `${parsed.hostname}:${parsed.port || '5432'}/${databaseName}`;
 }
 
 async function isPostgresReady() {
@@ -155,23 +176,56 @@ async function waitForPostgres() {
   throw new Error('Local Postgres did not become healthy in time');
 }
 
-async function waitForApi() {
+async function waitForApi(api: ReturnType<typeof spawn>) {
   const healthUrl = new URL('/api/health', GO_API_URL);
 
-  for (let attempt = 1; attempt <= API_HEALTH_RETRIES; attempt += 1) {
-    try {
-      const response = await fetch(healthUrl);
-      if (response.ok) {
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const settle = (callback: () => void) => {
+      if (settled) {
         return;
       }
-    } catch {
-      // Keep polling while the Go process starts.
-    }
+      settled = true;
+      api.off('exit', onExit);
+      callback();
+    };
 
-    await sleep(API_HEALTH_DELAY_MS);
-  }
+    const onExit = (code: number | null) => {
+      settle(() =>
+        reject(
+          new Error(`Go API exited with code ${code} before becoming healthy`)
+        )
+      );
+    };
 
-  throw new Error(`Go API did not become healthy at ${healthUrl}`);
+    const poll = async () => {
+      for (let attempt = 1; attempt <= API_HEALTH_RETRIES; attempt += 1) {
+        if (settled) {
+          return;
+        }
+
+        try {
+          const response = await fetch(healthUrl);
+          if (response.ok) {
+            settle(resolve);
+            return;
+          }
+        } catch {
+          // Keep polling while the Go process starts.
+        }
+
+        await sleep(API_HEALTH_DELAY_MS);
+      }
+
+      settle(() =>
+        reject(new Error(`Go API did not become healthy at ${healthUrl}`))
+      );
+    };
+
+    api.once('exit', onExit);
+    void poll();
+  });
 }
 
 function stopChildren() {
@@ -188,7 +242,7 @@ function stopChildren() {
 function watchProcess(
   proc: ReturnType<typeof spawn>,
   label: string,
-  settle: () => void,
+  settle: (code: number) => void,
   reject: (reason: Error) => void
 ) {
   proc.once('error', reject);
@@ -198,35 +252,12 @@ function watchProcess(
       return;
     }
 
-    settle();
+    settle(code ?? 0);
   });
 }
 
 async function main() {
-  log('Starting Postgres and Mailpit');
-  await run(['docker', 'compose', 'up', '-d', ...COMPOSE_SERVICES]);
-  await waitForPostgres();
-
-  log('Applying backend migrations');
-  await run(
-    [
-      'go',
-      'run',
-      'github.com/pressly/goose/v3/cmd/goose@v3.27.2',
-      '-dir',
-      'migrations',
-      'postgres',
-      DATABASE_URL,
-      'up',
-    ],
-    { cwd: 'backend' }
-  );
-
-  log('Starting Go API');
-  const api = spawnLogged(['go', 'run', './cmd/api'], 'api', {
-    cwd: 'backend',
-  });
-  await waitForApi();
+  validateDatabaseUrlPort();
 
   const nextBin =
     process.platform === 'win32'
@@ -237,26 +268,66 @@ async function main() {
     throw new Error('Next binary not found. Run `bun install` first.');
   }
 
+  if (GENERATED_AUTH_SECRET) {
+    log(
+      'Generated an ephemeral AUTH_JWT_SECRET; set one in .env.local to keep access tokens valid across restarts'
+    );
+  }
+
+  log('Starting Postgres and Mailpit');
+  await run(['docker', 'compose', 'up', '-d', ...COMPOSE_SERVICES]);
+  await waitForPostgres();
+
+  log(`Applying backend migrations to ${databaseTarget()}`);
+  await run(
+    [
+      'go',
+      'run',
+      `github.com/pressly/goose/v3/cmd/goose@${GOOSE_VERSION}`,
+      '-dir',
+      'migrations',
+      'postgres',
+      DATABASE_URL,
+      'up',
+    ],
+    { cwd: 'backend' }
+  );
+
+  log('Building Go API');
+  await run(['go', 'build', '-o', API_BIN, './cmd/api'], { cwd: 'backend' });
+
+  log('Starting Go API');
+  const api = spawnLogged([API_BIN]);
+  await waitForApi(api);
+
   log('Starting Next dev server');
-  const next = spawnLogged([nextBin, 'dev'], 'next');
+  const next = spawnLogged([nextBin, 'dev']);
 
   process.on('SIGINT', stopChildren);
   process.on('SIGTERM', stopChildren);
 
-  await new Promise<void>((resolve, reject) => {
+  return await new Promise<number>((resolve, reject) => {
     watchProcess(api, 'Go API', resolve, reject);
     watchProcess(next, 'Next dev server', resolve, reject);
-    process.once('SIGINT', resolve);
-    process.once('SIGTERM', resolve);
+    process.once('SIGINT', () => resolve(0));
+    process.once('SIGTERM', () => resolve(0));
   });
 }
 
 main()
+  .then((code) => {
+    process.exitCode = code;
+  })
   .catch((error) => {
     console.error(error instanceof Error ? error.message : error);
     stopChildren();
-    process.exit(1);
+    process.exitCode = 1;
   })
   .finally(() => {
     stopChildren();
+    try {
+      unlinkSync(API_BIN);
+    } catch {
+      // The binary may not exist if setup failed before the build step.
+    }
   });

--- a/scripts/dev-local.ts
+++ b/scripts/dev-local.ts
@@ -101,7 +101,21 @@ async function run(
   }
 }
 
-function validateDatabaseUrlPort() {
+/**
+ * Refuses to run the local stack against anything but the Compose Postgres.
+ *
+ * This script runs `goose up` unattended, so a wrong `DATABASE_URL` is not a
+ * failed connection — it is migrations applied to a database that never asked
+ * for them. Two ways that happens, both from a stale `.env.local`:
+ *
+ * - A **remote** host left over from the pre-#85 Neon stack. Fatal, no
+ *   override: `bun dev` provisions local Docker Postgres, so a remote target is
+ *   always a mistake here. Migrate a remote database deliberately, by hand.
+ * - A **local** host on the wrong port — typically `5432` from before the
+ *   Compose port moved to 54329, which lands on whatever host Postgres happens
+ *   to be listening there.
+ */
+function validateDatabaseTarget() {
   let parsed: URL;
   try {
     parsed = new URL(DATABASE_URL);
@@ -111,16 +125,25 @@ function validateDatabaseUrlPort() {
     );
   }
 
-  const localHosts = new Set(['localhost', '127.0.0.1', '::1']);
+  // `URL.hostname` keeps the brackets on IPv6 literals, so the loopback address
+  // has to be listed in its bracketed form to match at all.
+  const localHosts = new Set(['localhost', '127.0.0.1', '[::1]']);
   if (!localHosts.has(parsed.hostname)) {
-    return;
+    throw new Error(
+      [
+        `DATABASE_URL points at the remote host ${parsed.hostname}, but bun dev only drives the local Docker Postgres.`,
+        'It would have applied backend/migrations/ to that database. Refusing.',
+        'Check DATABASE_URL in .env.local — a Neon URL from before #85 is the usual cause.',
+        `Expected local default: postgres://nuchi:nuchi@localhost:${POSTGRES_PORT}/nuchi?sslmode=disable`,
+      ].join('\n')
+    );
   }
 
   const databasePort = parsed.port || '5432';
   if (databasePort !== POSTGRES_PORT) {
     throw new Error(
       [
-        `DATABASE_URL points at localhost:${databasePort}, but POSTGRES_PORT is ${POSTGRES_PORT}.`,
+        `DATABASE_URL points at ${parsed.hostname}:${databasePort}, but POSTGRES_PORT is ${POSTGRES_PORT}.`,
         'Update your local DATABASE_URL to match POSTGRES_PORT before running migrations.',
         `Expected local default: postgres://nuchi:nuchi@localhost:${POSTGRES_PORT}/nuchi?sslmode=disable`,
       ].join('\n')
@@ -194,7 +217,11 @@ async function waitForApi(api: ReturnType<typeof spawn>) {
     const onExit = (code: number | null) => {
       settle(() =>
         reject(
-          new Error(`Go API exited with code ${code} before becoming healthy`)
+          new Error(
+            stopping
+              ? 'Interrupted before the Go API became healthy'
+              : `Go API exited with code ${code} before becoming healthy`
+          )
         )
       );
     };
@@ -257,7 +284,7 @@ function watchProcess(
 }
 
 async function main() {
-  validateDatabaseUrlPort();
+  validateDatabaseTarget();
 
   const nextBin =
     process.platform === 'win32'
@@ -293,6 +320,13 @@ async function main() {
     { cwd: 'backend' }
   );
 
+  // Registered before the build, not after the spawns: from here on there is a
+  // binary in tmpdir to unlink, and an interrupt during the health wait would
+  // otherwise kill the script with the default handler and skip the cleanup in
+  // `finally`.
+  process.on('SIGINT', stopChildren);
+  process.on('SIGTERM', stopChildren);
+
   log('Building Go API');
   await run(['go', 'build', '-o', API_BIN, './cmd/api'], { cwd: 'backend' });
 
@@ -302,9 +336,6 @@ async function main() {
 
   log('Starting Next dev server');
   const next = spawnLogged([nextBin, 'dev']);
-
-  process.on('SIGINT', stopChildren);
-  process.on('SIGTERM', stopChildren);
 
   return await new Promise<number>((resolve, reject) => {
     watchProcess(api, 'Go API', resolve, reject);

--- a/scripts/dev-local.ts
+++ b/scripts/dev-local.ts
@@ -1,60 +1,107 @@
+import { randomBytes } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
 /**
- * Starts the local services the app needs, then the Next dev server.
+ * Starts the complete local dev stack:
  *
- * **This no longer runs migrations, and no longer provisions its own
- * database.** Both changed with #85, which removed Drizzle:
+ * - Docker Compose Postgres + Mailpit
+ * - goose migrations
+ * - Go API
+ * - Next dev server
  *
- * - Migrations belong to goose and run from `backend/` against the Go API's
- *   database. Running them from here would mean the frontend owned a schema it
- *   no longer touches — the frontend does not connect to Postgres at all now.
- * - The old `docker-compose.dev.yml` was deleted with it. It ran a separate
- *   `nuchi_dev` database on port 54329 whose bootstrap superuser *was* the
- *   application role, which is precisely the layout `docker-compose.yml`
- *   documents as unsafe: superusers bypass row level security outright, FORCE
- *   included, so RLS policies would silently not apply. Only the deleted
- *   Drizzle migrate script ever pointed at it.
- *
- * So this brings up the same `postgres` and `mailpit` services the Go API and
- * the backend test suite use, and leaves schema and API startup to `backend/`.
- *
- * **A fresh Compose volume therefore has no tables.** The init script creates
- * only the `nuchi` role and `citext`, and the API calls `VerifyRLSActive`
- * before serving, so it exits rather than starting against an unmigrated
- * database. Run the goose step from the README's "Running Next and Go Together"
- * flow once before `go run ./cmd/api`:
- *
- *     cd backend
- *     goose -dir migrations postgres 'postgres://nuchi:nuchi@localhost:5432/nuchi?sslmode=disable' up
- *
- * The URL is literal on purpose. `$DATABASE_URL` is not exported by anything —
- * `.env.local` is loaded by Bun for this process, not for goose or the Go API —
- * so passing `"$DATABASE_URL"` sends goose an empty string and it falls back to
- * libpq defaults, failing against your OS username.
- *
- * That step is deliberately not invoked here: it would put the backend's schema
- * ownership, and a Go toolchain dependency, inside the frontend dev server.
+ * The frontend still never connects to Postgres directly. This script only
+ * sequences the backend-owned setup so a fresh checkout can start from one
+ * command: `bun dev`.
  */
 const COMPOSE_SERVICES = ['postgres', 'mailpit'] as const;
 const HEALTH_RETRIES = 30;
 const HEALTH_DELAY_MS = 1000;
+const API_HEALTH_RETRIES = 30;
+const API_HEALTH_DELAY_MS = 1000;
+const POSTGRES_PORT = process.env.POSTGRES_PORT ?? '54329';
+const DATABASE_URL =
+  process.env.DATABASE_URL ??
+  `postgres://nuchi:nuchi@localhost:${POSTGRES_PORT}/nuchi?sslmode=disable`;
+const GO_API_URL =
+  process.env.GO_API_URL ??
+  `http://localhost:${process.env.BACKEND_PORT ?? '8080'}`;
 
 const baseEnv = {
   ...process.env,
-  APP_ENV: 'local',
+  APP_ENV: process.env.APP_ENV ?? 'local',
+  APP_BASE_URL: process.env.APP_BASE_URL ?? 'http://localhost:3000',
+  AUTH_COOKIE_SECURE: process.env.AUTH_COOKIE_SECURE ?? 'false',
+  AUTH_JWT_SECRET:
+    process.env.AUTH_JWT_SECRET ?? randomBytes(48).toString('base64'),
+  COMPOSE_PROJECT_NAME: process.env.COMPOSE_PROJECT_NAME ?? 'nuchi',
+  DATABASE_URL,
+  GO_API_URL,
+  MAIL_FROM: process.env.MAIL_FROM ?? 'nuchi@localhost',
+  NEXT_PUBLIC_API_URL:
+    process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000',
+  POSTGRES_PORT,
+  SMTP_ADDR: process.env.SMTP_ADDR ?? 'localhost:1025',
 };
+
+const children = new Set<ReturnType<typeof spawn>>();
+let stopping = false;
 
 async function sleep(ms: number) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function log(message: string) {
+  console.log(`[dev] ${message}`);
+}
+
+function spawnLogged(
+  command: [string, ...string[]],
+  label: string,
+  options: { cwd?: string } = {}
+) {
+  const proc = spawn(command[0], command.slice(1), {
+    cwd: options.cwd,
+    env: baseEnv,
+    stdio: ['inherit', 'pipe', 'pipe'],
+  });
+
+  children.add(proc);
+
+  proc.stdout?.on('data', (chunk) => {
+    process.stdout.write(prefixLines(label, chunk));
+  });
+  proc.stderr?.on('data', (chunk) => {
+    process.stderr.write(prefixLines(label, chunk));
+  });
+  proc.once('exit', () => {
+    children.delete(proc);
+  });
+
+  return proc;
+}
+
+function prefixLines(label: string, chunk: Buffer) {
+  return chunk
+    .toString()
+    .split(/\n/)
+    .map((line, index, lines) => {
+      if (index === lines.length - 1 && line === '') {
+        return '';
+      }
+      return `[${label}] ${line}`;
+    })
+    .join('\n');
+}
+
 async function run(
   command: [string, ...string[]],
-  options: { quiet?: boolean } = {}
+  options: { cwd?: string; quiet?: boolean } = {}
 ) {
   const code = await new Promise<number | null>((resolve, reject) => {
     const proc = spawn(command[0], command.slice(1), {
+      cwd: options.cwd,
       env: baseEnv,
       stdio: options.quiet ? 'ignore' : 'inherit',
     });
@@ -68,11 +115,6 @@ async function run(
   }
 }
 
-/**
- * `pg_isready` as the bootstrap superuser, matching the compose healthcheck.
- * The application role `nuchi` is created by an init script, so probing as
- * `nuchi` would fail on a first-run volume before that script completes.
- */
 async function isPostgresReady() {
   const code = await new Promise<number | null>((resolve) => {
     const proc = spawn(
@@ -89,6 +131,7 @@ async function isPostgresReady() {
         'nuchi',
       ],
       {
+        env: baseEnv,
         stdio: 'ignore',
       }
     );
@@ -112,36 +155,108 @@ async function waitForPostgres() {
   throw new Error('Local Postgres did not become healthy in time');
 }
 
+async function waitForApi() {
+  const healthUrl = new URL('/api/health', GO_API_URL);
+
+  for (let attempt = 1; attempt <= API_HEALTH_RETRIES; attempt += 1) {
+    try {
+      const response = await fetch(healthUrl);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Keep polling while the Go process starts.
+    }
+
+    await sleep(API_HEALTH_DELAY_MS);
+  }
+
+  throw new Error(`Go API did not become healthy at ${healthUrl}`);
+}
+
+function stopChildren() {
+  if (stopping) {
+    return;
+  }
+  stopping = true;
+
+  for (const child of children) {
+    child.kill();
+  }
+}
+
+function watchProcess(
+  proc: ReturnType<typeof spawn>,
+  label: string,
+  settle: () => void,
+  reject: (reason: Error) => void
+) {
+  proc.once('error', reject);
+  proc.once('exit', (code) => {
+    if (!stopping && code !== 0) {
+      reject(new Error(`${label} exited with code ${code}`));
+      return;
+    }
+
+    settle();
+  });
+}
+
 async function main() {
+  log('Starting Postgres and Mailpit');
   await run(['docker', 'compose', 'up', '-d', ...COMPOSE_SERVICES]);
   await waitForPostgres();
 
+  log('Applying backend migrations');
+  await run(
+    [
+      'go',
+      'run',
+      'github.com/pressly/goose/v3/cmd/goose@v3.27.2',
+      '-dir',
+      'migrations',
+      'postgres',
+      DATABASE_URL,
+      'up',
+    ],
+    { cwd: 'backend' }
+  );
+
+  log('Starting Go API');
+  const api = spawnLogged(['go', 'run', './cmd/api'], 'api', {
+    cwd: 'backend',
+  });
+  await waitForApi();
+
   const nextBin =
     process.platform === 'win32'
-      ? './node_modules/.bin/next.cmd'
-      : './node_modules/.bin/next';
+      ? join('.', 'node_modules', '.bin', 'next.cmd')
+      : join('.', 'node_modules', '.bin', 'next');
 
-  const next = spawn(nextBin, ['dev'], {
-    env: baseEnv,
-    stdio: 'inherit',
+  if (!existsSync(nextBin)) {
+    throw new Error('Next binary not found. Run `bun install` first.');
+  }
+
+  log('Starting Next dev server');
+  const next = spawnLogged([nextBin, 'dev'], 'next');
+
+  process.on('SIGINT', stopChildren);
+  process.on('SIGTERM', stopChildren);
+
+  await new Promise<void>((resolve, reject) => {
+    watchProcess(api, 'Go API', resolve, reject);
+    watchProcess(next, 'Next dev server', resolve, reject);
+    process.once('SIGINT', resolve);
+    process.once('SIGTERM', resolve);
   });
-
-  const stop = () => {
-    next.kill();
-  };
-
-  process.on('SIGINT', stop);
-  process.on('SIGTERM', stop);
-
-  const code = await new Promise<number | null>((resolve, reject) => {
-    next.once('error', reject);
-    next.on('exit', resolve);
-  });
-
-  process.exit(code ?? 0);
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
-});
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    stopChildren();
+    process.exit(1);
+  })
+  .finally(() => {
+    stopChildren();
+  });


### PR DESCRIPTION
## What changed

- Reworked `bun dev` into a full local stack launcher: Docker Postgres/Mailpit, Postgres readiness, goose migrations, Go API health check, then Next dev.
- Added `bun run dev:next` for frontend-only manual debugging.
- Moved the local Compose Postgres host port default to `54329` with `POSTGRES_PORT` override support, avoiding conflicts with a host Postgres already bound to `5432`.
- Updated `.env.example`, frontend/backend README docs, and the Go backend local default database URL to match the new dev setup.

## Why

After the Hono-to-Go migration, local development still required a multi-terminal sequence and manual migration/API startup. This PR makes the default dev path one command while preserving manual commands for debugging individual pieces.

## Validation

- `bunx tsc --noEmit`
- `bun run lint`
- `cd backend && go test ./internal/config`
- `bun dev` smoke test: started Compose services, migrated DB to version 5, Go API verified RLS and served on `8080`, Next became ready on `3000`.

## Notes

- `graphify update .` was run after the code changes, but `graphify-out/` output was intentionally left uncommitted per repo guidance.
